### PR TITLE
wallet: add state migration %5 -> %6

### DIFF
--- a/hoon/apps/wallet/lib/types.hoon
+++ b/hoon/apps/wallet/lib/types.hoon
@@ -351,6 +351,14 @@
         bc=blockchain-constants:transact
     ==
   ::
+  +$  state-6
+    $:  %6
+        balance=balance-v4
+        active-master=active-v4
+        keys=keys-v4
+        bc=blockchain-constants:transact
+    ==
+  ::
   ::  $versioned-state: wallet state
   ::
   +$  versioned-state
@@ -360,9 +368,10 @@
         state-3
         state-4
         state-5
+        state-6
     ==
   ::
-  +$  state  $>(%5 versioned-state)
+  +$  state  $>(%6 versioned-state)
   ::
   +$  seed-name   $~('default-seed' @t)
   ::

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -34,7 +34,7 @@
   ^-  state:wt
   |^
   |-
-  ?:  ?=(%5 -.old)
+  ?:  ?=(%6 -.old)
     old
   ~>  %slog.[0 'load: State upgrade required']
   ?-  -.old
@@ -121,7 +121,7 @@
     ==
   ::
   ++  state-4-5
-    ^-  state:wt
+    ^-  state-5:wt
     ?>  ?=(%4 -.old)
     ~>  %slog.[0 'upgrade version 4 to 5']
     :*  %5

--- a/hoon/apps/wallet/wallet.hoon
+++ b/hoon/apps/wallet/wallet.hoon
@@ -43,6 +43,7 @@
     %2  $(old state-2-3)
     %3  $(old state-3-4)
     %4  $(old state-4-5)
+    %5  $(old state-5-6)
   ==
   ::
   ++  state-0-1
@@ -124,6 +125,17 @@
     ?>  ?=(%4 -.old)
     ~>  %slog.[0 'upgrade version 4 to 5']
     :*  %5
+        balance.old
+        active-master.old
+        keys.old
+        *blockchain-constants:transact
+    ==
+  ::
+  ++  state-5-6
+    ^-  state:wt
+    ?>  ?=(%5 -.old)
+    ~>  %slog.[0 'upgrade version 5 to 6']
+    :*  %6
         balance.old
         active-master.old
         keys.old


### PR DESCRIPTION
## Summary
  - add wallet `state-6` and make `%6` the default wallet state version
  - extend `versioned-state` and `load` so existing `%5` wallets upgrade cleanly to `%6`
  - keep the `%5 -> %6` migration shape identical to v5 - we just needed to bump `blockchain-constants`