### PR TITLE
docs: add tx-engine architectural analysis with Bitcoin/Cardano design parallels

### DIFF
--- a/docs/architecture/tx-engine/00-overview.md
+++ b/docs/architecture/tx-engine/00-overview.md
@@ -1,0 +1,109 @@
+# Nockchain Transaction Engine: Architecture Overview
+
+## Purpose
+
+The Nockchain transaction engine (tx-engine) is the consensus-critical subsystem that defines how value is created, transferred, and validated on the Nockchain network. It implements a UTXO-based model with distinct design inspirations drawn from three pillars of blockchain innovation:
+
+- **Bitcoin Segregated Witness (SegWit)** — witness data separation from transaction structure
+- **Bitcoin Taproot (BIP 341/342)** — Merkelized script trees with selective branch revelation
+- **Extended UTXO (eUTXO)** — arbitrary data attached to UTXOs, as pioneered by Cardano
+
+The engine is distinctive in that it spans two languages and runtimes: **Hoon** (running on the Nock VM) is the **source of truth** for all type definitions and consensus validation logic, while **Rust** provides serialization/deserialization of Hoon nouns for networking, APIs, and wallet applications.
+
+## Design Lineage
+
+| Nockchain Concept | Bitcoin Equivalent | Cardano eUTXO Equivalent |
+|---|---|---|
+| Note | UTXO (TxOut) | UTxO |
+| Name (first, last) | Outpoint (txid:vout) | TxOutRef |
+| Lock (v0: M-of-N keys) | P2SH / P2PKH | — |
+| Lock tree (v1) | Taproot script tree (MAST) | — |
+| LockMerkleProof | Taproot control block + script | — |
+| Spend0 (legacy bridge) | SegWit P2SH-wrapped spend | — |
+| Spend1 (witness-based) | SegWit native spend | — |
+| Witness struct | SegWit witness field | Redeemer |
+| NoteData | — | Datum |
+| SpendCondition (AND list) | Script execution | Validator |
+| Lock primitives (Pkh/Tim/Hax/Burn) | OP_CHECKSIG / OP_CLTV / OP_HASH / OP_RETURN | — |
+| Seed | TxOut (output) | TxOut |
+| Nicks / Nocks | Satoshis / BTC | Lovelace / ADA |
+| Tip5 hash | SHA-256d | Blake2b |
+| z-map / z-set | — | — (Nock-native) |
+
+## Codebase Map
+
+### Hoon: Source of Truth (Type Definitions + Validation)
+
+```
+hoon/common/
+├── tx-engine.hoon      # Versioned facade: dispatches to tx-engine-0 or tx-engine-1
+├── tx-engine-0.hoon    # V0 engine: type definitions, validation, balance updates (~2471 lines)
+└── tx-engine-1.hoon    # V1 engine: type definitions, witness checks, lock merkle proofs,
+                        # fee calculation, context-aware validation (~1969 lines)
+```
+
+### Rust: Serialization/Deserialization Mirror (for Networking & Applications)
+
+```
+crates/nockchain-types/src/tx_engine/
+├── common/
+│   ├── mod.rs          # Hash, Name, Nicks, Version, Source, SchnorrPubkey/Signature, timelocks
+│   └── page.rs         # Page (block), BlockId, CoinbaseSplit, PageMsg
+├── v0/
+│   ├── tx.rs           # V0 RawTx, Input, Spend, Seeds, Seed
+│   └── note.rs         # NoteV0, Lock (M-of-N), Balance, Timelock
+├── v1/
+│   ├── tx.rs           # V1 RawTx, Spend enum (Legacy/Witness), Spend0, Spend1, Witness,
+│   │                   # LockMerkleProof, SpendCondition, LockPrimitive, Pkh, Tim, Hax, Seeds, Seed
+│   └── note.rs         # NoteV1, NoteData, NoteDataEntry, Balance, Note enum (V0/V1)
+└── mod.rs              # Module root
+```
+
+### Protocol Specifications
+
+```
+changelog/protocol/
+├── 009-legacy-segwit-cutover-initial.md  # V0→V1 split (block 37350)
+├── 010-legacy-v1-phase-39000.md          # V1 phase finalization
+├── 011-legacy-lmp-axis-hotfix.md         # Lock merkle proof axis fix
+├── 012-bythos.md                         # LMP versioning + fee rebalancing (block 54000)
+└── 013-nous.md                           # Networking upgrade (non-tx-engine)
+```
+
+## Version History
+
+```
+Genesis ──── Block 0
+   │         V0 engine only: M-of-N multisig, sig-keyed coinbase
+   │
+Protocol 009 ── Block 37350 (v1-phase)
+   │         Dual engine: V0 rejected, V1 required
+   │         Witness separation (Spend0 bridge, Spend1 native)
+   │         Lock trees with Merkle proofs
+   │         Note data (eUTXO datum)
+   │         Fee floor with word-count pricing
+   │
+Protocol 010 ── Block 39000
+   │         V1-phase boundary finalized
+   │
+Protocol 012 (Bythos) ── Block 54000
+   │         Lock merkle proof versioning (stub → full)
+   │         Fee rebalancing: witness discount (1/4 rate)
+   │         Context-aware mempool admission
+   │
+Present
+```
+
+## Analysis Index
+
+| Document | Topic |
+|---|---|
+| [01 — UTXO Model](01-utxo-model.md) | Notes, Names, Locks, balances, and asset denomination |
+| [02 — SegWit Witness Separation](02-segwit-witness-separation.md) | V1 witness separation, Spend0/Spend1, bridge spends |
+| [03 — Taproot Lock Merkle Proofs](03-taproot-lock-merkle-proofs.md) | MAST-like lock trees, selective branch revelation |
+| [04 — eUTXO Note Data](04-eutxo-note-data.md) | On-chain datum via NoteData |
+| [05 — Lock Primitives](05-lock-primitives-script-model.md) | Pkh, Tim, Hax, Burn and composition model |
+| [06 — Fee Structure](06-fee-structure.md) | SegWit-inspired witness weight discount |
+| [07 — Validation Pipeline](07-transaction-validation-pipeline.md) | End-to-end transaction validation |
+| [08 — Protocol Evolution](08-protocol-evolution.md) | Upgrade mechanics and history |
+| [09 — Noun Encoding](09-noun-encoding-data-layer.md) | Rust↔Hoon bridge via noun serialization |

--- a/docs/architecture/tx-engine/00-overview.md
+++ b/docs/architecture/tx-engine/00-overview.md
@@ -107,3 +107,9 @@ Present
 | [07 — Validation Pipeline](07-transaction-validation-pipeline.md) | End-to-end transaction validation |
 | [08 — Protocol Evolution](08-protocol-evolution.md) | Upgrade mechanics and history |
 | [09 — Noun Encoding](09-noun-encoding-data-layer.md) | Rust↔Hoon bridge via noun serialization |
+| [10 — Zoon Persistent Data Structures](10-zoon-persistent-data-structures.md) | Hash-ordered z-maps and z-sets (cryptographic treaps) |
+| [11 — Tip5 Hash Function](11-tip5-hash-function.md) | Algebraic sponge hash over Goldilocks field |
+| [12 — Schnorr Signatures & Cheetah Curve](12-schnorr-signatures-cheetah-curve.md) | STARK-friendly signatures over Fp^6 extension |
+| [13 — Merkle Trees & Commitments](13-merkle-trees-and-commitments.md) | Merkle proof construction and hashable commitment trees |
+| [14 — Goldilocks Field Arithmetic](14-goldilocks-field-arithmetic.md) | Base and extension field types (ztd one and two) |
+| [15 — ZTD STARK Proof Stack](15-ztd-stark-proof-stack.md) | Full STARK prover hierarchy (ztd three through eight) |

--- a/docs/architecture/tx-engine/01-utxo-model.md
+++ b/docs/architecture/tx-engine/01-utxo-model.md
@@ -1,0 +1,214 @@
+# The UTXO Model: Notes, Names, and Balances
+
+## Overview
+
+Nockchain uses an unspent transaction output (UTXO) model, where all on-chain value exists as discrete, immutable "notes" that are created by transactions and consumed (spent) exactly once. This is the same fundamental model used by Bitcoin, in contrast to Ethereum's account-based model.
+
+## Notes = UTXOs
+
+A **note** is Nockchain's UTXO. It represents a discrete unit of value locked under specific spending conditions. Notes exist in two versions, reflecting the protocol's evolution.
+
+All note types are defined authoritatively in Hoon (`hoon/common/tx-engine-0.hoon` and `tx-engine-1.hoon`). The Rust structs in `crates/nockchain-types/` are serialization mirrors that encode/decode Hoon nouns for networking and applications.
+
+### NoteV0 (Genesis)
+
+The Hoon type definition (authoritative):
+
+```hoon
+::  from hoon/common/tx-engine-0.hoon
++$  form
+  $:  $:  version=%0
+        origin-page=page-number
+        =timelock
+      ==
+    name=nname
+    =lock
+    =source
+    assets=coins
+  ==
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v0/note.rs:99-102
+pub struct NoteV0 {
+    pub head: NoteHead,    // version, origin_page, timelock
+    pub tail: NoteTail,    // name, lock, source, assets
+}
+```
+
+A V0 note carries:
+- **version**: always `V0` (encoded as `0`)
+- **origin_page**: the block height at which this note was added to the balance
+- **timelock**: optional absolute/relative constraints on when the note can be spent
+- **name**: the unique identifier (see below)
+- **lock**: M-of-N multisig condition (keys_required + set of Schnorr public keys)
+- **source**: provenance tracking (hash + coinbase flag)
+- **assets**: value in nicks
+
+### NoteV1 (Post-SegWit)
+
+Hoon type definition (authoritative, from `tx-engine-1.hoon`):
+
+```hoon
++$  nnote-1
+  $:  version=%1
+      origin-page=page-number
+      name=nname
+      note-data=(z-map @tas *)
+      assets=coins
+  ==
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:58-65
+pub struct NoteV1 {
+    pub version: Version,       // always V1
+    pub origin_page: BlockHeight,
+    pub name: Name,
+    pub note_data: NoteData,    // NEW: arbitrary key-value data (eUTXO datum)
+    pub assets: Nicks,
+}
+```
+
+V1 notes replace the explicit `Lock` and `Source` fields with:
+- **note_data**: a key-value map of arbitrary data (the eUTXO-inspired datum)
+- The lock information is now embedded in the `Name` itself (via the lock root hash)
+
+The lock is no longer stored in the note directly — instead, the note's `Name` commits to the lock root, and the spender must provide a `LockMerkleProof` in the witness to demonstrate they know a valid spending path.
+
+## Name: UTXO Identifier
+
+A **Name** (`nname` in Hoon) uniquely identifies a note within the UTXO set. Defined in Hoon as a pair of hashes plus a null terminator:
+
+```hoon
++$  nname  [first=hash last=hash ~]
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:266-270
+pub struct Name {
+    pub first: Hash,    // lock root hash
+    pub last: Hash,     // source-derived hash (parent hash of transaction)
+    null: usize,        // always 0 (Hoon noun alignment)
+}
+```
+
+### Comparison with Bitcoin's Outpoint
+
+| Property | Bitcoin Outpoint | Nockchain Name |
+|---|---|---|
+| Structure | `(txid, vout_index)` | `(lock_root_hash, source_last_hash)` |
+| References | Transaction + output index | Lock commitment + source commitment |
+| Size | 36 bytes (32 + 4) | 80 bytes (2 × Tip5 hash) |
+| Commits to lock? | No (lock is in the output) | Yes (first = lock root hash) |
+
+The key difference is that a Nockchain Name **commits to the spending conditions** in its identity. The `first` field is the hash of the lock tree root, meaning the UTXO's identity is intrinsically bound to how it can be spent. This is closer to Bitcoin's P2SH/P2WSH model (where the address commits to the script hash) than to bare P2PK.
+
+The `last` field derives from the source transaction's hash, ensuring uniqueness even when two outputs share the same lock.
+
+## Lock: Spending Conditions
+
+### V0 Lock (Simple M-of-N)
+
+```rust
+// crates/nockchain-types/src/tx_engine/v0/note.rs:38-44
+pub struct Lock {
+    pub keys_required: u64,         // M
+    pub pubkeys: Vec<SchnorrPubkey>, // N public keys
+}
+```
+
+This is analogous to Bitcoin's `OP_CHECKMULTISIG` — a simple threshold scheme requiring M of N Schnorr signatures.
+
+### V1 Lock (Lock Tree)
+
+In V1, the lock concept was generalized to a **tree of spend conditions** (see [03-taproot-lock-merkle-proofs.md](03-taproot-lock-merkle-proofs.md) and [05-lock-primitives-script-model.md](05-lock-primitives-script-model.md)). The lock is no longer stored on the note; instead, the note's Name commits to the lock root hash, and spenders provide a Merkle proof to a specific branch.
+
+## Asset Denomination
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:82
+pub struct Nicks(pub usize);
+```
+
+Nockchain uses a two-tier denomination:
+- **Nicks**: the base unit (analogous to satoshis)
+- **Nocks**: the display unit (analogous to bitcoin), where `1 nock = 65536 nicks` (2^16)
+
+The choice of 2^16 as the subdivision factor (vs Bitcoin's 10^8) reflects Nockchain's preference for power-of-two arithmetic, consistent with the Nock VM's binary tree orientation.
+
+## Balance: The UTXO Set
+
+The full UTXO set is called the **balance** — a persistent sorted map (`z-map`) from Names to Notes:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:23
+pub struct Balance(pub Vec<(Name, Note)>);
+```
+
+Where `Note` is a version-discriminated enum:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:53-56
+pub enum Note {
+    V0(NoteV0),
+    V1(NoteV1),
+}
+```
+
+Discrimination is structural: V0 notes have a cell (pair) as their head element; V1 notes have an atom (the version number). This allows the balance to contain both V0 and V1 notes simultaneously during the transition period.
+
+## Source: Provenance Tracking
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:134-137
+pub struct Source {
+    pub hash: Hash,
+    pub is_coinbase: bool,
+}
+```
+
+Every note tracks its origin: whether it was created by a coinbase (mining reward) or a regular transaction, plus a hash linking to the originating transaction. This is used in the Name computation and for validation rules that may treat coinbase outputs differently (e.g., maturation requirements).
+
+## Transaction Structure
+
+### V0 Transaction
+
+```rust
+// crates/nockchain-types/src/tx_engine/v0/tx.rs:95-100
+pub struct RawTx {
+    pub id: TxId,
+    pub inputs: Inputs,               // z-map of (Name → Input)
+    pub timelock_range: TimelockRangeAbsolute,
+    pub total_fees: Nicks,
+}
+```
+
+V0 transactions embed the full note in each input (`Input { note, spend }`), and the spend carries an optional signature directly.
+
+### V1 Transaction
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:19-23
+pub struct RawTx {
+    pub version: Version,
+    pub id: TxId,
+    pub spends: Spends,               // z-map of (Name → Spend)
+}
+```
+
+V1 transactions are leaner: they reference notes by Name rather than embedding them, and carry a version tag. The `Spends` map associates each consumed note (by Name) with its spending proof. See [02-segwit-witness-separation.md](02-segwit-witness-separation.md) for the Spend structure.
+
+## Key Design Observations
+
+1. **Identity-committed locks**: Unlike Bitcoin where an outpoint is `(txid, index)` and the lock script lives in the output, Nockchain bakes the lock hash into the Name itself. This means you cannot construct a valid Name without knowing the lock, providing an inherent binding between identity and spending authority.
+
+2. **Structural version discrimination**: Rather than using explicit version tags for note discrimination, the system uses structural patterns (cell head vs atom head). This is idiomatic Hoon — types are discriminated by shape, not by tags.
+
+3. **Persistent balanced trees**: The balance (UTXO set) is stored as a z-map (a persistent balanced binary tree with Tip5-based ordering), which allows efficient functional updates — inserting and removing notes without mutating the existing tree.

--- a/docs/architecture/tx-engine/01-utxo-model.md
+++ b/docs/architecture/tx-engine/01-utxo-model.md
@@ -15,14 +15,14 @@ All note types are defined authoritatively in Hoon (`hoon/common/tx-engine-0.hoo
 The Hoon type definition (authoritative):
 
 ```hoon
-::  from hoon/common/tx-engine-0.hoon
+::  from hoon/common/tx-engine-0.hoon (++nnote, line 1621)
 +$  form
   $:  $:  version=%0
         origin-page=page-number
         =timelock
       ==
     name=nname
-    =lock
+    =sig             :: M-of-N multisig (Hoon type is ++sig, Rust mirrors as Lock)
     =source
     assets=coins
   ==
@@ -43,7 +43,7 @@ A V0 note carries:
 - **origin_page**: the block height at which this note was added to the balance
 - **timelock**: optional absolute/relative constraints on when the note can be spent
 - **name**: the unique identifier (see below)
-- **lock**: M-of-N multisig condition (keys_required + set of Schnorr public keys)
+- **sig**: M-of-N multisig condition (Hoon `++sig` type: `m` + z-set of Schnorr public keys; Rust mirrors as `Lock`)
 - **source**: provenance tracking (hash + coinbase flag)
 - **assets**: value in nicks
 
@@ -116,15 +116,25 @@ The `last` field derives from the source transaction's hash, ensuring uniqueness
 
 ### V0 Lock (Simple M-of-N)
 
+Authoritative Hoon type (`tx-engine-0.hoon:1389`, named `++sig`):
+
+```hoon
++$  form
+  $~  [m=1 pubkeys=*(z-set schnorr-pubkey)]
+  [m=@udD pubkeys=(z-set schnorr-pubkey)]
+```
+
+Rust serialization mirror:
+
 ```rust
-// crates/nockchain-types/src/tx_engine/v0/note.rs:38-44
+// crates/nockchain-types/src/tx_engine/v0/note.rs:39
 pub struct Lock {
-    pub keys_required: u64,         // M
-    pub pubkeys: Vec<SchnorrPubkey>, // N public keys
+    pub keys_required: u64,         // M (Hoon: m=@udD, max 255)
+    pub pubkeys: Vec<SchnorrPubkey>, // N public keys (Hoon: z-set)
 }
 ```
 
-This is analogous to Bitcoin's `OP_CHECKMULTISIG` — a simple threshold scheme requiring M of N Schnorr signatures.
+This is analogous to Bitcoin's `OP_CHECKMULTISIG` — a simple threshold scheme requiring M of N Schnorr signatures. The Hoon type uses a `z-set` (Tip5-ordered persistent set) for pubkeys, ensuring deterministic ordering; the Rust mirror serializes this as a `Vec`.
 
 ### V1 Lock (Lock Tree)
 

--- a/docs/architecture/tx-engine/02-segwit-witness-separation.md
+++ b/docs/architecture/tx-engine/02-segwit-witness-separation.md
@@ -1,0 +1,217 @@
+# SegWit-Inspired Witness Separation
+
+## Bitcoin SegWit Recap
+
+Bitcoin's Segregated Witness (BIP 141, activated August 2017) introduced a fundamental structural change: **signature (witness) data was moved out of the transaction body** into a separate witness structure. This achieved three goals:
+
+1. **Transaction malleability fix**: Transaction IDs no longer depend on signatures, preventing third parties from modifying txids by tweaking signatures.
+2. **Fee discount**: Witness data is counted at 1/4 weight, incentivizing efficient use of block space.
+3. **Script versioning**: A new `witness_version` byte enabled future soft-fork upgrades (which led to Taproot).
+
+## Nockchain's Witness Separation
+
+Nockchain's V1 transaction engine (Protocol 009, activated at block 37350) implements an analogous separation. The design is documented as the "segwit cutover" in `changelog/protocol/009-legacy-segwit-cutover-initial.md`.
+
+### V0 Model: Embedded Signatures
+
+In V0, spending proofs were embedded directly in the input. The authoritative Hoon type definition:
+
+```hoon
+::  from hoon/common/tx-engine-0.hoon
+++  input   [note=nnote =spend]
+++  spend   $:  signature=(unit signature)
+                =seeds
+                fee=coins
+            ==
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v0/tx.rs:51-54
+pub struct Input {
+    pub note: NoteV0,     // The full UTXO being spent (embedded!)
+    pub spend: Spend,     // Contains signature directly
+}
+```
+
+Problems with this model:
+- The full note is embedded in each input, duplicating data already in the UTXO set
+- Signatures are part of the core transaction structure, complicating ID computation
+- No extensibility path for new authentication mechanisms
+
+### V1 Model: Separated Witness
+
+V1 introduces a clean separation. The authoritative Hoon type definitions:
+
+```hoon
+::  from hoon/common/tx-engine-1.hoon
+++  spend
+  $%  [%0 =signature =seeds fee=coins]
+      [%1 =witness =seeds fee=coins]
+  ==
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:90-94
+pub enum Spend {
+    Legacy(Spend0),    // Tag %0: bridge spend (v0 note → v1 output)
+    Witness(Spend1),   // Tag %1: native v1 spend with separate witness
+}
+```
+
+#### Spend0: Legacy Bridge
+
+`Spend0` (tag `%0`) exists solely to allow v0 notes (created before the cutover) to be spent under the v1 engine. It carries a direct signature, just like v0, but produces v1 outputs. It is a **bridge mechanism** — once all v0 notes are spent, Spend0 becomes unnecessary.
+
+This is analogous to Bitcoin's P2SH-wrapped SegWit outputs, which allowed SegWit transactions to be sent from non-SegWit-aware wallets during the transition.
+
+#### Spend1: Native Witness
+
+`Spend1` (tag `%1`) is the native V1 spend with a separated witness. The Hoon type:
+
+```hoon
+::  The witness type (authoritative definition from tx-engine-1.hoon)
+++  witness
+  $:  =lock-merkle-proof   :: which branch of the lock tree
+      =pkh-signature        :: Schnorr signature proofs
+      hax=(z-map hash *)    :: hash preimage reveals
+      tim=@                 :: reserved (always 0)
+  ==
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:167-174
+pub struct Witness {
+    pub lock_merkle_proof: LockMerkleProof,
+    pub pkh_signature: PkhSignature,
+    pub hax: Vec<HaxPreimage>,
+    pub tim: usize,
+}
+```
+
+Each witness field corresponds to a lock primitive type:
+- `lock_merkle_proof` → proves which spend condition branch is being exercised
+- `pkh_signature` → satisfies `Pkh` (public-key-hash) lock primitives
+- `hax` → satisfies `Hax` (hash preimage) lock primitives
+- `tim` → reserved for `Tim` (timelock) witness data (currently unused; timelocks are checked against block context)
+
+## Structural Comparison
+
+### V0 Transaction Layout
+
+```
+RawTx
+├── id: TxId
+├── inputs: z-map
+│   └── (Name → Input)
+│       ├── note: NoteV0          ← full UTXO embedded
+│       └── spend
+│           ├── signature         ← auth proof embedded in spend
+│           ├── seeds             ← outputs
+│           └── fee
+├── timelock_range
+└── total_fees
+```
+
+### V1 Transaction Layout
+
+```
+RawTx
+├── version: 1
+├── id: TxId
+└── spends: z-map
+    └── (Name → Spend)
+        └── Spend::Witness(Spend1)
+            ├── witness           ← SEPARATED authentication proof
+            │   ├── lock_merkle_proof
+            │   ├── pkh_signature
+            │   ├── hax
+            │   └── tim
+            ├── seeds             ← outputs
+            └── fee
+```
+
+Key structural differences:
+1. **No embedded note**: V1 references notes by Name only; the validator looks them up in the balance
+2. **Witness separated**: Authentication data has its own structured container
+3. **Extensible witness**: The Witness struct has dedicated fields per lock primitive type, allowing independent evolution
+4. **Version tagged**: The RawTx carries an explicit version number
+
+## Height-Gated Activation
+
+The cutover is enforced by a strict height-based rule matrix:
+
+| Block Height | V0 Transactions | V1 Transactions | Coinbase Format |
+|---|---|---|---|
+| `< v1-phase` (37350) | Allowed | Rejected | V0 (sig-keyed) |
+| `≥ v1-phase` (37350) | Rejected | Required | V1 (lock-hash-rooted) |
+
+From `changelog/protocol/009-legacy-segwit-cutover-initial.md`:
+> At `height >= v1-phase`: v1 raw transactions are required. v0 raw transactions are rejected (`%v0-tx-after-cutoff`).
+
+This is a **hard cutover**, not a gradual transition. All nodes must agree on the same rules at the same height.
+
+## Bridge Spending: V0 → V1 Transition
+
+When a V0 note needs to be spent after the cutover, it uses `Spend0`:
+
+1. The spender references the V0 note by its Name
+2. Provides a V0-style signature (directly, not via witness)
+3. The outputs (seeds) are V1-format, producing V1 notes
+
+The Hoon validation logic checks spend-version compatibility:
+
+```hoon
+:: From hoon/common/tx-engine-1.hoon (validate-with-context)
+::  v0 note must back a %0 spend
+?:  ?=(@ -.note)  [%.n %v1-spend-version-mismatch]
+```
+
+- V0 notes (head is a cell) → must use Spend0
+- V1 notes (head is an atom) → must use Spend1
+
+This ensures that the more expressive V1 witness/lock system is only used with V1 notes that were created with lock tree commitments.
+
+## Transaction ID Computation
+
+In V1, the transaction ID (`TxId`) is computed as a hash of the full spend data including witnesses. This differs from Bitcoin SegWit, where the `txid` excludes witness data (and a separate `wtxid` includes it).
+
+However, the **sig-hash** (the message that gets signed) excludes the witness:
+
+```rust
+// The sig_hash is computed over (seeds, fee) — not the witness
+// This is analogous to Bitcoin's sighash, which signs the transaction
+// structure without the signatures themselves
+```
+
+This means:
+- The transaction ID is stable once all witnesses are attached
+- The signing message doesn't include signatures (avoiding circular dependency)
+- Unlike Bitcoin SegWit, there is no separate "witness txid" — just one ID
+
+## Fee Implications
+
+The witness separation enabled the Bythos upgrade (Protocol 012) to introduce **differential fee pricing** for witness vs non-witness data, directly analogous to Bitcoin SegWit's weight system:
+
+- **Seed words** (outputs): charged at full `base_fee` per word
+- **Witness words** (inputs): charged at `base_fee / input_fee_divisor` (1/4 rate)
+
+See [06-fee-structure.md](06-fee-structure.md) for the full fee analysis.
+
+## Comparison: Bitcoin SegWit vs Nockchain V1
+
+| Aspect | Bitcoin SegWit | Nockchain V1 |
+|---|---|---|
+| Activation | BIP 9 signaling (soft fork) | Height-gated hard cutover |
+| Witness location | Separate witness field in serialization | `Witness` struct in `Spend1` |
+| Transaction ID | `txid` excludes witness; `wtxid` includes | Single ID includes all data |
+| Signature exclusion | Witness stripped for txid | Witness excluded from sig-hash |
+| Fee discount | 4:1 witness weight ratio | 4:1 input fee divisor (Bythos) |
+| Legacy compatibility | P2SH-wrapped SegWit | Spend0 bridge spends |
+| Script versioning | witness_version byte | Spend enum tag (0 or 1) |
+| Extensibility | Led to Taproot (v1) | Led to lock trees + note data |

--- a/docs/architecture/tx-engine/03-taproot-lock-merkle-proofs.md
+++ b/docs/architecture/tx-engine/03-taproot-lock-merkle-proofs.md
@@ -1,0 +1,187 @@
+# Taproot-Inspired Lock Merkle Proofs (MAST)
+
+## Bitcoin Taproot Recap
+
+Bitcoin Taproot (BIP 341/342, activated November 2021) introduced **Merkelized Abstract Syntax Trees (MAST)**: a way to commit to multiple spending scripts in a Merkle tree, where only the executed script branch is revealed on-chain.
+
+Key Taproot concepts:
+- **Key-path spending**: If all parties agree, the output can be spent with a single Schnorr signature (no script revealed)
+- **Script-path spending**: Reveal one script from the MAST tree + Merkle proof to root
+- **Privacy**: Unexecuted scripts remain hidden behind Merkle hashes
+- **Efficiency**: Only the relevant branch is included in the transaction
+
+## Nockchain's Lock Tree
+
+Nockchain implements an analogous pattern through its **lock tree** and **lock Merkle proof** system. A lock in V1 is a binary tree of spend conditions, where each leaf is a `SpendCondition` (a list of lock primitives that must all be satisfied — AND logic). Different branches of the tree represent alternative ways to spend (OR logic).
+
+### The Lock Tree Structure
+
+```
+            Lock Root
+           /         \
+      Branch A      Branch B
+      /     \          |
+   Leaf 1  Leaf 2   Leaf 3
+   [pkh]   [pkh,    [tim,
+            tim]     hax]
+```
+
+Each leaf is a `SpendCondition`: a list of `LockPrimitive` values that are ANDed together. The tree itself provides OR semantics — any one leaf (branch) can authorize spending.
+
+This maps directly to Taproot's MAST:
+
+| Taproot | Nockchain |
+|---|---|
+| Script tree | Lock tree |
+| Script leaf | SpendCondition (list of LockPrimitive) |
+| Control block | LockMerkleProof |
+| Script-path spend | Spend1 with LockMerkleProof |
+| Key-path spend | No direct equivalent (always reveals a branch) |
+
+Notable difference: Nockchain does not have a key-path equivalent. Every spend must reveal at least one branch of the lock tree. This is a deliberate simplification — there is no "cooperative spend" shortcut that bypasses the Merkle proof.
+
+## LockMerkleProof: The Control Block
+
+When spending a V1 note, the spender provides a `lock-merkle-proof` that reveals exactly one branch of the lock tree. The authoritative Hoon type (from `tx-engine-1.hoon`):
+
+```hoon
++$  lock-merkle-proof
+  $^  :: stub (3-tuple):
+      [=spend-condition axis=@ =merk-proof:merkle]
+      :: full (4-tuple with %full tag):
+      [version=%full =spend-condition axis=@ =merk-proof:merkle]
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:339-344
+pub enum LockMerkleProof {
+    Full(LockMerkleProofFull),  // Post-Bythos: axis committed in hash
+    Stub(LockMerkleProofStub),  // Pre-Bythos: axis not committed
+}
+```
+
+### Stub Format (Pre-Bythos)
+
+The stub is a 3-tuple `[spend-condition axis merk-proof]`. The axis is not committed in the hash.
+
+### Full Format (Post-Bythos)
+
+The full format is a 4-tuple `[%full spend-condition axis merk-proof]`. The `%full` tag distinguishes it from stub proofs via structural discrimination (a standard Hoon `$^` pattern).
+
+The difference: Full proofs include the `axis` in the hashable commitment. In Stub proofs, the axis was replaced by a hardcoded placeholder hash, meaning the witness hash did not commit to *which branch* was being executed — a weakness fixed by Bythos.
+
+## The Axis: Binary Tree Addressing
+
+The `axis` field is a Nock-native concept for addressing positions in binary trees. In Nock, every value is a binary tree (a "noun"), and tree positions are addressed by axes:
+
+```
+        1 (root)
+       / \
+      2    3
+     / \  / \
+    4  5 6   7
+```
+
+- Axis 1: root
+- Axis 2: left child
+- Axis 3: right child
+- Axis 4: left-left
+- Axis 5: left-right
+- etc.
+
+When a lock tree has multiple branches, the axis tells the validator which leaf position the provided `SpendCondition` occupies. The Merkle proof then demonstrates that this leaf, at this axis, hashes up to the lock root committed in the note's Name.
+
+## Merkle Proof Structure
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:408-412
+pub struct MerkleProof {
+    pub root: Hash,        // The expected root hash (matches Name.first)
+    pub path: Vec<Hash>,   // Sibling hashes from leaf to root
+}
+```
+
+The proof contains:
+1. **root**: the expected Merkle root (must match the lock root hash stored in the note's Name)
+2. **path**: a list of sibling hashes, one per level from the leaf up to the root
+
+Verification proceeds by:
+1. Hash the spend condition (the revealed leaf)
+2. At each level, combine with the sibling hash from the path
+3. Check that the result equals the declared root
+4. Check that the declared root matches the note's lock root (committed in `Name.first`)
+
+## Hashable Construction
+
+The hash commitment for a lock Merkle proof is computed differently for stub and full formats.
+
+### Stub Hashable (Pre-Bythos)
+
+From `changelog/protocol/012-bythos.md`:
+
+```hoon
+:+  hash+(hash:spend-condition spend-condition.form)
+    hash+(from-b58:^hash '6mhCSwJQDvbkbiPAUNjetJtVoo1VLtEhmEYoU4hmdGd6ep1F6ayaV4A')
+  (hashable-merk-proof merk-proof.form)
+```
+
+The second element is a **hardcoded hash** — a static placeholder that does not depend on the axis. This means two different branches of the same lock tree would produce the same witness hash if their spend conditions happened to hash identically.
+
+### Full Hashable (Post-Bythos)
+
+```hoon
+:*  leaf+version.form
+    hash+(hash:spend-condition spend-condition.form)
+    leaf+axis.form
+    (hashable-merk-proof merk-proof.form)
+==
+```
+
+The full format includes `axis` as a leaf in the hashable tree, ensuring the witness hash commits to the specific branch being executed. This is a stronger security property — the witness is now bound to a particular position in the lock tree.
+
+## Height-Gated Proof Format Selection
+
+The proof format is determined by the note's origin page:
+
+```hoon
+=/  parent-lmp=lock-merkle-proof
+  ?:  (gte origin-page.note bythos-phase)
+    (build-lock-merkle-proof-full:lock parent-lock 1)
+  (build-lock-merkle-proof-stub:lock parent-lock 1)
+```
+
+- Notes created **before Bythos** (origin page < 54000): use stub proofs
+- Notes created **at/after Bythos** (origin page ≥ 54000): use full proofs
+
+The validator accepts both formats but gates full proof acceptance on the Bythos activation height.
+
+## Privacy Properties
+
+Like Taproot, Nockchain's lock Merkle proofs provide **partial script privacy**:
+
+- **Revealed**: The spend condition being exercised (one branch of the lock tree)
+- **Hidden**: All other branches remain behind Merkle hashes
+- **Observable**: The number of tree levels (depth) can hint at the number of branches, but the exact count remains ambiguous
+
+For a lock tree with N branches:
+- The spender reveals 1 spend condition + log2(N) sibling hashes
+- The remaining N-1 conditions are hidden
+
+This is the same privacy model as Bitcoin Taproot script-path spends.
+
+## Comparison: Bitcoin Taproot vs Nockchain Lock Merkle Proofs
+
+| Aspect | Bitcoin Taproot | Nockchain Lock Merkle Proof |
+|---|---|---|
+| Script tree | MAST of TapScript leaves | Binary tree of SpendConditions |
+| Key-path spend | Yes (single Schnorr sig, no script revealed) | No (always reveal a branch) |
+| Script-path spend | Control block + script + Merkle proof | LockMerkleProof (spend condition + axis + proof) |
+| Branch addressing | Control block leaf version + script | Axis (Nock binary tree address) |
+| Proof structure | Internal key + parity + Merkle path | Root hash + sibling hash path |
+| Hash function | SHA-256 (tagged) | Tip5 |
+| Privacy | Unrevealed scripts hidden | Unrevealed conditions hidden |
+| Commitment strength | Axis committed via control block | Stub: axis not committed; Full: axis committed |
+| Composability | TapScript opcodes | AND within SpendCondition, OR across branches |
+| Activation | BIP 9 signaling soft fork | Height-gated hard cutover |

--- a/docs/architecture/tx-engine/04-eutxo-note-data.md
+++ b/docs/architecture/tx-engine/04-eutxo-note-data.md
@@ -1,0 +1,181 @@
+# Extended UTXO: Note Data as On-Chain Datum
+
+## Cardano eUTXO Recap
+
+Cardano's extended UTXO (eUTXO) model extends Bitcoin's UTXO model with three additions:
+
+1. **Datum**: Arbitrary data attached to each UTXO, available to validator scripts
+2. **Redeemer**: Data provided by the spender to the validator when consuming a UTXO
+3. **Script context**: The full transaction context available to validator scripts
+
+The datum allows UTXOs to carry state, enabling stateful smart contracts within the UTXO paradigm — each UTXO becomes a "mini-state-machine" rather than just a value container.
+
+## Nockchain's Note Data
+
+V1 notes carry a `note-data` field — a z-map (persistent sorted map) from `@tas` symbol keys to arbitrary nouns. The authoritative Hoon definition:
+
+```hoon
+::  from hoon/common/tx-engine-1.hoon
+::  note-data is a z-map of @tas keys to arbitrary noun values
+note-data=(z-map @tas *)
+```
+
+Rust serialization mirror (represents the z-map as a list of key-value pairs with jammed noun blobs):
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:98-99
+pub struct NoteData(pub Vec<NoteDataEntry>);
+
+// crates/nockchain-types/src/tx_engine/v1/note.rs:115-120
+pub struct NoteDataEntry {
+    pub key: String,       // @tas (Hoon "cord" / symbol string)
+    pub blob: bytes::Bytes, // Jammed noun (arbitrary serialized Nock data)
+}
+```
+
+### How Note Data Attaches to UTXOs
+
+Note data flows from transaction outputs (seeds) to the notes they create:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:158-165
+pub struct Seed {
+    pub output_source: Option<Source>,
+    pub lock_root: Hash,
+    pub note_data: NoteData,    // Data for the new UTXO
+    pub gift: Nicks,
+    pub parent_hash: Hash,
+}
+```
+
+When a transaction is applied to the balance:
+1. Each seed creates a new V1 note
+2. The seed's `note_data` becomes the note's `note_data`
+3. The resulting `NoteV1` carries this data for its entire lifetime
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:58-65
+pub struct NoteV1 {
+    pub version: Version,
+    pub origin_page: BlockHeight,
+    pub name: Name,
+    pub note_data: NoteData,    // Carried from the creating seed
+    pub assets: Nicks,
+}
+```
+
+### Noun Encoding
+
+Note data entries use Hoon's `@tas` (text atom symbol) for keys and **jammed nouns** for values. A jammed noun is a compressed binary serialization of an arbitrary Nock value — it can represent any data structure expressible in Nock:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:128-145
+impl NounEncode for NoteData {
+    fn to_noun<A: NounAllocator>(&self, allocator: &mut A) -> Noun {
+        self.0.iter().fold(D(0), |map, entry| {
+            let mut key = make_tas(allocator, &entry.key).as_noun();
+            // Cue (decompress) the jammed blob back into a noun
+            let mut slab: NounSlab<NockJammer> = NounSlab::new();
+            slab.cue_into(entry.blob.clone()).expect("failed to cue blob");
+            let mut value = unsafe {
+                let &root = slab.root();
+                allocator.copy_into(root)
+            };
+            zmap::z_map_put(allocator, &map, &mut key, &mut value, &DefaultTipHasher)
+                .expect("failed to encode note-data entry")
+        })
+    }
+}
+```
+
+The data is stored on-chain as a z-map (persistent sorted map) of `(@tas, *)` — string keys to arbitrary nouns. This makes it a fully general key-value store per UTXO.
+
+## Lock-Root Aggregation
+
+A distinctive feature of Nockchain's note data model: **outputs (seeds) sharing the same lock root have their note-data merged**.
+
+From `hoon/common/tx-engine-1.hoon`:
+
+```hoon
+++  note-data-by-lock-root
+  |=  sps=form
+  ^-  (z-mip ^hash @tas *)
+  =/  all-seeds=(list seed)  ...
+  =/  by-lock-root=(z-mip ^hash @tas *)
+    %+  roll  all-seeds
+    |=  [sed=seed acc=(z-mip ^hash @tas *)]
+    =/  key=hash  lock-root.sed
+    =/  existing=(unit (z-map @tas *))
+      (~(get z-by acc) key)
+    ?~  existing
+      (~(put z-by acc) key note-data.sed)
+    =/  merged=(z-map @tas *)
+      (~(uni z-by u.existing) note-data.sed)
+    (~(put z-by acc) key merged)
+  by-lock-root
+```
+
+This means:
+- If a transaction has three outputs to the same lock root, each with note-data `{a: 1}`, `{b: 2}`, `{c: 3}`, they merge into one note with `{a: 1, b: 2, c: 3}`
+- Fee calculation charges once for the merged data, not three times
+- Size validation (`max-size`) applies to the merged result
+
+This is an unusual design choice with no direct equivalent in Bitcoin or Cardano. It enables efficient batch data attachment to a single spending authority.
+
+## Size Limits
+
+Bythos (Protocol 012) introduced per-output size validation for note data:
+
+```hoon
+++  note-data-exceeds-max
+  |=  [sps=form max=@]
+  ^-  ?
+  %+  lien  ~(tap z-by (note-data-by-lock-root sps))
+  |=  [key=hash note-data=(z-map @tas *)]
+  =/  data-size=@
+    %-  num-of-leaves:shape
+    %-  ~(rep z-by note-data)
+    |=  [[k=@tas v=*] tree=*]
+    [k v tree]
+  (gth data-size max)
+```
+
+The size is measured by counting the number of leaves in the noun tree representation of the note-data map. This is checked per-output (after merging by lock-root), not per-seed.
+
+The `max-size` limit is configured in `blockchain-constants.data.max-size` and provides protection against bloating the UTXO set with arbitrarily large datum.
+
+## Comparison: Cardano Datum vs Nockchain Note Data
+
+| Aspect | Cardano eUTXO Datum | Nockchain NoteData |
+|---|---|---|
+| Data type | Arbitrary Plutus Data (CBOR) | Arbitrary jammed nouns (key-value map) |
+| Structure | Single datum per UTxO | Key-value map (`@tas → *`) per note |
+| Attachment | Per output | Per output, merged by lock root |
+| Size limits | Protocol parameter (max tx size) | `max-size` per merged output |
+| Validator access | Full datum available to script | Note data available to Hoon validation |
+| Inline vs reference | Both supported (Vasil) | Always inline |
+| Hash commitment | Datum hash in output (pre-Vasil) | Note data included in note structure |
+| Fee impact | Contributes to transaction size/fee | Contributes to seed word count for fee |
+| Use cases | DeFi state, NFT metadata, oracle data | TBD (protocol-level data attachment) |
+
+## Key Differences from Full eUTXO
+
+Nockchain's note data is inspired by eUTXO but is **not a full implementation** of the Cardano model:
+
+1. **No validator execution per UTXO**: Cardano runs Plutus validators when UTXOs are consumed; Nockchain's lock primitives (`Pkh`, `Tim`, `Hax`, `Burn`) are fixed opcodes, not arbitrary scripts. The note data is not consumed by a user-defined validator.
+
+2. **No redeemer concept**: In Cardano, the spender provides a "redeemer" argument to the validator. Nockchain's closest equivalent is the `Witness` struct, but its fields are purpose-specific (signatures, preimages), not general-purpose redeemer data.
+
+3. **No script context**: Cardano validators receive the full transaction context (all inputs, outputs, validity range, etc.). Nockchain's lock primitives check individual conditions without access to the full transaction.
+
+4. **Key-value structure**: Unlike Cardano's single datum blob, Nockchain uses a structured key-value map, which provides native namespacing and avoids the need for application-level datum parsing.
+
+The note data is best understood as a **data attachment mechanism** — a way to carry metadata alongside value — rather than a full programmable state machine. It provides the substrate for future extensions where lock primitives or validators could inspect note data during spending.
+
+## Potential Applications
+
+The note data mechanism enables:
+- **Token metadata**: Attaching token names, symbols, or URIs to value-carrying notes
+- **On-chain state**: Carrying application state that transitions with UTXO spending
+- **Provenance tracking**: Recording the history or classification of value flows
+- **Cross-chain data**: Carrying data needed for bridge or interoperability proofs

--- a/docs/architecture/tx-engine/05-lock-primitives-script-model.md
+++ b/docs/architecture/tx-engine/05-lock-primitives-script-model.md
@@ -78,16 +78,27 @@ pub struct PkhSignatureEntry {
 }
 ```
 
-The Hoon validation from `tx-engine-1.hoon`:
+The Hoon validation (`tx-engine-1.hoon`, `check:pkh` at line 1656):
 
 ```hoon
-%pkh  (check:pkh +.p form)
+++  check
+  |=  [=form ctx=check-context]
+  ?&  =(m.form ~(wyt z-by pkh.witness.ctx))           :: exactly M signatures provided
+      =(~ (~(dif z-in ~(key z-by pkh.witness.ctx))    :: all pubkey hashes are in the
+               h.form))                                ::   Pkh's permitted set
+      %-  ~(rep z-by pkh.witness.ctx)                  :: each pubkey hashes to its
+      |=  [[h=^hash pk=schnorr-pubkey sig=schnorr-signature] a=?]  :: claimed hash
+      ?&  a  =(h (hash:schnorr-pubkey pk))  ==
+      %-  batch-verify:affine:belt-schnorr:cheetah     :: all signatures are valid
+      (signatures:pkh-signature pkh.witness.ctx sig-hash.ctx)
+  ==
 ```
 
-This checks:
-- Each provided signature corresponds to a pubkey whose hash is in the Pkh's hash set
-- The signature verifies against the sig-hash
-- At least `m` valid signatures exist
+This checks four conditions (AND):
+1. **Exactly** `m` signatures are provided (not "at least" — the count must match precisely)
+2. All provided pubkey hashes are members of the Pkh's permitted hash set
+3. Each provided public key hashes to its declared hash (binding pubkey to commitment)
+4. All signatures pass batch Schnorr verification against the sig-hash via `batch-verify:affine:belt-schnorr:cheetah`
 
 ## Tim: Timelock Constraints
 
@@ -115,11 +126,21 @@ The relative constraints use `origin_page` (the block where the note was created
 
 ### Witness Satisfaction
 
-The `tim` field in the Witness is currently reserved (always 0). Timelock validation is **context-based** — it checks the current block height against the constraints without requiring witness data:
+The `tim` field in the Witness is currently reserved (always 0). Timelock validation is **context-based** — it checks the current block height against the constraints without requiring witness data.
+
+The Hoon validation (`tx-engine-1.hoon`, `check:tim` at line 1741):
 
 ```hoon
-%tim  (check:tim +.p form)
+++  check
+  |=  [=form ctx=check-context]
+  =/  rmin-ok=?  ?~(min.rel.form %.y (gte now.ctx (add since.ctx u.min.rel.form)))
+  =/  rmax-ok=?  ?~(max.rel.form %.y (lte now.ctx (add since.ctx u.max.rel.form)))
+  =/  amin-ok=?  ?~(min.abs.form %.y (gte now.ctx u.min.abs.form))
+  =/  amax-ok=?  ?~(max.abs.form %.y (lte now.ctx u.max.abs.form))
+  &(rmin-ok rmax-ok amin-ok amax-ok)
 ```
+
+Where `now.ctx` is the current block height and `since.ctx` is the note's `origin_page`. Each constraint is optional (`unit`); absent constraints are vacuously satisfied.
 
 ## Hax: Hash Preimage Verification
 
@@ -150,12 +171,26 @@ pub struct HaxPreimage {
 }
 ```
 
-The validator:
-1. For each required hash in the Hax set
-2. Looks up the corresponding preimage in the witness
-3. Hashes the preimage and checks it matches the committed hash
+The Hoon validation (`tx-engine-1.hoon`, `check:hax` at line 1704):
 
-Notably, the preimage values are **jammed nouns** — not raw bytes. This means the preimage can be any structured Nock data (a list, a tree, a complex record), serialized to bytes via Nock's jam encoding.
+```hoon
+++  check
+  |=  [=form ctx=check-context]
+  %-  ~(all z-in form)
+  |=  =^hash
+  =/  preimage  (~(get z-by hax.witness.ctx) hash)
+  ?~  preimage  %|
+  =(hash (hash-noun u.preimage))
+```
+
+For each committed hash in the Hax set:
+1. Look up the preimage in the witness `hax` map (`z-map hash *`)
+2. If no preimage provided, fail
+3. Hash the preimage via `hash-noun` (recursive hashable decomposition of the noun tree) and check it matches the committed hash
+
+The `hash-noun` arm builds a hashable tree from the noun's structure — cells become pairs, atoms become leaves — then hashes via `hash-hashable:tip5`. This is distinct from `hash-noun-varlen` (used in zoon for tree ordering), which uses the Dyck word encoding.
+
+In Hoon, preimage values are arbitrary nouns (`*`). The Rust serialization represents them as **jammed noun bytes** (`bytes::Bytes`) — Nock's binary serialization format — which are cued (decompressed) back to nouns during validation. This means preimages can be any structured Nock data (lists, trees, records), serialized to bytes for transport.
 
 ## Burn: Unspendable Output
 

--- a/docs/architecture/tx-engine/05-lock-primitives-script-model.md
+++ b/docs/architecture/tx-engine/05-lock-primitives-script-model.md
@@ -1,0 +1,227 @@
+# Lock Primitives: A Composable Script Model
+
+## Context: Programmable Spending
+
+Bitcoin uses Script — a stack-based, non-Turing-complete language — to express spending conditions. Cardano uses Plutus validators — Haskell-based programs compiled to Plutus Core. Nockchain takes a third approach: a fixed set of **lock primitives** composed via AND/OR logic, with Merkle tree branch selection providing the OR.
+
+## LockPrimitive: Authoritative Hoon Definition
+
+Lock primitives are defined in Hoon (`tx-engine-1.hoon`) as a tagged union using `@tas` (text atom symbol) tags. The Hoon definition is the source of truth:
+
+```hoon
++$  lock-primitive
+  $%  [%pkh m=@ hashes=(z-set hash)]
+      [%tim rel=timelock-range-relative abs=timelock-range-absolute]
+      [%hax hashes=(z-set hash)]
+      [%brn ~]
+  ==
+```
+
+A `spend-condition` is a list of lock primitives (AND logic):
+
+```hoon
++$  spend-condition  (list lock-primitive)
+```
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:478-484
+pub enum LockPrimitive {
+    Pkh(Pkh),       // %pkh - Pay-to-public-key-hash (M-of-N Schnorr)
+    Tim(LockTim),   // %tim - Timelock constraints
+    Hax(Hax),       // %hax - Hash preimage verification
+    Burn,           // %brn - Unspendable (proof-of-burn)
+}
+```
+
+## Pkh: Pay-to-Public-Key-Hash
+
+Defined in Hoon as `[%pkh m=@ hashes=(z-set hash)]`: a threshold `m` and a set of public key hashes.
+
+Rust serialization mirror:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:534-539
+pub struct Pkh {
+    pub m: u64,            // Required signature count (threshold)
+    pub hashes: Vec<Hash>, // z-set of public key hashes
+}
+```
+
+Pkh is the primary authentication primitive. It requires M Schnorr signatures from a set of N public key hashes — a threshold multisig scheme.
+
+### How Pkh Differs from Bitcoin
+
+| Feature | Bitcoin P2PKH | Bitcoin P2TR Key-Path | Nockchain Pkh |
+|---|---|---|---|
+| Key type | ECDSA | Schnorr | Schnorr (Cheetah curve) |
+| Hash stores | Single pubkey hash | Tweaked public key | Set of pubkey hashes |
+| Multisig | Separate OP_CHECKMULTISIG | MuSig2 aggregation | Native M-of-N threshold |
+| Reveals | Full public key on spend | Only aggregated key | Only signing pubkeys' hashes |
+
+The Pkh primitive uses **public key hashes** rather than public keys directly. The lock commits to `Hash(pubkey)`, and the witness provides `(pubkey, signature)` pairs. The validator:
+1. Checks that `Hash(pubkey)` matches one of the committed hashes
+2. Verifies the Schnorr signature against the pubkey and sig-hash
+3. Counts that at least M valid signatures are provided
+
+### Witness Satisfaction
+
+The `PkhSignature` in the witness provides the satisfying data:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:296-301
+pub struct PkhSignatureEntry {
+    pub hash: Hash,                   // The pubkey hash being satisfied
+    pub pubkey: SchnorrPubkey,        // The actual public key
+    pub signature: SchnorrSignature,  // Schnorr signature
+}
+```
+
+The Hoon validation from `tx-engine-1.hoon`:
+
+```hoon
+%pkh  (check:pkh +.p form)
+```
+
+This checks:
+- Each provided signature corresponds to a pubkey whose hash is in the Pkh's hash set
+- The signature verifies against the sig-hash
+- At least `m` valid signatures exist
+
+## Tim: Timelock Constraints
+
+Defined in Hoon as `[%tim rel=timelock-range-relative abs=timelock-range-absolute]`. Each range is a pair of optional bounds (min, max).
+
+Timelocks constrain *when* a note can be spent, with both relative and absolute bounds:
+
+### Comparison with Bitcoin Timelocks
+
+| Feature | Bitcoin CLTV (BIP 65) | Bitcoin CSV (BIP 112) | Nockchain Tim |
+|---|---|---|---|
+| Type | Absolute | Relative | Both combined |
+| Granularity | Block height or timestamp | Block count or time | Block height only |
+| Min constraint | ✓ (cannot spend before) | ✓ (must wait N blocks) | ✓ (min height/delta) |
+| Max constraint | ✗ (no expiry in CLTV) | ✗ (no expiry in CSV) | ✓ (max height/delta) |
+| Implementation | OP_CHECKLOCKTIMEVERIFY | OP_CHECKSEQUENCEVERIFY | Lock primitive |
+
+Nockchain's Tim is more expressive than Bitcoin's individual timelock opcodes because it combines:
+- **Absolute minimum**: like CLTV — "cannot spend before block X"
+- **Absolute maximum**: "cannot spend after block Y" (not available in Bitcoin)
+- **Relative minimum**: like CSV — "must wait N blocks after creation"
+- **Relative maximum**: "must spend within N blocks of creation" (not available in Bitcoin)
+
+The relative constraints use `origin_page` (the block where the note was created) as the reference point, analogous to CSV's reference to the block containing the spending transaction's input.
+
+### Witness Satisfaction
+
+The `tim` field in the Witness is currently reserved (always 0). Timelock validation is **context-based** — it checks the current block height against the constraints without requiring witness data:
+
+```hoon
+%tim  (check:tim +.p form)
+```
+
+## Hax: Hash Preimage Verification
+
+Defined in Hoon as `[%hax hashes=(z-set hash)]`: a set of Tip5 hash commitments.
+
+Hax requires the spender to reveal preimages whose hashes match the committed values. This is the foundation for:
+- **Hash Time-Locked Contracts (HTLCs)**: Combined with Tim for atomic swaps
+- **Payment channels**: Conditional payments based on secret revelation
+- **Commit-reveal schemes**: On-chain commitment to off-chain data
+
+### Comparison with Bitcoin Hash Locks
+
+| Feature | Bitcoin OP_SHA256/OP_HASH160 | Nockchain Hax |
+|---|---|---|
+| Hash function | SHA-256, RIPEMD-160, SHA-1 | Tip5 |
+| Multiple preimages | Via script composition | Native set of hash commitments |
+| Preimage type | Raw bytes | Jammed nouns (arbitrary Nock data) |
+
+### Witness Satisfaction
+
+The `hax` field in the Witness provides preimage revelations:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:253-258
+pub struct HaxPreimage {
+    pub hash: Hash,
+    pub value: bytes::Bytes,  // Jammed noun bytes
+}
+```
+
+The validator:
+1. For each required hash in the Hax set
+2. Looks up the corresponding preimage in the witness
+3. Hashes the preimage and checks it matches the committed hash
+
+Notably, the preimage values are **jammed nouns** — not raw bytes. This means the preimage can be any structured Nock data (a list, a tree, a complex record), serialized to bytes via Nock's jam encoding.
+
+## Burn: Unspendable Output
+
+```rust
+LockPrimitive::Burn  // Tag: "brn", value: 0
+```
+
+Burn creates an **unconditionally unspendable** output. Any SpendCondition containing a Burn primitive can never be satisfied:
+
+```hoon
+%brn  %|   :: always fails
+```
+
+This is Nockchain's equivalent of Bitcoin's `OP_RETURN` — used for:
+- **Proof-of-burn**: Permanently destroying value
+- **Data anchoring**: Committing data to the chain without creating spendable outputs
+- **Mining commitments**: Permanently locking value as a proof mechanism
+
+## Composition Model
+
+### AND Logic: Within a SpendCondition
+
+A `SpendCondition` is a **list** of `LockPrimitive` values. All primitives in the list must be satisfied — AND logic:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:442-443
+pub struct SpendCondition(pub Vec<LockPrimitive>);
+```
+
+Example: `[Pkh(1-of-2), Tim(min=100)]` means "provide 1 of 2 valid signatures AND the block height must be ≥ 100."
+
+### OR Logic: Across Lock Tree Branches
+
+Different branches of the lock Merkle tree provide OR semantics — any one branch can authorize spending. The spender chooses which branch to reveal via the `LockMerkleProof`.
+
+Example lock tree:
+```
+         Root
+        /    \
+  Branch A   Branch B
+  [Pkh(2-of-3)]  [Tim(height>1000), Hax(secret)]
+```
+
+This means: "Either provide 2-of-3 signatures, OR wait until block 1000 and reveal the secret."
+
+### Expressiveness Summary
+
+The AND/OR composition with four primitive types enables:
+
+| Pattern | Primitives Used | Use Case |
+|---|---|---|
+| Simple pay | Pkh(1-of-1) | Standard payment |
+| Multisig | Pkh(M-of-N) | Shared custody |
+| Timelock + multisig | Pkh + Tim | Vesting schedule |
+| HTLC | Pkh + Hax + Tim | Atomic swaps |
+| Dead man's switch | Branch A: Pkh(owner) OR Branch B: Pkh(heir) + Tim(delay) | Inheritance |
+| Proof-of-burn | Burn | Value destruction |
+| Escrow with timeout | Branch A: Pkh(2-of-2) OR Branch B: Pkh(sender) + Tim(expiry) | Conditional escrow |
+
+### What Cannot Be Expressed
+
+The fixed primitive set means some Bitcoin Script / Plutus capabilities are not available:
+- **Arithmetic conditions**: No equivalent to `OP_ADD`, `OP_LESSTHAN`
+- **Introspection**: No access to transaction structure (inputs/outputs) within primitives
+- **Loops**: Not possible (but also not possible in Bitcoin Script)
+- **State machines**: Cannot inspect note data during validation (unlike Cardano validators)
+- **Covenants**: Cannot constrain how outputs must be structured
+
+This is a deliberate trade-off: simplicity and auditability over expressiveness. The four-primitive model covers the vast majority of practical spending patterns while remaining easy to formally verify.

--- a/docs/architecture/tx-engine/05-lock-primitives-script-model.md
+++ b/docs/architecture/tx-engine/05-lock-primitives-script-model.md
@@ -58,7 +58,7 @@ Pkh is the primary authentication primitive. It requires M Schnorr signatures fr
 | Key type | ECDSA | Schnorr | Schnorr (Cheetah curve) |
 | Hash stores | Single pubkey hash | Tweaked public key | Set of pubkey hashes |
 | Multisig | Separate OP_CHECKMULTISIG | MuSig2 aggregation | Native M-of-N threshold |
-| Reveals | Full public key on spend | Only aggregated key | Only signing pubkeys' hashes |
+| Reveals | Full public key on spend | Only aggregated key | Signing pubkeys + signatures (lock stores only hashes) |
 
 The Pkh primitive uses **public key hashes** rather than public keys directly. The lock commits to `Hash(pubkey)`, and the witness provides `(pubkey, signature)` pairs. The validator:
 1. Checks that `Hash(pubkey)` matches one of the committed hashes

--- a/docs/architecture/tx-engine/06-fee-structure.md
+++ b/docs/architecture/tx-engine/06-fee-structure.md
@@ -48,26 +48,23 @@ Where:
 - `input_fee_divisor = 4`
 - `min_fee = 256`
 
-The Hoon implementation from `tx-engine-1.hoon`:
+The Hoon implementation from `tx-engine.hoon` (the versioned facade, line 916):
 
 ```hoon
 ++  calculate-min-fee
   |=  [sps=form page-num=page-number]
   ^-  coins
-  =/  seed-word-count=@  (count-seed-words [sps page-num])
-  =/  witness-word-count=@  (count-witness-words [sps page-num])
   =/  bythos-active=?  (gte page-num bythos-phase)
-  ::  pre-bythos uses legacy base-fee (2x configured base-fee)
+  ::  bythos halves base-fee at activation; pre-bythos uses legacy 2x rate
   =/  effective-base-fee=coins
     ?:(bythos-active base-fee (mul 2 base-fee))
+  =/  seed-word-count=@  (count-seed-words [sps page-num])
+  =/  witness-word-count=@  (count-witness-words [sps page-num])
   ::  inputs pay discounted fee only at/after bythos activation
-  =/  witness-divisor=@
-    ?:  bythos-active
-      input-fee-divisor
-    1
+  =/  witness-divisor=@  ?:(bythos-active input-fee-divisor 1)
   ::  outputs (seeds) pay full effective-base-fee per word
   =/  seed-fee=coins  (mul seed-word-count effective-base-fee)
-  ::  inputs (witnesses) pay effective-base-fee / witness-divisor per word
+  ::  inputs (witnesses) pay effective-base-fee / input-fee-divisor per word
   =/  witness-fee=coins  (div (mul witness-word-count effective-base-fee) witness-divisor)
   =/  word-fee=coins  (add seed-fee witness-fee)
   (max word-fee min-fee.data)

--- a/docs/architecture/tx-engine/06-fee-structure.md
+++ b/docs/architecture/tx-engine/06-fee-structure.md
@@ -1,0 +1,140 @@
+# Fee Structure: SegWit-Inspired Weight Discounting
+
+## Bitcoin SegWit Fee Model Recap
+
+Bitcoin SegWit introduced a **virtual weight** system where witness data is discounted at a 4:1 ratio:
+
+- Non-witness data: 4 weight units per byte
+- Witness data: 1 weight unit per byte
+- Block limit: 4,000,000 weight units (effectively ~1MB non-witness + ~3MB witness)
+
+The rationale: witness data does not contribute to the UTXO set and is only needed for validation, so it should cost less than output data that persists until spent.
+
+## Nockchain's Fee Model
+
+Nockchain's fee model evolved through two phases, ultimately arriving at the same principle: **witness (input) data should cost less than output data**.
+
+All fee logic is defined in Hoon (`hoon/common/tx-engine-1.hoon`), which is the authoritative source. The Rust types in `crates/nockchain-types/` carry the `BlockchainConstants` structure for deserialization but do not implement fee calculation.
+
+### Pre-Bythos Fee Model (Before Block 54000)
+
+Before Bythos, fees were calculated uniformly:
+
+```
+min_fee = max(
+  (seed_words + witness_words) * (2 * base_fee),
+  min_fee_constant
+)
+```
+
+Where:
+- `base_fee = 2^15 = 32768` (configured, but doubled in practice)
+- `min_fee = 256`
+- All transaction words charged at the same rate
+
+### Post-Bythos Fee Model (Block 54000+)
+
+Bythos (Protocol 012) introduced differential pricing, directly analogous to SegWit's weight discount:
+
+```
+min_fee = max(
+  (seed_words * base_fee) + (witness_words * base_fee / input_fee_divisor),
+  min_fee_constant
+)
+```
+
+Where:
+- `base_fee = 2^14 = 16384` (halved from pre-Bythos effective rate)
+- `input_fee_divisor = 4`
+- `min_fee = 256`
+
+The Hoon implementation from `tx-engine-1.hoon`:
+
+```hoon
+++  calculate-min-fee
+  |=  [sps=form page-num=page-number]
+  ^-  coins
+  =/  seed-word-count=@  (count-seed-words [sps page-num])
+  =/  witness-word-count=@  (count-witness-words [sps page-num])
+  =/  bythos-active=?  (gte page-num bythos-phase)
+  ::  pre-bythos uses legacy base-fee (2x configured base-fee)
+  =/  effective-base-fee=coins
+    ?:(bythos-active base-fee (mul 2 base-fee))
+  ::  inputs pay discounted fee only at/after bythos activation
+  =/  witness-divisor=@
+    ?:  bythos-active
+      input-fee-divisor
+    1
+  ::  outputs (seeds) pay full effective-base-fee per word
+  =/  seed-fee=coins  (mul seed-word-count effective-base-fee)
+  ::  inputs (witnesses) pay effective-base-fee / witness-divisor per word
+  =/  witness-fee=coins  (div (mul witness-word-count effective-base-fee) witness-divisor)
+  =/  word-fee=coins  (add seed-fee witness-fee)
+  (max word-fee min-fee.data)
+```
+
+## Blockchain Constants
+
+Fee parameters are part of the `blockchain-constants` structure defined in Hoon. The Rust side mirrors these for deserialization:
+
+| Constant | Mainnet Value | Fakenet Value | Purpose |
+|---|---|---|---|
+| `base-fee` | 16384 (2^14) | 128 | Per-word fee rate for outputs |
+| `input-fee-divisor` | 4 | 4 | Witness discount factor |
+| `min-fee` | 256 | 256 | Absolute fee floor |
+| `max-size` | (configured) | (configured) | Max note-data size per output |
+| `bythos-phase` | 54000 | 54000 | Activation height for new fee model |
+
+## Word Counting
+
+Fees are denominated in "words" — the number of Nock noun tree nodes in the serialized transaction structure. This is Nock-native sizing: rather than counting bytes (as Bitcoin does), Nockchain counts the structural complexity of the noun representation.
+
+Two separate word counts are computed:
+- **Seed words**: counted from the outputs (seeds), representing data that creates new UTXOs
+- **Witness words**: counted from the inputs (witnesses), representing authentication data consumed during validation
+
+### Note-Data Accounting
+
+Seed word counting includes note-data, but with an important optimization: **note-data maps for outputs sharing the same lock root are merged first**, and the merged map's leaf count is charged once.
+
+From `tx-engine-1.hoon`:
+
+```hoon
+++  note-data-by-lock-root
+  |=  sps=form
+  ^-  (z-mip ^hash @tas *)
+  ...
+  :: merges note-data from all seeds with the same lock-root
+```
+
+This prevents double-charging when multiple outputs to the same lock root carry overlapping data.
+
+## Comparison: Bitcoin SegWit Weight vs Nockchain Fee Formula
+
+| Aspect | Bitcoin SegWit | Nockchain (Post-Bythos) |
+|---|---|---|
+| Measurement unit | Bytes → weight units | Noun words |
+| Output data rate | 4 WU per byte | `base_fee` per word |
+| Witness data rate | 1 WU per byte | `base_fee / 4` per word |
+| Discount ratio | 4:1 | 4:1 (configurable via `input-fee-divisor`) |
+| Fee floor | Dust relay minimum | `min_fee = 256` |
+| Activation | Soft fork (BIP 141) | Height-gated (block 54000) |
+| Rationale | Witness data doesn't grow UTXO set | Inputs are consumed; outputs persist |
+
+The 4:1 discount ratio is identical to Bitcoin SegWit. The rationale is the same: outputs create new UTXOs that the network must store until spent, while input/witness data is validated once and discarded. Discounting witness data incentivizes spending (consuming UTXOs) over creating new ones.
+
+## Fee Transition Mechanics
+
+The Bythos upgrade handled the fee transition smoothly:
+
+1. **Before block 54000**: `effective_base_fee = 2 * base_fee = 2 * 16384 = 32768`, `witness_divisor = 1`
+   - Net effect: `(all_words) * 32768`
+2. **At/after block 54000**: `effective_base_fee = base_fee = 16384`, `witness_divisor = 4`
+   - Net effect: `(seed_words * 16384) + (witness_words * 4096)`
+
+For a typical transaction where witness data is ~50% of total words:
+- Pre-Bythos: `100 words * 32768 = 3,276,800`
+- Post-Bythos: `50 * 16384 + 50 * 4096 = 819,200 + 204,800 = 1,024,000`
+- ~69% fee reduction for typical transactions
+
+This mirrors the practical effect of Bitcoin SegWit, where SegWit transactions paid significantly lower fees than legacy transactions.

--- a/docs/architecture/tx-engine/07-transaction-validation-pipeline.md
+++ b/docs/architecture/tx-engine/07-transaction-validation-pipeline.md
@@ -1,0 +1,219 @@
+# Transaction Validation Pipeline
+
+## Overview
+
+Transaction validation in Nockchain is a multi-phase process implemented primarily in Hoon (`hoon/common/tx-engine-0.hoon` and `hoon/common/tx-engine-1.hoon`), which is the authoritative source of truth for all validation logic. The Rust layer handles deserialization and networking but defers consensus validation to the Nock VM executing the Hoon kernel.
+
+Validation proceeds through three phases:
+1. **Structural validation** — well-formedness of the transaction itself
+2. **Witness verification** — cryptographic proof checking
+3. **Context-aware validation** — checking against the current chain state
+
+## Phase 1: Structural Validation
+
+Structural validation checks that the transaction is well-formed without reference to the UTXO set or chain state.
+
+### V0 Transactions
+
+The V0 `validate` arm in `tx-engine-0.hoon` checks:
+- Transaction ID (`tx-id`) matches the hash of the transaction body
+- Inputs are non-empty
+- Fee amounts are non-negative
+- Timelock ranges are internally consistent (min ≤ max)
+- Total fees match the sum of per-input fees
+
+### V1 Transactions
+
+The V1 `validate` arm in `tx-engine-1.hoon` checks:
+- Version tag is `%1`
+- Transaction ID matches the hash of the spends
+- Spends map is non-empty
+- Each spend is internally consistent:
+  - Seeds (outputs) are non-empty
+  - Fee is non-negative
+  - Gift amounts sum correctly
+  - Spend version tag is valid (`%0` or `%1`)
+
+## Phase 2: Witness Verification
+
+### V0: Direct Signature Verification
+
+V0 spends carry signatures directly. Verification involves:
+1. Computing the sig-hash from the spend's seeds and fee
+2. For each (pubkey, signature) pair in the signature map:
+   - Verify the Schnorr signature against the sig-hash
+3. Check that at least `keys_required` valid signatures exist (M-of-N threshold)
+
+### V1: Lock Primitive Satisfaction
+
+V1 verification is more complex, with each lock primitive type checked independently.
+
+#### Lock Merkle Proof Validation
+
+The `check:lock-merkle-proof` arm verifies:
+1. The spend condition hashes to the correct leaf
+2. The Merkle path from leaf to root is valid (each level combines with the sibling hash)
+3. The computed root matches the lock root in the note's Name
+4. (Post-Bythos) For full proofs: the axis is committed in the hash and `origin-page ≥ bythos-phase`
+
+#### PKH Signature Check
+
+The `check:pkh` arm verifies:
+1. For each public key hash in the Pkh primitive
+2. Look up the corresponding `PkhSignatureEntry` in the witness
+3. Verify that `Hash(pubkey)` matches the committed hash
+4. Verify the Schnorr signature against the sig-hash
+5. Count at least M valid signatures
+
+The sig-hash for V1 is computed over the spend's seeds and fee (excluding the witness), ensuring signatures don't circularly depend on themselves.
+
+#### Timelock Check
+
+The `check:tim` arm verifies:
+1. Current page number satisfies absolute constraints:
+   - `page_num ≥ abs.min` (if set)
+   - `page_num ≤ abs.max` (if set)
+2. Current page number satisfies relative constraints (relative to origin page):
+   - `page_num ≥ origin_page + rel.min` (if set)
+   - `page_num ≤ origin_page + rel.max` (if set)
+
+No witness data is needed — timelocks are validated against the block context.
+
+#### Hash Preimage Check
+
+The `check:hax` arm verifies:
+1. For each hash commitment in the Hax primitive
+2. Look up the corresponding preimage in the witness `hax` map
+3. Hash the preimage and verify it matches the committed hash
+
+#### Burn Check
+
+The `%brn` case always returns false — burn primitives can never be satisfied.
+
+### The check-context Arm
+
+V1 introduces a unified `check-context` structure that bundles all context needed for witness verification:
+
+```hoon
+++  check-context
+  =<  form
+  |%
+  +$  form
+    $:  now=page-number        :: current block height
+        origin-page=@          :: when the note was created
+        sig-hash=hash          :: sig-hash of the spend (for signature verification)
+        =witness               :: the witness data being verified
+        bythos-phase=@         :: bythos activation height
+    ==
+  ++  check
+    |=  [=form lock=hash]
+    ^-  ?
+    ...
+```
+
+This arm validates a complete spend by:
+1. Checking Bythos compatibility (full proofs only after bythos-phase)
+2. Extracting the spend condition from the lock merkle proof
+3. Verifying the lock merkle proof against the lock root
+4. Checking each lock primitive in the spend condition:
+   - `%tim` → check timelocks against current height
+   - `%hax` → check hash preimages
+   - `%pkh` → check Schnorr signatures
+   - `%brn` → always fail
+
+All checks must pass (AND logic within a spend condition).
+
+## Phase 3: Context-Aware Validation
+
+Added by Bythos (Protocol 012), context-aware validation checks the transaction against the current chain state.
+
+### validate-with-context
+
+The `validate-with-context` arm in `tx-engine-1.hoon` takes:
+- `balance`: the current UTXO set (z-map of Name → Note)
+- `sps`: the transaction's spends
+- `page-num`: current block height
+- `max-size`: maximum note-data size
+- `bythos-phase`: activation height for Bythos rules
+
+It performs:
+
+1. **Note-data size check**: Ensure no merged output exceeds `max-size`
+2. **For each spend**:
+   a. **UTXO existence**: The referenced note must exist in the balance
+   b. **Version matching**:
+      - V0 note (head is cell) → must use Spend0
+      - V1 note (head is atom, version=1) → must use Spend1
+   c. **Spend verification**:
+      - Spend0: verify V0-style signature, check gifts and fees
+      - Spend1: build check-context, verify lock, check gifts and fees
+   d. **Gifts and fees**: Total output gifts + fee ≤ input note's assets
+
+### Error Taxonomy
+
+The validation pipeline returns named rejection reasons (Hoon `@tas` cords):
+
+| Error | Meaning |
+|---|---|
+| `%v1-note-data-exceeds-max-size` | Merged note-data exceeds max-size limit |
+| `%v1-input-missing` | Referenced UTXO not in balance |
+| `%v1-spend-version-mismatch` | V0 note with Spend1, or V1 note with Spend0 |
+| `%v1-note-version-mismatch` | V1 note has unexpected version number |
+| `%v1-spend-0-verify-failed` | Spend0 signature verification failed |
+| `%v1-spend-0-gifts-failed` | Spend0 output amounts don't balance |
+| `%v1-spend-1-lock-failed` | Spend1 lock merkle proof / witness check failed |
+| `%v1-spend-1-gifts-failed` | Spend1 output amounts don't balance |
+
+## Mempool vs Block Validation
+
+Bythos tightened the gap between mempool admission and block validation:
+
+**Before Bythos**: Mempool admission used only structural validation (`validate:raw-tx`) plus UTXO presence checks. Context-invalid transactions could circulate in mempools until block processing rejected them.
+
+**After Bythos**: V1 transactions in the mempool must also pass `validate-with-context` using current chain state:
+
+```hoon
+=/  ctx-valid=(reason:t ~)
+  ?^  -.raw
+    [%.y ~]
+  %-  validate-with-context:spends:t
+  :*  get-cur-balance:con
+      spends.raw
+      get-cur-height:con
+      max-size.data.constants.k
+      bythos-phase.constants.k
+  ==
+?.  ?=(%.y -.ctx-valid)
+  ~>  %slog.[1 (cat 3 'heard-tx: Transaction context invalid: ' +.ctx-valid)]
+  `k
+```
+
+This means transactions that are structurally valid but fail context checks (expired timelocks, invalid lock proofs, oversized note-data, missing UTXOs) are dropped immediately at receipt rather than propagated through the network.
+
+## Validation Flow Summary
+
+```
+Transaction arrives
+    │
+    ├─ Phase 1: Structural Validation
+    │   ├─ Version check
+    │   ├─ ID integrity
+    │   ├─ Non-empty inputs
+    │   └─ Internal consistency
+    │
+    ├─ Phase 2: Witness Verification
+    │   ├─ Lock Merkle proof validation
+    │   ├─ PKH signature verification
+    │   ├─ Timelock satisfaction
+    │   ├─ Hash preimage verification
+    │   └─ Burn rejection
+    │
+    └─ Phase 3: Context-Aware Validation (Bythos+)
+        ├─ Note-data size limits
+        ├─ UTXO existence
+        ├─ Version matching
+        ├─ Full witness+lock verification
+        └─ Gift/fee balance check
+```
+
+Each phase can independently reject the transaction with a specific error code. A transaction must pass all three phases to be admitted to the mempool or included in a block.

--- a/docs/architecture/tx-engine/07-transaction-validation-pipeline.md
+++ b/docs/architecture/tx-engine/07-transaction-validation-pipeline.md
@@ -54,28 +54,27 @@ The `check:lock-merkle-proof` arm verifies:
 1. The spend condition hashes to the correct leaf
 2. The Merkle path from leaf to root is valid (each level combines with the sibling hash)
 3. The computed root matches the lock root in the note's Name
-4. (Post-Bythos) For full proofs: the axis is committed in the hash and `origin-page ≥ bythos-phase`
+4. (Post-Bythos) For full proofs: the axis is committed in the hash and `now ≥ bythos-phase`
 
 #### PKH Signature Check
 
-The `check:pkh` arm verifies:
-1. For each public key hash in the Pkh primitive
-2. Look up the corresponding `PkhSignatureEntry` in the witness
-3. Verify that `Hash(pubkey)` matches the committed hash
-4. Verify the Schnorr signature against the sig-hash
-5. Count at least M valid signatures
+The `check:pkh` arm verifies (all conditions must hold):
+1. **Signature count**: The number of witness PKH entries equals `m` (the M-of-N threshold)
+2. **Permissible keys**: The set of witness pubkey hashes is a subset of the committed hashes (checked via `z-in dif`)
+3. **Hash binding**: Each `Hash(pubkey)` in the witness matches its committed hash (checked via `z-by rep`)
+4. **Batch signature verification**: All Schnorr signatures are verified against the sig-hash in a single batch call via `batch-verify:affine:belt-schnorr:cheetah`
 
 The sig-hash for V1 is computed over the spend's seeds and fee (excluding the witness), ensuring signatures don't circularly depend on themselves.
 
 #### Timelock Check
 
 The `check:tim` arm verifies:
-1. Current page number satisfies absolute constraints:
-   - `page_num ≥ abs.min` (if set)
-   - `page_num ≤ abs.max` (if set)
-2. Current page number satisfies relative constraints (relative to origin page):
-   - `page_num ≥ origin_page + rel.min` (if set)
-   - `page_num ≤ origin_page + rel.max` (if set)
+1. Current page number (`now.ctx`) satisfies absolute constraints:
+   - `now ≥ abs.min` (if set)
+   - `now ≤ abs.max` (if set)
+2. Current page number satisfies relative constraints (relative to `since.ctx`, the note's origin page):
+   - `now ≥ since + rel.min` (if set)
+   - `now ≤ since + rel.max` (if set)
 
 No witness data is needed — timelocks are validated against the block context.
 
@@ -100,10 +99,10 @@ V1 introduces a unified `check-context` structure that bundles all context neede
   |%
   +$  form
     $:  now=page-number        :: current block height
-        origin-page=@          :: when the note was created
+        since=page-number      :: page height of the note (origin page)
         sig-hash=hash          :: sig-hash of the spend (for signature verification)
         =witness               :: the witness data being verified
-        bythos-phase=@         :: bythos activation height
+        bythos-phase=page-number  :: height at which bythos activates
     ==
   ++  check
     |=  [=form lock=hash]
@@ -112,14 +111,14 @@ V1 introduces a unified `check-context` structure that bundles all context neede
 ```
 
 This arm validates a complete spend by:
-1. Checking Bythos compatibility (full proofs only after bythos-phase)
-2. Extracting the spend condition from the lock merkle proof
+1. Checking Bythos compatibility (full proofs only after bythos-phase; gates `%full` LMP format to `now >= bythos-phase`)
+2. Extracting the spend condition from the lock merkle proof (handles both stub 3-tuple and full 4-tuple formats)
 3. Verifying the lock merkle proof against the lock root
-4. Checking each lock primitive in the spend condition:
+4. Checking each lock primitive in the spend condition via `levy` (AND logic):
    - `%tim` → check timelocks against current height
    - `%hax` → check hash preimages
-   - `%pkh` → check Schnorr signatures
-   - `%brn` → always fail
+   - `%pkh` → check Schnorr signatures (with batch verification)
+   - `%brn` → always fail (`%|`)
 
 All checks must pass (AND logic within a spend condition).
 

--- a/docs/architecture/tx-engine/08-protocol-evolution.md
+++ b/docs/architecture/tx-engine/08-protocol-evolution.md
@@ -1,0 +1,164 @@
+# Protocol Evolution: Upgrade Mechanics and History
+
+## Upgrade Philosophy
+
+Nockchain uses **height-gated hard cutovers** for consensus-critical upgrades. Unlike Bitcoin's BIP 9/BIP 8 miner-signaling soft fork mechanism, Nockchain upgrades activate at a predetermined block height with no signaling period. All nodes must upgrade before the activation height or risk forking.
+
+This approach is documented in `changelog/protocol/SPECIFICATION.md` and reflected in the protocol changelog entries.
+
+### Comparison: Bitcoin BIP Activation vs Nockchain Height-Gating
+
+| Aspect | Bitcoin (BIP 9/8) | Nockchain |
+|---|---|---|
+| Activation trigger | Miner signaling threshold | Fixed block height |
+| Signaling period | ~2 weeks per retarget | None |
+| Backward compatibility | Soft fork (old nodes accept) | Hard cutover (old nodes may fork) |
+| Coordination | Miners signal readiness | All operators must upgrade |
+| Rollback | Possible before lock-in | Only safe before activation |
+| Upgrade timeline | Months (signaling + lock-in) | Days to weeks (deploy before height) |
+
+## Protocol Changelog
+
+All consensus-critical changes are documented in `changelog/protocol/`, with a structured frontmatter format:
+
+```toml
+version = "0.1.11"
+status = "final"            # draft | final | superseded
+consensus_critical = true
+activation_height = 54000
+published = "2026-01-19"
+activation_target = "2026-03-01"
+```
+
+## Version History
+
+### V0 Genesis (Block 0)
+
+The original transaction engine, defined entirely in `hoon/common/tx-engine-0.hoon` (~2471 lines).
+
+**Characteristics:**
+- Single engine, no version tagging
+- Simple M-of-N multisig via `Lock` (keys_required + set of Schnorr pubkeys)
+- Signature directly embedded in `Spend` structure
+- Coinbase keyed by signer pubkeys
+- Notes carry full lock, source, and timelock data
+- No note-data (no eUTXO datum)
+
+### Protocol 009: SegWit Cutover (Block 37350)
+
+**File**: `changelog/protocol/009-legacy-segwit-cutover-initial.md`
+
+The most significant upgrade — introduced the V0/V1 split. This is Nockchain's "SegWit moment."
+
+**Changes:**
+1. **Dual engine architecture**: `tx-engine.hoon` became a versioned facade dispatching to `tx-engine-0.hoon` or `tx-engine-1.hoon`
+2. **Witness separation**: V1 `Spend1` carries a separate `Witness` struct
+3. **Lock trees**: V1 replaces M-of-N locks with Merkle trees of `SpendCondition` branches
+4. **Lock primitives**: `Pkh`, `Tim`, `Hax`, `Burn` replace the monolithic lock
+5. **Note data**: V1 notes carry `NoteData` (eUTXO-inspired datum)
+6. **Bridge spends**: `Spend0` allows V0 notes to transition to V1 outputs
+7. **Coinbase format**: Changed from sig-keyed to lock-hash-rooted
+8. **Fee floor**: Word-count-based pricing with `base-fee = 2^15`
+
+**Height-gated rule matrix:**
+
+| Block Height | V0 Tx | V1 Tx | Coinbase |
+|---|---|---|---|
+| `< 37350` | Allowed | Rejected | V0 format |
+| `≥ 37350` | Rejected | Required | V1 format |
+
+**State migration**: Kernel state upgraded to v6 to carry versioned consensus objects.
+
+### Protocol 010: V1-Phase Finalization (Block 39000)
+
+**File**: `changelog/protocol/010-legacy-v1-phase-39000.md`
+
+Finalized the V1-phase boundary. The initial plan (Protocol 009) set `v1-phase = 37350`, and Protocol 010 confirmed the transition period ended cleanly at block 39000.
+
+### Protocol 011: LMP Axis Hotfix
+
+**File**: `changelog/protocol/011-legacy-lmp-axis-hotfix.md`
+
+A targeted fix for a lock merkle proof issue related to axis handling — addressed a specific vulnerability or edge case before the Bythos comprehensive fix.
+
+### Protocol 012: Bythos (Block 54000)
+
+**File**: `changelog/protocol/012-bythos.md`
+
+A consensus-critical upgrade addressing two issues discovered after the initial SegWit cutover.
+
+**Lock Merkle Proof Versioning:**
+- Problem: Stub proofs used a hardcoded placeholder instead of committing to the axis field, meaning the witness hash didn't bind to which branch was executed
+- Solution: Introduced `lock-merkle-proof-full` with axis in the hashable
+- Backward compatibility: Both stub and full formats accepted after activation; stub proofs only before activation
+- Format gating by note origin page, not current height
+
+**Fee Rebalancing:**
+- Base fee halved: `2^15 → 2^14`
+- Input/witness discount: `input-fee-divisor = 4` (inputs charged at 1/4 output rate)
+- Separate seed/witness word counting
+- Note-data size validation moved to per-output (after merge by lock-root)
+
+**Context-Aware Mempool Admission:**
+- V1 transactions now validated with `validate-with-context` at mempool receipt
+- Transactions failing context checks (expired timelocks, invalid lock proofs, oversized note-data) dropped immediately
+
+### Protocol 013: Nous (Draft, Non-Consensus)
+
+**File**: `changelog/protocol/013-nous.md`
+
+A networking-layer upgrade (not tx-engine). Adds batched transport requests for the libp2p request-response protocol. Included here for completeness — it does not change transaction formats or consensus rules.
+
+## The Versioned Facade
+
+The Hoon facade (`hoon/common/tx-engine.hoon`) is the authoritative dispatch layer:
+
+```hoon
+/=  v0  /common/tx-engine-0
+/=  v1  /common/tx-engine-1
+...
+|_  blockchain-constants
++*  v0  ~(. ^v0 +63:+<)
+```
+
+It wraps types as tagged unions for consensus-visible structures:
+
+```hoon
+++  coinbase-split
+  =<  form
+  |%
+  +$  form
+    $%  [%0 coinbase-split:v0]
+        [%1 coinbase-split:v1]
+    ==
+```
+
+This pattern applies to `page`, `raw-tx`, `local-page`, `coinbase-split`, and other consensus types. The facade checks version tags and routes to the appropriate engine.
+
+## Kernel State Migration
+
+Protocol upgrades sometimes require kernel state migration. The kernel state carries the UTXO balance, chain tip, and other consensus data. When the state format changes:
+
+1. The kernel state version is bumped (e.g., v5 → v6 for Protocol 009)
+2. Old state is migrated to the new format on first load
+3. Legacy entries are tagged with version markers (e.g., V0 notes in the balance)
+
+The Hoon kernel manages this migration during node startup. The Rust networking layer is agnostic to the internal state format — it only handles serialized nouns for transport.
+
+## Upgrade Coordination Model
+
+Nockchain upgrades follow a predictable pattern:
+
+1. **Protocol spec published** in `changelog/protocol/` with all technical details
+2. **Software updated** to include new rules, gated by activation height
+3. **Operators deploy** updated software before activation
+4. **Activation height reached** — new rules take effect network-wide
+5. **Old software** may fork or reject valid blocks
+
+There is no soft-fork compatibility layer. This is a deliberate choice:
+- Simpler reasoning about consensus rules at any given height
+- No ambiguity about which rules apply
+- No "anyone can spend" risks from soft fork semantics
+- Clear upgrade timeline for operators
+
+The trade-off is that upgrades require full network coordination. Late upgraders will fork.

--- a/docs/architecture/tx-engine/09-noun-encoding-data-layer.md
+++ b/docs/architecture/tx-engine/09-noun-encoding-data-layer.md
@@ -1,0 +1,199 @@
+# Noun Encoding and the Nock Data Layer
+
+## Architecture: Hoon as Source of Truth
+
+A critical architectural point: **Hoon is the source of truth** for all type definitions and validation logic in the Nockchain transaction engine. The Rust type definitions in `crates/nockchain-types/` are serialization/deserialization mirrors — they exist to encode and decode Hoon nouns for networking and application layers, but they do not define the canonical semantics.
+
+This means:
+- **Consensus validation runs in Nock**: The Hoon kernel executing on the Nock VM is what actually validates transactions, computes fees, checks witnesses, and updates balances
+- **Rust types are wire-format adapters**: They serialize Rust structs into nouns (for sending to the Hoon kernel) and deserialize nouns back into Rust structs (for networking, APIs, and wallet logic)
+- **The Hoon types are authoritative**: If the Rust types and Hoon types disagree, the Hoon definition is correct and the Rust code must be fixed
+
+## Nock Nouns: The Universal Data Representation
+
+Nock (the virtual machine underlying Hoon) has exactly one data type: the **noun**. A noun is either:
+- An **atom**: an arbitrary-precision natural number (0, 1, 2, ..., 2^256, ...)
+- A **cell**: an ordered pair of nouns `[left right]`
+
+Every data structure in the system — transactions, notes, balances, blocks, proofs — is ultimately a noun: a binary tree of natural numbers. This is radically different from conventional type systems:
+
+```
+Transaction (as a noun):
+[1 [hash...] [[name spend] [name spend] 0]]
+ │    │              │
+ ver  id          spends (z-map)
+```
+
+## NounEncode / NounDecode: The Rust↔Hoon Bridge
+
+The Rust codebase uses `NounEncode` and `NounDecode` traits to bridge between typed Rust structs and untyped Nock nouns:
+
+```rust
+// Example from crates/nockchain-types/src/tx_engine/v1/tx.rs:25-31
+impl NounEncode for RawTx {
+    fn to_noun<A: NounAllocator>(&self, allocator: &mut A) -> Noun {
+        let version = self.version.to_noun(allocator);
+        let id = self.id.to_noun(allocator);
+        let spends = self.spends.to_noun(allocator);
+        nockvm::noun::T(allocator, &[version, id, spends])
+    }
+}
+```
+
+This creates a noun cell tree: `[version [id spends]]` — matching the Hoon type definition:
+
+```hoon
++$  form
+  $:  version=%1
+      id=tx-id
+      =spends
+  ==
+```
+
+### Structural Discrimination
+
+Because nouns are untyped, version discrimination happens by **examining the shape** of the data. For example, the `Note` enum:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/note.rs:77-84
+impl NounDecode for Note {
+    fn from_noun(noun: &Noun) -> Result<Self, NounDecodeError> {
+        let hed = noun.as_cell()?.head();
+        match hed.is_cell() {
+            true => Ok(Note::V0(NoteV0::from_noun(noun)?)),   // head is cell → V0
+            false => Ok(Note::V1(NoteV1::from_noun(noun)?)),   // head is atom → V1
+        }
+    }
+}
+```
+
+V0 notes have a `NoteHead` (a cell) as their first element; V1 notes have a `Version` atom (1). The decoder probes the structure to determine the variant. This is idiomatic Hoon — `$^` and `$@` runes discriminate types by whether the head is a cell or atom.
+
+Similarly, `LockMerkleProof` discriminates stub vs full:
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:394-406
+impl NounDecode for LockMerkleProof {
+    fn from_noun(noun: &Noun) -> Result<Self, NounDecodeError> {
+        if let Ok(full) = LockMerkleProofFull::from_noun(noun) {
+            if full.version != nockvm_macros::tas!(b"full") {
+                return Err(NounDecodeError::Custom(...));
+            }
+            return Ok(Self::Full(full));
+        }
+        Ok(Self::Stub(LockMerkleProofStub::from_noun(noun)?))
+    }
+}
+```
+
+Try the 4-tuple (Full) first; if it fails or the version tag isn't `%full`, fall back to the 3-tuple (Stub).
+
+## Z-Maps and Z-Sets: Persistent Sorted Trees
+
+Nockchain uses **z-maps** and **z-sets** — balanced binary trees ordered by Tip5 hash — for all collection types. These are the Nock-native equivalents of sorted maps and sets.
+
+### Z-Map (Sorted Map)
+
+Used for:
+- **Spends**: `z-map(Name → Spend)` — associates each UTXO being consumed with its spend proof
+- **Balance**: `z-map(Name → Note)` — the full UTXO set
+- **PkhSignature**: `z-map(Hash → PkhSignatureEntry)` — signature proofs keyed by pubkey hash
+- **NoteData**: `z-map(@tas → *)` — arbitrary key-value data on notes
+- **Witness Hax**: `z-map(Hash → *)` — hash preimage reveals keyed by commitment hash
+
+```rust
+// Z-map put operation (from Spends encoding):
+zmap::z_map_put(allocator, &acc, &mut key, &mut value, &DefaultTipHasher)
+```
+
+### Z-Set (Sorted Set)
+
+Used for:
+- **Seeds**: `z-set(Seed)` — the set of outputs in a spend
+- **Pkh hashes**: `z-set(Hash)` — the set of authorized pubkey hashes
+- **Hax hashes**: `z-set(Hash)` — the set of hash commitments
+
+```rust
+// Z-set put operation (from Seeds encoding):
+zset::z_set_put(allocator, &acc, &mut value, &DefaultTipHasher)
+```
+
+Both structures use `DefaultTipHasher` (Tip5) for ordering, ensuring deterministic tree layout regardless of insertion order. This is essential for consensus — every node must produce the same noun representation for the same logical data.
+
+## Tip5: The Hash Function
+
+Nockchain uses **Tip5** as its universal hash function for:
+- Merkle trees (lock merkle proofs, block commitments)
+- Transaction IDs
+- Note Names
+- UTXO set ordering (z-map/z-set balancing)
+- Public key hashing (Pkh)
+
+Tip5 produces a 5-element tuple of field elements (`[Belt; 5]`), where each `Belt` is a `u64` reduced modulo a prime:
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:149-150
+pub struct Hash(pub [Belt; 5]);
+```
+
+### Hashable Construction
+
+Hoon defines `hashable` arms for each type that specify how to construct the hash input tree:
+
+```hoon
+++  hashable
+  |=  =form
+  ^-  hashable:tip5
+  :*  leaf+version.form
+      hash+(hash:spend-condition spend-condition.form)
+      leaf+axis.form
+      (hashable-merk-proof merk-proof.form)
+  ==
+```
+
+The `hashable` type is a tagged tree of `leaf` (raw values) and `hash` (pre-computed hashes) nodes. The Tip5 hasher traverses this tree to produce a deterministic hash. This is defined in Hoon and executed in the Nock VM; the Rust side does not reimplement the hashing logic for consensus purposes.
+
+## Jamming: Noun Serialization
+
+**Jam** is Nock's native serialization format — it compresses an arbitrary noun into a byte sequence. **Cue** is the inverse (deserialization).
+
+Jam is used for:
+- **NoteData blobs**: Each note-data entry's value is a jammed noun
+- **HaxPreimage values**: Hash preimages are jammed nouns
+- **Wire format**: Nouns sent between nodes are jammed for transport
+
+```rust
+// Jamming a noun for storage:
+let mut slab: NounSlab<NockJammer> = NounSlab::new();
+slab.copy_into(raw_value);
+let jam = slab.jam();  // → bytes::Bytes
+
+// Cueing bytes back into a noun:
+slab.cue_into(entry.blob.clone())?;
+```
+
+Jam achieves compression through structure sharing — if the same sub-noun appears multiple times, it's stored once and referenced by back-pointer. This is particularly efficient for the repetitive structures common in transaction data.
+
+## Architectural Significance
+
+### Why Nouns?
+
+The noun-based architecture has several consequences:
+
+1. **Language-independent consensus**: The Nock VM specification is ~300 words. Any implementation that correctly evaluates Nock programs will produce identical results. This makes consensus validation implementation-independent.
+
+2. **Deterministic serialization**: Nouns have a canonical form — the same logical data always produces the same noun, which always produces the same jam bytes, which always produces the same hash. No sorting, normalization, or canonicalization heuristics needed.
+
+3. **Unified type system**: Everything is a noun. There's no impedance mismatch between "transaction types" and "hash inputs" and "serialized bytes" — they're all the same thing at different levels of interpretation.
+
+4. **Functional state updates**: Z-maps and z-sets are persistent (immutable) data structures. Updating the balance (UTXO set) produces a new tree that shares structure with the old one, enabling efficient versioning and rollback.
+
+### Performance Considerations
+
+The noun-based approach has trade-offs:
+
+- **Encoding overhead**: Converting between Rust structs and nouns requires allocation and tree traversal. This is more expensive than zero-copy serialization formats like FlatBuffers.
+- **Hash computation**: Tip5 hashing traverses the noun tree, which is more expensive than hashing a flat byte array. However, Tip5 is specifically designed for efficient operation within the Nock VM.
+- **Memory layout**: Nouns are pointer-heavy binary trees, which are less cache-friendly than contiguous arrays. The Nock VM uses arena allocation to mitigate this.
+
+These costs are accepted because the noun layer is the consensus boundary — it provides the deterministic execution guarantee that makes decentralized validation possible. Performance-critical paths (like signature verification) are accelerated by **jets** — optimized Rust implementations of commonly-used Nock functions that produce identical results to the pure Nock evaluation.

--- a/docs/architecture/tx-engine/10-zoon-persistent-data-structures.md
+++ b/docs/architecture/tx-engine/10-zoon-persistent-data-structures.md
@@ -1,0 +1,269 @@
+# Zoon: Hash-Ordered Persistent Trees
+
+## Overview
+
+Zoon (`hoon/common/zoon.hoon`, ~700 lines) is Nockchain's vendored balanced tree library, adapted from Hoon's standard `by`/`in` containers. It provides cryptographically-ordered persistent (immutable) collections — z-maps and z-sets — that use Tip5 hashing for deterministic element ordering. These are the data structures that hold the UTXO set, transaction spends, seeds, signatures, and every other collection in the transaction engine.
+
+Zoon explicitly deprecates the standard Hoon containers:
+
+```hoon
+::  /lib/zoon: vendored types from hoon.hoon
++|  %no-by-in
+++  by  %do-not-use
+++  in  %do-not-use
+++  ju  %do-not-use
+++  ja  %do-not-use
+++  bi  %do-not-use
+```
+
+This ensures the entire codebase uses Tip5-ordered trees, which is critical for consensus — all nodes must produce identical noun representations for the same logical data.
+
+## Import Chain
+
+```
+zoon.hoon
+  └─ imports zeke.hoon
+       └─ re-exports ztd/eight.hoon
+            └─ ... (full STARK stack, including Tip5)
+```
+
+Zoon imports `zeke.hoon` (a 1-line re-export of `ztd/eight.hoon`) to get access to the Tip5 hash function. The jet hint `~% %zoon ..stark-engine-jet-hook:z ~` registers the entire zoon library for JIT acceleration by the Nock VM.
+
+## z-map: Persistent Sorted Map
+
+```hoon
+++  z-map
+  |$  [key value]
+  $|  (tree (pair key value))
+  |=(a=(tree (pair)) ?:(=(~ a) & ~(apt z-by a)))
+```
+
+A z-map is a balanced binary tree where each node is a `[key value]` pair. The tree maintains two invariants:
+
+1. **gor-tip ordering**: Keys are ordered by their Tip5 hash (primary key comparison via `gor-tip`)
+2. **mor-tip heap property**: Parent nodes have higher `mor-tip` (double-hash) priority than children
+
+Together, these make the tree a **treap** (tree + heap) — the combination of hash-based ordering and hash-based priority ensures a unique tree shape for any set of keys, regardless of insertion order.
+
+### z-by: The z-map Engine
+
+The `z-by` core provides the full API, all jet-hinted with `~/`:
+
+| Arm | Purpose | Complexity |
+|---|---|---|
+| `get` | Look up value by key | O(log n) |
+| `put` | Insert or update key-value pair | O(log n) |
+| `del` | Remove key from map | O(log n) |
+| `has` | Check key existence | O(log n) |
+| `gas` | Batch insert from list | O(k log n) |
+| `uni` | Union (merge two maps, right-biased) | O(n + m) |
+| `int` | Intersection of two maps | O(n + m) |
+| `dif` | Difference (remove keys in other map) | O(n + m) |
+| `bif` | Split map at a key | O(log n) |
+| `tap` | Convert to list (in-order traversal) | O(n) |
+| `rep` | Fold/reduce over all entries | O(n) |
+| `run` | Apply gate to all values | O(n) |
+| `urn` | Apply gate to all key-value pairs | O(n) |
+| `wyt` | Count entries | O(n) |
+| `key` | Extract z-set of keys | O(n) |
+| `val` | Extract list of values | O(n) |
+| `apt` | Validate tree invariants | O(n) |
+| `dig` | Find axis of key in tree | O(log n) |
+| `jab` | Update value at key via gate | O(log n) |
+| `mar` | Conditional put/delete | O(log n) |
+| `uno` | General union with merge function | O(n + m) |
+
+### The `put` Algorithm
+
+The `put` arm illustrates how the treap invariants work:
+
+```hoon
+++  put
+  ~/  %put
+  |*  [b=* c=*]
+  |-  ^+  a
+  ?~  a
+    [[b c] ~ ~]
+  ?:  =(b p.n.a)
+    ?:  =(c q.n.a)  a
+    a(n [b c])
+  ?:  (gor-tip b p.n.a)
+    =+  d=$(a l.a)
+    ?>  ?=(^ d)
+    ?:  (mor-tip p.n.a p.n.d)
+      a(l d)
+    d(r a(l r.d))
+  =+  d=$(a r.a)
+  ?>  ?=(^ d)
+  ?:  (mor-tip p.n.a p.n.d)
+    a(r d)
+  d(l a(r l.d))
+```
+
+1. If tree is empty: create leaf `[[key value] ~ ~]`
+2. If key matches: update value
+3. Recurse left or right based on `gor-tip` comparison
+4. After insertion, check `mor-tip` heap property; if violated, rotate
+
+## z-set: Persistent Sorted Set
+
+```hoon
+++  z-set
+  |$  [item]
+  $|  (tree item)
+  |=(a=(tree) ?:(=(~ a) & ~(apt z-in a)))
+```
+
+A z-set is a z-map with keys only (no values). The `z-in` engine provides a parallel API: `put`, `has`, `del`, `dif`, `int`, `uni`, `bif`, `tap`, `wyt`, `all`, `any`, `run`, `gas`, `rep`, `dig`.
+
+## z-mip and z-jug: Nested Collections
+
+Zoon also provides two higher-order collection types:
+
+**z-mip** (map of maps):
+```hoon
+++  z-mip  |$  [kex key value]  (z-map kex (z-map key value))
+```
+
+Used in the tx-engine for `note-data-by-lock-root`: a map from lock-root hash to note-data maps.
+
+**z-jug** (map of sets):
+```hoon
+++  z-jug  |$  [key value]  (z-map key (z-set value))
+```
+
+A key-to-set-of-values mapping, with `z-ju` engine providing `put`, `get`, `has`, `del`, `gas`.
+
+## Ordering Functions: The Cryptographic Heart
+
+The ordering functions define the tree layout. All comparisons ultimately derive from Tip5 hashing.
+
+### tip: Primary Hash
+
+```hoon
+++  tip
+  |=  a=*
+  ^-  noun-digest:tip5:z
+  (hash-noun-varlen:tip5:z a)
+```
+
+Computes the Tip5 hash of an arbitrary noun. This is a 5-element digest `[Belt; 5]`.
+
+### double-tip: Secondary Hash
+
+```hoon
+++  double-tip
+  |=  a=*
+  ^-  noun-digest:tip5:z
+  =/  one  (tip a)
+  (hash-ten-cell:tip5:z one one)
+```
+
+Hashes the Tip5 digest with itself, producing a secondary hash used for the heap property.
+
+### dor-tip: Canonical Depth-First Ordering
+
+```hoon
+++  dor-tip
+  ~/  %dor-tip
+  |=  [a=* b=*]
+  ^-  ?
+  ?:  =(a b)  &
+  ?.  ?=(@ a)
+    ?:  ?=(@ b)  |
+    ?:  =(-.a -.b)  $(a +.a, b +.b)
+    $(a -.a, b -.b)
+  ?.  ?=(@ b)  &
+  (lth a b)
+```
+
+A deterministic fallback ordering: atoms before cells, then left-to-right comparison. Used when Tip5 hashes collide (astronomically unlikely but handled for correctness).
+
+### gor-tip: Primary Key Ordering
+
+```hoon
+++  gor-tip
+  ~/  %gor-tip
+  |=  [a=* b=*]
+  ^-  ?
+  =+  [c=(tip a) d=(tip b)]
+  ?:  =(c d)  (dor-tip a b)
+  (lth-tip c d)
+```
+
+Compare by Tip5 hash; fall back to `dor-tip` on collision. This is the **BST property** — determines left vs right in the tree.
+
+### mor-tip: Heap Priority Ordering
+
+```hoon
+++  mor-tip
+  ~/  %mor-tip
+  |=  [a=* b=*]
+  ^-  ?
+  =+  [c=(double-tip a) d=(double-tip b)]
+  ?:  =(c d)  (dor-tip a b)
+  (lth-tip c d)
+```
+
+Compare by double-Tip5 hash; fall back to `dor-tip` on collision. This is the **heap property** — determines parent vs child.
+
+Using two independent hash functions (Tip5 and double-Tip5) for BST ordering and heap priority ensures that the tree shape is deterministic and unique for any set of elements — a cryptographic treap.
+
+## Why Hash-Based Ordering Matters for Consensus
+
+In a decentralized system, every node must independently arrive at the same UTXO set representation. If tree layout depended on insertion order, different nodes processing the same transactions in different orders would produce different trees — same logical data, different nouns, different hashes.
+
+Tip5-based ordering guarantees:
+1. **Deterministic layout**: Same elements → same tree → same noun → same hash
+2. **No sorting needed**: Elements self-organize via their hashes during insertion
+3. **Merkle-like properties**: The tree root hash effectively commits to the entire set's contents
+4. **Efficient verification**: Two nodes can compare z-maps by comparing root hashes
+
+## Rust Jet Implementations
+
+The ordering functions and z-map/z-set operations are jetted in Rust for performance:
+
+| Hoon | Rust File | Key Functions |
+|---|---|---|
+| `tip`, `double-tip`, `gor-tip`, `mor-tip`, `dor-tip`, `lth-tip` | `crates/nockchain-math/src/zoon/common.rs` | `TipHasher` trait, `DefaultTipHasher` |
+| `z-map put` | `crates/nockchain-math/src/zoon/zmap.rs` | `z_map_put()`, `z_map_rep()` |
+| `z-set put/bif/dif` | `crates/nockchain-math/src/zoon/zset.rs` | `z_set_put()`, `z_set_bif()`, `z_set_dif()` |
+
+The `TipHasher` trait abstracts the hash function:
+
+```rust
+pub trait TipHasher {
+    fn hash_noun_varlen(&self, noun: &Noun) -> [u64; 5];
+    fn hash_ten_cell(&self, a: &[u64; 5], b: &[u64; 5]) -> [u64; 5];
+}
+```
+
+`DefaultTipHasher` uses Tip5, but the trait allows alternative hashers for testing.
+
+## Usage in the Transaction Engine
+
+Every collection type in the tx-engine is a z-map or z-set:
+
+| Collection | Type | Keys | Values |
+|---|---|---|---|
+| Spends | z-map | Name (UTXO ID) | Spend (proof) |
+| Balance (UTXO set) | z-map | Name | Note |
+| Seeds (outputs) | z-set | Seed | — |
+| PkhSignature | z-map | Hash (pubkey hash) | PkhSignatureEntry |
+| NoteData | z-map | @tas (string key) | * (arbitrary noun) |
+| Hax (hash commitments) | z-set | Hash | — |
+| Pkh hashes | z-set | Hash | — |
+| note-data-by-lock-root | z-mip | Hash (lock root) | @tas → * |
+
+## Comparison with Other Blockchains
+
+| Aspect | Bitcoin | Cardano | Nockchain |
+|---|---|---|---|
+| UTXO set structure | LevelDB flat index | Haskell `Data.Map` | z-map (Tip5-ordered treap) |
+| Ordering | None (hash-indexed) | Ord instance | Cryptographic (Tip5 hash) |
+| Persistence | Copy-on-write DB | Persistent maps | Structural sharing (immutable trees) |
+| Deterministic layout | N/A (DB internal) | Yes (Ord-based) | Yes (hash-based, unique treap) |
+| Merkle commitment | Separate Merkle tree | Separate Merkle root | Implicit in tree root hash |
+| Collection operations | DB queries | Standard Haskell | z-by/z-in engines (30+ arms each) |
+
+The key differentiator: Nockchain's UTXO set is itself a cryptographically-ordered tree, not a separate database with a Merkle root bolt-on. The tree structure *is* the commitment.

--- a/docs/architecture/tx-engine/10-zoon-persistent-data-structures.md
+++ b/docs/architecture/tx-engine/10-zoon-persistent-data-structures.md
@@ -233,12 +233,14 @@ The `TipHasher` trait abstracts the hash function:
 
 ```rust
 pub trait TipHasher {
-    fn hash_noun_varlen(&self, noun: &Noun) -> [u64; 5];
-    fn hash_ten_cell(&self, a: &[u64; 5], b: &[u64; 5]) -> [u64; 5];
+    fn hash_noun_varlen<A: NounAllocator>(
+        &self, stack: &mut A, a: Noun,
+    ) -> Result<[u64; 5], JetErr>;
+    fn hash_ten_cell(&self, ten: [u64; 10]) -> Result<[u64; 5], JetErr>;
 }
 ```
 
-`DefaultTipHasher` uses Tip5, but the trait allows alternative hashers for testing.
+Note that `hash_ten_cell` takes a single `[u64; 10]` array (the two 5-element digests concatenated), not two separate `[u64; 5]` arrays. `DefaultTipHasher` uses Tip5, but the trait allows alternative hashers for testing.
 
 ## Usage in the Transaction Engine
 

--- a/docs/architecture/tx-engine/11-tip5-hash-function.md
+++ b/docs/architecture/tx-engine/11-tip5-hash-function.md
@@ -1,0 +1,222 @@
+# Tip5: The Sponge Hash Function
+
+## Overview
+
+Tip5 is the cryptographic hash function used throughout Nockchain for commitments, Merkle trees, data structure ordering, and transaction IDs. It belongs to the family of **algebraic sponge hashes** (alongside Poseidon, Neptune, and Rescue) — hash functions designed to be efficient both natively and inside zero-knowledge proof circuits.
+
+The authoritative implementation is in Hoon (`hoon/common/ztd/three.hoon`), with a Rust jet in `crates/nockchain-math/src/tip5/`.
+
+## Design Parameters
+
+| Parameter | Value | Meaning |
+|---|---|---|
+| Field | Goldilocks, p = 2^64 − 2^32 + 1 | Each state element is a 64-bit field element |
+| State size | 16 elements | Total permutation width |
+| Capacity | 6 elements | Security margin (never directly exposed) |
+| Rate | 10 elements | Input absorbed per permutation |
+| Rounds | 7 | Number of permutation rounds |
+| Digest length | 5 elements (320 bits) | Output size |
+| S-box (first 4) | Lookup table (Fermat map) | x → x^(p−2) via 256-byte table |
+| S-box (last 12) | 7th power map | x → x^7 in 4 multiplications |
+
+## Sponge Construction
+
+Tip5 uses the standard sponge construction:
+
+```
+Input: [a₀, a₁, ..., aₙ]
+
+1. Pad input: append [1, 0, 0, ...] to reach a multiple of RATE (10)
+2. Convert to Montgomery form (montify each element)
+3. Initialize sponge state (16 elements)
+4. For each RATE-sized chunk:
+   a. XOR chunk into the rate portion of the state
+   b. Apply permutation (7 rounds)
+5. Extract first 5 elements as digest
+6. Convert back from Montgomery form
+```
+
+Two initialization modes exist:
+- **Variable-length** (`hash-varlen`): for arbitrary-length inputs
+- **Fixed-length** (`hash-10`): optimized for exactly 10 elements (one rate block)
+
+## Permutation Round Structure
+
+Each of the 7 rounds applies three layers:
+
+### 1. S-box Layer
+
+The S-box provides non-linearity. It applies two different maps depending on position:
+
+```hoon
+++  sbox-layer
+  ~/  %sbox-layer
+  |=  =state
+  ?>  =((lent state) state-size)
+  %+  weld
+    (turn (scag num-split-and-lookup state) split-and-lookup)  :: first 4
+  %+  turn  (slag num-split-and-lookup state)                   :: last 12
+  |=  m=melt
+  =/  sq  (bmul m m)      :: x²
+  =/  qu  (bmul sq sq)    :: x⁴
+  :(bmul m sq qu)         :: x⁷ = x · x² · x⁴
+```
+
+- **First 4 elements**: `split-and-lookup` — decomposes the element into bytes, applies a 256-byte lookup table (implementing the Fermat map x → x^(p−2) ≡ x^(−1)), then recombines
+- **Last 12 elements**: 7th power map — computes x^7 using 4 field multiplications (x → x² → x⁴ → x·x²·x⁴)
+
+The hybrid S-box design is a performance optimization: the lookup-table-based Fermat map is faster for the first few elements, while the power map avoids the table dependency for the remaining elements.
+
+### 2. MDS Layer
+
+Linear mixing via a 16×16 circulant MDS (Maximum Distance Separable) matrix:
+
+```hoon
+++  mds-cyclomul-m
+  ~/  %mds-cyclomul-m
+  |=  v=(list @)
+  ^-  (list @)
+  %+  turn  mds-matrix
+  |=  row=(list @)
+  (mod (inner-product row v) p)
+```
+
+The MDS matrix ensures maximum diffusion — every output element depends on every input element. The circulant structure allows optimization via the inner product computation.
+
+### 3. Round Constant Addition
+
+Each round adds a unique set of 16 precomputed constants:
+
+```hoon
+++  round
+  ~/  %round
+  |=  [sponge=tip5-state round-index=@]
+  =.  sponge  (mds-cyclomul-m (sbox-layer sponge))
+  %^  zip  sponge  (range state-size)
+  |=  [b=belt i=@]
+  (badd b (snag (add (mul round-index state-size) i) round-constants))
+```
+
+Total round constants: 7 rounds × 16 elements = 112 precomputed Goldilocks field elements.
+
+## Montgomery Representation
+
+All permutation arithmetic operates in **Montgomery space** for efficiency:
+
+- `melt`: a field element in Montgomery form (multiplied by R = 2^64 mod p)
+- `montify`: convert belt → melt (multiply by R mod p)
+- `mont-reduction`: convert melt → belt (multiply by R^(-1) mod p)
+- `montiply`: Montgomery multiplication — `a * b * R^(-1) mod p` in a single operation
+
+Montgomery multiplication avoids expensive division-based modular reduction by using a shift-based reduction, roughly 4× faster for repeated multiplications.
+
+## Hash Variants
+
+### hash-10: Fixed 10-Element Input
+
+```hoon
+++  hash-10
+  ~/  %hash-10
+  |=  input=(list belt)
+  ^-  (list belt)
+  ?>  =((lent input) rate)
+  ?>  (levy input based)
+  =.  input   (turn input montify)
+  =/  sponge  (init-tip5-state %fixed)
+  =.  sponge  (permutation (weld input (slag rate sponge)))
+  (turn (scag digest-length sponge) mont-reduction)
+```
+
+Optimized path for exactly 10 elements. Used by `double-tip` in zoon (hashes two 5-element digests together).
+
+### hash-varlen: Variable-Length Input
+
+Pads input, absorbs in rate-sized chunks, returns 5-element digest. Used for hashing arbitrary-length data.
+
+### hash-noun-varlen: Noun Hashing
+
+Hashes an arbitrary Nock noun by extracting its **leaf sequence** (atoms at the leaves of the binary tree) and **Dyck word** (the tree structure encoding), then feeding both through the sponge. This ensures that structurally different nouns produce different hashes even if they contain the same atoms.
+
+### hash-hashable: Commitment Hashing
+
+Hashes a tagged `hashable` tree structure. The `hashable` type is:
+
+```hoon
++$  hashable
+  $%  [%leaf p=@]               :: raw value
+      [%hash p=noun-digest]     :: pre-computed hash
+      [%list p=(list hashable)] :: list of hashables
+  ==
+```
+
+Transaction engine types define `++hashable` arms that build these trees, which `hash-hashable` then traverses to produce deterministic commitments. For example, the lock-merkle-proof-full hashable:
+
+```hoon
+:*  leaf+version.form
+    hash+(hash:spend-condition spend-condition.form)
+    leaf+axis.form
+    (hashable-merk-proof merk-proof.form)
+==
+```
+
+### Tog: Deterministic PRNG
+
+The `tog` interface provides deterministic pseudorandom generation from a sponge state:
+
+- `belts`: generate N random belt (field element) values
+- `felt`: generate a random felt (extension field element)
+- `indices`: generate random indices for spot checks
+
+Used in the STARK proof system for Fiat-Shamir challenges.
+
+## Rust Jet Implementation
+
+The Rust jet mirrors the Hoon implementation exactly:
+
+**Constants** (`crates/nockchain-math/src/tip5/mod.rs`):
+- `LOOKUP_TABLE`: 256-byte S-box for the Fermat map
+- `ROUND_CONSTANTS`: 112 `u64` values (7 rounds × 16 state elements)
+- `MDS_MATRIX_MONT`: 16×16 matrix in Montgomery representation
+
+**Functions** (`crates/nockchain-math/src/tip5/hash.rs`):
+- `permute(sponge: &mut [u64; 16])`: applies 7 rounds in-place
+- `hash_varlen(input: &[u64]) -> [u64; 5]`: variable-length hash
+- `hash_10(input: &[u64; 10]) -> [u64; 5]`: fixed 10-element hash
+- `hash_noun_varlen(noun: &Noun) -> [u64; 5]`: noun hash
+
+## Usage in the Transaction Engine
+
+Tip5 is used at every layer of the tx-engine:
+
+| Usage | Function | Input |
+|---|---|---|
+| Transaction ID | `hash-hashable` | Hashable tree of spends |
+| Lock root | `hash:lock` | Lock tree structure |
+| Note Name.first | `hash:lock` | Lock root of the spending conditions |
+| Note Name.last | derived | Source hash (parent transaction) |
+| Merkle proof siblings | `hash-ten-cell` | Pair of sibling hashes |
+| z-map/z-set ordering | `hash-noun-varlen` | Element nouns (via `tip` in zoon) |
+| z-map/z-set priority | `hash-ten-cell` + `hash-noun-varlen` | Double-hash (via `double-tip`) |
+| PKH commitment | `hash` | Public key → public key hash |
+| Hax commitment | `hash` | Preimage → commitment hash |
+| Block commitment | `hash-hashable` | Page/block contents |
+
+## Comparison with Other Blockchain Hash Functions
+
+| Hash | Blockchain | Field | Design | ZK-Friendly |
+|---|---|---|---|---|
+| SHA-256d | Bitcoin | Binary (256-bit) | Merkle-Damgård | No |
+| Keccak-256 | Ethereum | Binary (256-bit) | Sponge (binary) | No |
+| Poseidon | Mina, Filecoin | Various prime fields | Algebraic sponge | Yes |
+| Rescue-Prime | Various | Various prime fields | Algebraic sponge | Yes |
+| Tip5 | Nockchain | Goldilocks (64-bit) | Algebraic sponge | Yes |
+
+### Why Tip5 Matters for STARK Compatibility
+
+Traditional hash functions like SHA-256 and Keccak operate on bits/bytes. Verifying them inside a STARK circuit requires encoding binary operations as algebraic constraints — extremely expensive (thousands of constraints per hash).
+
+Tip5 operates natively on Goldilocks field elements — the same field used for STARK arithmetic. This means:
+- Hashing inside a STARK circuit requires only ~7 × 16 = 112 field operations per permutation
+- No binary-to-field conversion overhead
+- The S-box, MDS matrix, and round constants all operate in the native field
+- Merkle proof verification in-circuit is practical, enabling efficient recursive proofs

--- a/docs/architecture/tx-engine/12-schnorr-signatures-cheetah-curve.md
+++ b/docs/architecture/tx-engine/12-schnorr-signatures-cheetah-curve.md
@@ -1,0 +1,273 @@
+# Schnorr Signatures over the Cheetah Curve
+
+## Overview
+
+Nockchain uses **Schnorr signatures** over the **Cheetah elliptic curve** — a STARK-friendly curve defined over a sextic extension of the Goldilocks prime field. The Cheetah curve was designed by Toposware specifically for efficient verification both natively and inside zero-knowledge proof circuits.
+
+The Rust implementation is in `crates/nockchain-math/src/crypto/cheetah.rs` (~455 lines). The Hoon types are authoritative in `tx-engine-1.hoon`, with Rust serialization mirrors in `crates/nockchain-types/src/tx_engine/`.
+
+## Why Not secp256k1 or Ed25519?
+
+Bitcoin uses secp256k1 (ECDSA, later Schnorr via Taproot). Ethereum and many other chains use Ed25519 or secp256k1. These curves operate over 256-bit prime fields that have no special relationship to Nockchain's arithmetic.
+
+Nockchain's entire proof system operates over the **Goldilocks field** (p = 2^64 − 2^32 + 1). For STARK compatibility, all cryptographic operations — including signature verification — must be efficiently expressible as constraints over this field. A standard 256-bit curve would require multi-limb arithmetic inside the STARK circuit, making signature verification prohibitively expensive.
+
+The Cheetah curve solves this: its base field *is* Goldilocks, and its extension field arithmetic reduces to `u64` operations over the Goldilocks prime. This means Schnorr signature verification inside a STARK circuit requires only native field operations.
+
+## Cheetah Curve Specification
+
+The Cheetah curve comes from Toposware's research on elliptic curves over sextic extensions of small prime fields (ePrint 2022/277).
+
+### Field Tower
+
+| Layer | Definition | Meaning |
+|---|---|---|
+| Base field Fp | p = 2^64 − 2^32 + 1 | Goldilocks prime, fits in one `u64` |
+| Extension Fp^6 | Fp[X]/(X^6 − 7) | Degree-6 extension, implemented as `F6lt = [Belt; 6]` |
+
+The extension field is constructed as Fp^6 = Fp[u] where u^6 = 7. Each element is a 6-tuple of Goldilocks field elements.
+
+### Curve Parameters
+
+| Parameter | Value |
+|---|---|
+| Curve equation | E: y² = x³ + x + (u + 395), where u^6 = 7 |
+| Base field | Fp, p = 2^64 − 2^32 + 1 |
+| Scalar field | Fp^6 = Fp[X]/(X^6 − 7) |
+| Group order | `0x7af2599b3b3f22d0563fbf0f990a37b5327aa72330157722d443623eaed4accf` (~255 bits) |
+| Security level | ~128 bits (resistant to Pollard-Rho, twist, MOV, cover, decomposition attacks) |
+| Generator | `A_GEN` (predefined constant in `cheetah.rs`) |
+| Identity | `A_ID` (point at infinity, `{x: 0, y: 1, inf: true}`) |
+
+### Why Sextic Extension?
+
+The degree-6 extension is a carefully chosen balance:
+
+1. **64-bit base field**: Each base element fits in a single machine word → fast native arithmetic
+2. **Large group order**: The ~255-bit subgroup provides ~128 bits of security (comparable to secp256k1)
+3. **Attack resistance**: Degree 6 is small enough to resist cover and decomposition attacks specific to extension-field curves, while large enough for security
+4. **STARK efficiency**: All field operations reduce to `u64` arithmetic over Goldilocks → efficient as STARK AIR constraints
+
+## Point Representation
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:60-65
+pub struct CheetahPoint {
+    pub x: F6lt,    // x-coordinate in Fp^6
+    pub y: F6lt,    // y-coordinate in Fp^6
+    pub inf: bool,  // point at infinity flag
+}
+
+pub struct F6lt(pub [Belt; 6]);  // 6 Goldilocks field elements
+```
+
+A point on the Cheetah curve is represented by its (x, y) coordinates in the sextic extension field, plus an infinity flag. Each coordinate is 6 × 64 = 384 bits, so a full point is 768 bits + flag.
+
+## Extension Field Arithmetic
+
+The `F6lt` type supports full field arithmetic, implemented via Karatsuba-style multiplication:
+
+| Operation | Function | Notes |
+|---|---|---|
+| Addition | `f6_add(a, b)` | Component-wise addition mod p |
+| Negation | `f6_neg(a)` | Component-wise negation mod p |
+| Subtraction | `f6_sub(a, b)` | `f6_add(a, f6_neg(b))` |
+| Multiplication | `f6_mul(a, b)` | Karatsuba via `karat3` — reduces to three degree-3 multiplications |
+| Squaring | `f6_square(a)` | Currently `f6_mul(a, a)` (TODO: dedicated Karatsuba-square) |
+| Inversion | `f6_inv(a)` | Extended GCD over polynomial ring Fp[X]/(X^6 − 7) |
+| Division | `f6_div(a, b)` | `f6_mul(a, f6_inv(b))` |
+| Scalar mult | `f6_scal(s, a)` | Multiply each component by base field element |
+
+The Karatsuba multiplication (`karat3`) is the key optimization: it multiplies two degree-2 polynomials using 3 component multiplications instead of the naive 9, then composes two `karat3` calls to handle the full degree-5 multiplication with reduction by X^6 − 7.
+
+The reduction by the irreducible polynomial X^6 − 7 appears in `f6_mul` as additions of `Belt(7) * (...)` terms — when a product exceeds degree 5, the X^6 term is replaced by 7 (since X^6 ≡ 7 mod (X^6 − 7)).
+
+## Point Arithmetic
+
+| Operation | Function | Notes |
+|---|---|---|
+| Point addition | `ch_add(p, q)` | Handles identity, negation, and doubling cases |
+| Point doubling | `ch_double(p)` | Optimized doubling using tangent slope |
+| Point negation | `ch_neg(p)` | Negate y-coordinate |
+| Scalar mult (u64) | `ch_scal(n, p)` | Binary method for 64-bit scalars |
+| Scalar mult (big) | `ch_scal_big(n, p)` | Binary method for arbitrary-size integers (UBig) |
+
+The addition formula for non-special cases:
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:262-271
+pub fn ch_add_unsafe(p: CheetahPoint, q: CheetahPoint) -> Result<CheetahPoint, JetErr> {
+    let slope = f6_div(&f6_sub(&p.y, &q.y), &f6_sub(&p.x, &q.x))?;
+    let x_out = f6_sub(&f6_square(&slope), &f6_add(&p.x, &q.x));
+    let y_out = f6_sub(&f6_mul(&slope, &f6_sub(&p.x, &x_out)), &p.y);
+    Ok(CheetahPoint { x: x_out, y: y_out, inf: false })
+}
+```
+
+The doubling formula uses the curve equation's derivative (3x² + a where a = 1 for Cheetah):
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:228-240
+pub fn ch_double_unsafe(x: &F6lt, y: &F6lt) -> Result<CheetahPoint, JetErr> {
+    let slope = f6_div(
+        &f6_add(&f6_scal(Belt(3), &f6_square(x)), &F6_ONE),  // 3x² + 1
+        &f6_scal(Belt(2), y),                                  // 2y
+    )?;
+    let x_out = f6_sub(&f6_square(&slope), &f6_scal(Belt(2), x));
+    let y_out = f6_sub(&f6_mul(&slope, &f6_sub(x, &x_out)), y);
+    Ok(CheetahPoint { x: x_out, y: y_out, inf: false })
+}
+```
+
+## Curve Validation
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:114-121
+pub fn in_curve(&self) -> bool {
+    if *self == A_ID { return true; }
+    let scaled = ch_scal_big(&G_ORDER, self)
+        .expect("scalar multiplication should succeed");
+    scaled == A_ID  // [n]G = ∞ iff G has order dividing n
+}
+```
+
+Validation checks that `[G_ORDER]P = ∞` — the point has order dividing the group order. This is sufficient because the subgroup has prime order, so any non-identity point with this property is a valid group element.
+
+## Schnorr Signature Types
+
+### SchnorrPubkey
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:15-16
+pub struct SchnorrPubkey(pub CheetahPoint);
+```
+
+A public key is a point on the Cheetah curve. It derives `NounEncode`/`NounDecode` automatically from `CheetahPoint`.
+
+### SchnorrSignature
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:30-34
+pub struct SchnorrSignature {
+    pub chal: [Belt; 8],  // Challenge (Fiat-Shamir hash of commitment)
+    pub sig: [Belt; 8],   // Response scalar
+}
+```
+
+A signature consists of a challenge and response, each represented as 8 Goldilocks field elements (512 bits). The 8-element representation accommodates the ~255-bit group order with room for the encoding.
+
+### PkhSignatureEntry
+
+```rust
+// crates/nockchain-types/src/tx_engine/v1/tx.rs:296-301
+pub struct PkhSignatureEntry {
+    pub hash: Hash,                   // The pubkey hash being satisfied
+    pub pubkey: SchnorrPubkey,        // The actual public key
+    pub signature: SchnorrSignature,  // Schnorr signature
+}
+```
+
+When satisfying a `Pkh` lock primitive, the witness provides a `PkhSignatureEntry` for each signing key. The entry binds together:
+1. The pubkey hash (committed in the lock)
+2. The actual public key (revealed at spend time)
+3. The Schnorr signature over the transaction's sig-hash
+
+### Sig-Hash: What Gets Signed
+
+The message signed by a Schnorr signature is the **sig-hash** of the transaction — a hash of the seeds (outputs) and fee, but *excluding* the witness data. This is the same SegWit-inspired design described in file 02: the witness does not sign itself, enabling witness malleability prevention.
+
+## Key Encoding
+
+Public keys use Base58 serialization:
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:67-81
+const BYTES: usize = 97;  // 1 prefix + 12 Belt elements × 8 bytes each
+
+pub fn into_base58(&self) -> Result<String, CheetahError> {
+    let mut bytes = Vec::new();
+    bytes.push(0x1);  // Prefix byte
+    for belt in self.y.0.iter().rev().chain(self.x.0.iter().rev()) {
+        bytes.extend_from_slice(&belt.0.to_be_bytes());
+    }
+    Ok(bs58::encode(bytes).into_string())
+}
+```
+
+The encoding is: `[0x01 | y₅..y₀ | x₅..x₀]` in big-endian, producing a 97-byte value that encodes to a ~132-character Base58 string. The leading `0x01` byte serves as a version/format prefix.
+
+Decoding includes `in_curve()` validation to reject points not on the curve.
+
+## Signature Collection
+
+The `Signature` type in the witness is a z-map (hash-ordered persistent tree) of `(SchnorrPubkey → SchnorrSignature)` pairs:
+
+```rust
+// crates/nockchain-types/src/tx_engine/common/mod.rs:36-48
+pub struct Signature(pub Vec<(SchnorrPubkey, SchnorrSignature)>);
+
+impl NounEncode for Signature {
+    fn to_noun<A: NounAllocator>(&self, stack: &mut A) -> Noun {
+        self.0.iter().fold(D(0), |map, (pubkey, sig)| {
+            let mut key = pubkey.to_noun(stack);
+            let mut value = sig.to_noun(stack);
+            zmap::z_map_put(stack, &map, &mut key, &mut value, &DefaultTipHasher)
+                .expect("z-map put for signature should not fail")
+        })
+    }
+}
+```
+
+Signatures are stored in a z-map keyed by public key, ensuring deterministic ordering regardless of the order signatures were collected. This is critical for consensus — the noun representation of the witness must be identical across all nodes.
+
+## The `trunc_g_order` Function
+
+```rust
+// crates/nockchain-math/src/crypto/cheetah.rs:332-339
+pub fn trunc_g_order(a: &[u64]) -> UBig {
+    let mut result = UBig::from(a[0]);
+    result += &*P_BIG * UBig::from(a[1]);
+    result += &*P_BIG_2 * UBig::from(a[2]);
+    result += &*P_BIG_3 * UBig::from(a[3]);
+    result % &*G_ORDER
+}
+```
+
+This converts a 4-element array of `u64` values into a scalar modulo the group order, interpreting the array as a base-p number: `a[0] + a[1]·p + a[2]·p² + a[3]·p³ mod G_ORDER`. This is used to convert Tip5 hash outputs (which are in the Goldilocks field) into scalars suitable for elliptic curve operations.
+
+## Also Available: Ed25519 Jets
+
+The Nock VM also includes Ed25519 jets for non-consensus cryptographic operations:
+
+| Jet | Location | Purpose |
+|---|---|---|
+| `jet_sign` | `crates/nockvm/rust/nockvm/src/jets/lock/ed.rs` | Ed25519 signing |
+| `jet_veri` | same | Ed25519 verification |
+| `jet_puck` | same | Public key derivation |
+| `jet_shar` | same | Shared secret (X25519) |
+
+These are available in the VM for application-level cryptography (e.g., key derivation, off-chain signatures) but are not used in the consensus-critical transaction engine. The transaction engine exclusively uses Schnorr over Cheetah for on-chain authentication.
+
+Additionally, `crates/nockchain-math/src/crypto/argon2.rs` provides Argon2 key derivation — used for wallet password hashing, not consensus operations.
+
+## Comparison with Bitcoin's Signature Evolution
+
+| Aspect | Bitcoin (pre-Taproot) | Bitcoin (Taproot) | Nockchain |
+|---|---|---|---|
+| Signature scheme | ECDSA | Schnorr | Schnorr |
+| Curve | secp256k1 (256-bit) | secp256k1 (256-bit) | Cheetah (Fp^6 over Goldilocks) |
+| Key size | 33 bytes (compressed) | 32 bytes (x-only) | 97 bytes (full point) |
+| Signature size | ~72 bytes (DER) | 64 bytes | 128 bytes (8+8 Belt elements) |
+| Multisig | OP_CHECKMULTISIG (N pubkeys + N sigs) | MuSig2 (single aggregated key) | Native M-of-N via Pkh primitive |
+| ZK-friendly | No | No | Yes (native field arithmetic in STARKs) |
+| Batch verification | No | Yes (Schnorr linearity) | Possible (Schnorr linearity) |
+
+### Key Design Differences
+
+1. **Larger keys and signatures**: Cheetah operates over Fp^6, so points and scalars are larger than secp256k1. The trade-off is STARK-circuit efficiency.
+
+2. **No x-only pubkeys**: Bitcoin Taproot uses x-only public keys (32 bytes) where the y-coordinate is implicitly even. Nockchain encodes the full (x, y) point, avoiding the parity ambiguity at the cost of larger keys.
+
+3. **Hash-based key commitment**: Like Bitcoin P2PKH but unlike Taproot's key-path, Nockchain's Pkh stores `Hash(pubkey)` rather than the pubkey itself. The actual key is revealed only at spend time.
+
+4. **Schnorr from inception**: Bitcoin migrated from ECDSA to Schnorr over a decade. Nockchain chose Schnorr from V1 inception, benefiting from linearity (enabling potential future MuSig-style aggregation) without legacy compatibility concerns.

--- a/docs/architecture/tx-engine/12-schnorr-signatures-cheetah-curve.md
+++ b/docs/architecture/tx-engine/12-schnorr-signatures-cheetah-curve.md
@@ -31,13 +31,14 @@ The extension field is constructed as Fp^6 = Fp[u] where u^6 = 7. Each element i
 
 | Parameter | Value |
 |---|---|
-| Curve equation | E: y² = x³ + x + (u + 395), where u^6 = 7 |
-| Base field | Fp, p = 2^64 − 2^32 + 1 |
-| Scalar field | Fp^6 = Fp[X]/(X^6 − 7) |
+| Curve equation | E: y² = x³ + x + b, where b = 395 + u (see `++b` in `ztd/three.hoon:1472`) |
+| Prime field | Fp, p = 2^64 − 2^32 + 1 (Goldilocks) |
+| Coordinate field | Fp^6 = Fp[u]/(u^6 − 7), each point's (x, y) lives here |
 | Group order | `0x7af2599b3b3f22d0563fbf0f990a37b5327aa72330157722d443623eaed4accf` (~255 bits) |
+| Scalar field | Z/nZ where n = group order (~255 bits) |
 | Security level | ~128 bits (resistant to Pollard-Rho, twist, MOV, cover, decomposition attacks) |
-| Generator | `A_GEN` (predefined constant in `cheetah.rs`) |
-| Identity | `A_ID` (point at infinity, `{x: 0, y: 1, inf: true}`) |
+| Generator | `a-gen` / `A_GEN` (predefined constant in `ztd/three.hoon:1535` / `cheetah.rs:22`) |
+| Identity | `a-id` / `A_ID` (point at infinity: `[f6-zero f6-one %.y]`) |
 
 ### Why Sextic Extension?
 
@@ -133,7 +134,63 @@ pub fn in_curve(&self) -> bool {
 
 Validation checks that `[G_ORDER]P = ∞` — the point has order dividing the group order. This is sufficient because the subgroup has prime order, so any non-identity point with this property is a valid group element.
 
-## Schnorr Signature Types
+## Schnorr Signature Scheme (Authoritative Hoon)
+
+The Schnorr scheme is defined in `hoon/common/ztd/three.hoon` within the `++schnorr` core of the `++cheetah` library.
+
+### Signing (`++sign`, `three.hoon:1628-1661`)
+
+```hoon
+++  sign
+  |=  [sk-as-32-bit-belts=(list belt) m=noun-digest:tip5]
+  ^-  [c=@ux s=@ux]
+```
+
+1. Derive public key: `pubkey = [sk]G`
+2. Compute nonce deterministically: `nonce = trunc-g-order(hash-varlen(pubkey_x || pubkey_y || m || sk_belts))`
+3. Compute commitment point: `R = [nonce]G`
+4. Compute challenge: `chal = trunc-g-order(hash-varlen(R_x || R_y || pubkey_x || pubkey_y || m))`
+5. Compute response: `sig = (nonce + chal · sk) mod g-order`
+6. Return `[chal, sig]`
+
+The nonce is derived deterministically from the secret key and message (like RFC 6979), avoiding the need for a random number generator.
+
+### Verification (`++verify`, `three.hoon:1663-1686`)
+
+```hoon
+++  verify
+  |=  [pubkey=a-pt:curve m=noun-digest:tip5 chal=@ux sig=@ux]
+  ^-  ?
+```
+
+1. Check `0 < chal < g-order` and `0 < sig < g-order`
+2. Recover commitment: `R = [sig]G − [chal]pubkey`
+3. Recompute challenge: `chal' = trunc-g-order(hash-varlen(R_x || R_y || pubkey_x || pubkey_y || m))`
+4. Accept if `chal == chal'`
+
+This is a standard Schnorr verification: if `sig = nonce + chal·sk`, then `[sig]G − [chal]pubkey = [nonce]G + [chal·sk]G − [chal·sk]G = [nonce]G = R`, recovering the original commitment point.
+
+### `trunc-g-order`: Hash-to-Scalar (`three.hoon:1695-1706`)
+
+```hoon
+++  trunc-g-order
+  |=  a=(list belt)
+  (mod (add (snag 0 a) (mul p (snag 1 a)) ...) g-order:curve)
+```
+
+Converts a Tip5 hash output (list of belts) into a scalar in `[0, g-order)` by interpreting the first 4 elements as a base-p number and reducing modulo the group order. This is the bridge between the hash function's Goldilocks output and the elliptic curve's scalar field.
+
+### Batch Verification
+
+```hoon
+++  batch-verify
+  |=  batch=(list [pubkey=a-pt:curve m=noun-digest:tip5 chal=@ux sig=@ux])
+  (levy batch verify)
+```
+
+Currently verifies each signature independently. Schnorr's linearity enables future optimization via randomized batch verification.
+
+## Schnorr Signature Types (Rust Serialization Mirror)
 
 ### SchnorrPubkey
 
@@ -149,12 +206,12 @@ A public key is a point on the Cheetah curve. It derives `NounEncode`/`NounDecod
 ```rust
 // crates/nockchain-types/src/tx_engine/common/mod.rs:30-34
 pub struct SchnorrSignature {
-    pub chal: [Belt; 8],  // Challenge (Fiat-Shamir hash of commitment)
-    pub sig: [Belt; 8],   // Response scalar
+    pub chal: [Belt; 8],  // Challenge scalar as 8 base field elements
+    pub sig: [Belt; 8],   // Response scalar as 8 base field elements
 }
 ```
 
-A signature consists of a challenge and response, each represented as 8 Goldilocks field elements (512 bits). The 8-element representation accommodates the ~255-bit group order with room for the encoding.
+In Hoon, challenge and response are raw `@ux` atoms. The Rust serialization represents each as 8 Goldilocks field elements (512 bits), which accommodates the ~255-bit group order. The `[Belt; 8]` encoding matches how Hoon nouns serialize large integers as sequences of 64-bit words.
 
 ### PkhSignatureEntry
 

--- a/docs/architecture/tx-engine/13-merkle-trees-and-commitments.md
+++ b/docs/architecture/tx-engine/13-merkle-trees-and-commitments.md
@@ -1,0 +1,306 @@
+# Merkle Trees and Commitment Schemes
+
+## Overview
+
+Nockchain uses Tip5-based Merkle trees for two distinct purposes: (1) **lock trees** — Taproot-style MAST structures that define spending conditions, and (2) **hashable commitment trees** — deterministic hash commitments over structured data (transactions, proofs, blocks). Both share the same underlying Merkle primitives from `hoon/common/ztd/three.hoon`.
+
+## Merkle Tree Types
+
+The authoritative Hoon types from `ztd/three.hoon`:
+
+### merk: Tagged Merkle Tree
+
+```hoon
+++  merk
+  |$  [node]
+  $~  [%leaf *noun-digest:tip5 ~]
+  $%  [%leaf h=noun-digest:tip5 ~]
+      [%tree h=noun-digest:tip5 t=(pair (merk node) (merk node))]
+  ==
+```
+
+A `merk` is a tagged union:
+- `[%leaf h ~]`: a leaf node containing only a hash digest
+- `[%tree h [left right]]`: an internal node containing a hash and two children
+
+Every node carries its hash `h`, which is either the hash of the leaf data or `hash-ten-cell(h.left, h.right)` for internal nodes.
+
+### merk-proof: Inclusion Proof
+
+```hoon
++$  merk-proof  [root=noun-digest:tip5 path=(list noun-digest:tip5)]
+```
+
+A Merkle proof consists of:
+- **root**: the expected root hash (must match the committed root)
+- **path**: sibling hashes from the leaf up to the root, one per level
+
+### merk-heap: Flat Array Representation
+
+```hoon
++$  merk-heap  [h=noun-digest:tip5 m=mary]
+```
+
+A heap-layout Merkle tree stored as a flat `mary` (fixed-stride array). The root hash `h` is stored separately. This representation is used for FRI polynomial commitment Merkle trees where random-access to sibling nodes is needed.
+
+### mee: Untagged Binary Tree
+
+```hoon
+++  mee
+  |$  [node]
+  $~  [%leaf *node]
+  $%  [%leaf n=node]
+      [%tree l=(mee node) r=(mee node)]
+  ==
+```
+
+A simpler binary tree without hash annotations, used as an intermediate structure during tree construction (`list-to-balanced-tree`).
+
+## Tree Construction
+
+### list-to-balanced-tree
+
+Converts a flat `mary` (array) into a balanced binary `mee` tree:
+
+```hoon
+++  list-to-balanced-tree
+  |=  lis=mary
+  ^-  [h=@ t=(mee mary)]
+  :-  (xeb len.array.lis)  :: height = ceil(log2(len))
+  |-
+  ?>  !=(0 len.array.lis)
+  =/  len  len.array.lis
+  ?:  =(1 len)  [%leaf ...]
+  ?:  =(2 len)  [%tree [%leaf left] [%leaf right]]
+  :: Split: left gets ceil(len/2), right gets floor(len/2)
+  [%tree $(lis left-half) $(lis right-half)]
+```
+
+For odd-length lists, the left subtree gets one extra element, producing a left-heavy balanced tree.
+
+### build-merk
+
+Converts a `mary` into a full `merk` with hash annotations:
+
+```hoon
+++  build-merk
+  |=  m=mary
+  ^-  (pair @ (merk mary))
+  =/  [h=@ n=(mee mary)]  (list-to-balanced-tree m)
+  :-  h
+  |-
+  ?:  ?=([%leaf *] n)
+    [%leaf (hash-hashable:tip5 (hashable-mary:tip5 n.n)) ~]
+  =/  l=(merk mary)  $(n l.n)
+  =/  r=(merk mary)  $(n r.n)
+  [%tree (hash-ten-cell:tip5 h.l h.r) l r]
+```
+
+1. Build a balanced binary tree from the input array
+2. Hash each leaf via `hash-hashable:tip5`
+3. Hash each internal node as `hash-ten-cell(left.hash, right.hash)`
+4. Return the tree height and annotated Merkle tree
+
+### build-merk-heap
+
+Builds a heap-layout Merkle tree (flat array) for efficient random-access proof generation:
+
+```hoon
+++  build-merk-heap
+  |=  m=mary
+  ^-  [depth=@ heap=merk-heap]
+```
+
+The heap layout stores all nodes in a contiguous array where index 0 is the root, and children of index `i` are at `2i+1` and `2i+2`. This layout is used by the FRI polynomial commitment scheme for efficient Merkle proof construction during STARK proof generation.
+
+## Proof Generation
+
+### prove-hashable-by-index
+
+Generates an inclusion proof for a specific leaf in a hashable tree:
+
+```hoon
+++  prove-hashable-by-index
+  |=  [h=hashable:tip5 idx=@]
+  ^-  [axis=@ proof=merk-proof]
+```
+
+The algorithm:
+1. Count leaves in the left and right subtrees
+2. Recurse into the subtree containing the target index
+3. At each level, record the sibling's hash in the proof path
+4. Convert the leaf position to a Nock axis using `peg`
+5. Return both the axis (for the lock Merkle proof) and the proof path
+
+### build-merk-proof
+
+Generates a proof from a heap-layout Merkle tree:
+
+```hoon
+++  build-merk-proof
+  |=  [merk=merk-heap axis=@]
+  ^-  merk-proof
+  :-  h.merk   :: root hash
+  |-            :: walk from leaf to root collecting siblings
+  ?:  =(0 axis)  ~
+  =/  parent   (div (dec axis) 2)
+  =/  sibling  ?:((mod axis 2) (add axis 1) (sub axis 1))
+  [(snag-as-digest:tip5 m.merk sibling) $(axis parent)]
+```
+
+Starting from the leaf's heap index, it walks up to the root, collecting the sibling hash at each level. The axis-to-heap-index conversion uses `(dec axis)`.
+
+### verify-merk-proof
+
+Verifies a Merkle inclusion proof:
+
+```hoon
+++  verify-merk-proof
+  |=  [leaf=noun-digest:tip5 axis=@ merk-proof]
+  ^-  ?
+  ?:  =(1 axis)  &(=(root leaf) ?=(~ path))
+  ?:  =(2 axis)  &(=(root (hash-ten-cell:tip5 leaf sib)) ?=(~ t.path))
+  ?:  =(3 axis)  &(=(root (hash-ten-cell:tip5 sib leaf)) ?=(~ t.path))
+  :: General case: reconstruct hashes from leaf to root
+  ?:  =((mod axis 2) 0)
+    $(axis (div axis 2), leaf (hash-ten-cell:tip5 leaf sib), path t.path)
+  $(axis (div (dec axis) 2), leaf (hash-ten-cell:tip5 sib leaf), path t.path)
+```
+
+The axis determines sibling ordering at each level:
+- **Even axis** (left child): hash as `(leaf, sibling)`
+- **Odd axis** (right child): hash as `(sibling, leaf)`
+
+This uses Nock's binary tree addressing where left children have even axes and right children have odd axes.
+
+### index-to-axis
+
+Maps a leaf index (0-based) to a Nock tree axis:
+
+```hoon
+++  index-to-axis
+  |=  [h=@ i=@]
+  ^-  axis
+  =/  min  (bex (dec h))  :: 2^(height-1)
+  (add min i)
+```
+
+In a balanced tree of height `h`, the leftmost leaf has axis `2^(h-1)` and leaf `i` has axis `2^(h-1) + i`.
+
+## Hashable Commitment Construction
+
+The `hashable` type is the central abstraction for computing deterministic hash commitments over structured data.
+
+### The Hashable Type
+
+From `ztd/three.hoon`:
+
+```hoon
++$  hashable
+  $%  [%leaf p=@]               :: raw value
+      [%hash p=noun-digest]     :: pre-computed hash
+      [%list p=(list hashable)] :: list of hashables
+  ==
+```
+
+A `hashable` is a tagged tree:
+- `leaf+value`: a raw atom to be hashed
+- `hash+digest`: an already-computed 5-element Tip5 digest (avoids re-hashing)
+- `list+[...]`: a list of sub-hashables, converted to a balanced binary tree for hashing
+
+### hash-hashable: The Universal Commitment Function
+
+`hash-hashable:tip5` traverses a hashable tree, producing a single 5-element Tip5 digest:
+
+- **leaf**: hash the atom via `hash-varlen`
+- **hash**: return the pre-computed digest directly
+- **list**: convert to a balanced binary tree, hash leaves, then hash pairs up to the root via `hash-ten-cell`
+
+This provides a **compositional** hashing interface: complex data structures define their `++hashable` arms that construct hashable trees, and `hash-hashable` traverses them uniformly.
+
+### Transaction Engine Hashable Arms
+
+Each tx-engine type defines a `++hashable` arm that builds its commitment structure:
+
+**Lock Merkle Proof (Full format, post-Bythos):**
+
+```hoon
+:*  leaf+version.form
+    hash+(hash:spend-condition spend-condition.form)
+    leaf+axis.form
+    (hashable-merk-proof merk-proof.form)
+==
+```
+
+This commits to: the proof format version, the spend condition hash, the axis (which branch), and the Merkle path.
+
+**Lock Merkle Proof (Stub format, pre-Bythos):**
+
+```hoon
+:+  hash+(hash:spend-condition spend-condition.form)
+    hash+(from-b58:^hash '6mhCSwJQDvbkbiPAUNjetJtVoo1VLtEhmEYoU4hmdGd6ep1F6ayaV4A')
+  (hashable-merk-proof merk-proof.form)
+```
+
+The stub format replaces the axis with a **hardcoded hash** — a static placeholder. This means the witness hash does not commit to which branch is being executed, a weakness fixed by the full format in Bythos.
+
+**Spend Condition:**
+
+The spend condition hashable includes all lock primitives in the condition list, each contributing their parameters as leaves and hashes.
+
+**Transaction (Spends):**
+
+The transaction ID is computed as `hash-hashable` of the entire spends structure — the map of all inputs being consumed.
+
+## Usage in the Transaction Engine
+
+### Lock Tree (MAST)
+
+The lock tree is the primary use of Merkle trees in the tx-engine:
+
+1. **Construction**: A lock is built as a Merkle tree of spend conditions. Each leaf is a `SpendCondition` (a list of lock primitives). The root hash becomes `Name.first` — the first component of the UTXO identifier.
+
+2. **Proof**: When spending, the `LockMerkleProof` reveals one leaf (the spend condition being exercised) plus the sibling hashes from leaf to root.
+
+3. **Verification**: The validator hashes the revealed spend condition, combines with siblings using the axis to determine ordering, and checks the result equals `Name.first`.
+
+### Transaction IDs
+
+The `TxId` (alias for `Hash`) is computed as `hash-hashable` of the transaction's spends structure, providing a unique, deterministic identifier for each transaction.
+
+### Note Names
+
+A Note's `Name` is `[first=Hash, last=Hash, null=0]` where:
+- `first` = hash of the lock tree root (the spending conditions)
+- `last` = hash of the source (parent transaction or coinbase)
+
+Both components use Tip5 hashing via the hashable commitment machinery.
+
+### Block Commitments
+
+Pages (blocks) commit to their contents via Merkle roots over the included transactions, using the same `build-merk` infrastructure.
+
+### FRI Polynomial Commitments
+
+The STARK proof system uses `build-merk-heap` to commit to polynomial evaluations. The heap layout enables efficient Merkle proof construction for the spot-check queries in the FRI protocol.
+
+## Comparison with Other Blockchain Merkle Trees
+
+| Aspect | Bitcoin | Bitcoin Taproot | Nockchain |
+|---|---|---|---|
+| Hash function | SHA-256d | SHA-256 (tagged) | Tip5 |
+| Transaction Merkle | Binary tree of txids | Same | Hashable tree of spends |
+| Script tree | N/A | MAST of TapScript leaves | Lock tree of SpendConditions |
+| Proof structure | txid + siblings | Control block + script + path | Axis + spend condition + path |
+| UTXO commitment | None (pre-UtreexO) | None | Implicit in z-map root hash |
+| ZK-friendly | No (SHA-256 is expensive in circuits) | No | Yes (Tip5 is native field arithmetic) |
+
+### Nockchain's Merkle Innovation
+
+Nockchain combines two Merkle patterns:
+
+1. **Explicit Merkle trees** (lock trees, FRI commitments): traditional hash trees with sibling proofs, matching Taproot's MAST model
+
+2. **Implicit Merkle structure** (z-map/z-set): the Tip5-ordered treap data structures (zoon) function as hash-committed collections without a separate Merkle tree — the z-map root hash already commits to the entire set's contents and structure
+
+This means the UTXO set itself is a Merkle-like commitment — comparing two UTXO sets reduces to comparing their z-map root hashes. Bitcoin requires a separate accumulator (like Utreexo) to achieve similar properties.

--- a/docs/architecture/tx-engine/14-goldilocks-field-arithmetic.md
+++ b/docs/architecture/tx-engine/14-goldilocks-field-arithmetic.md
@@ -1,0 +1,286 @@
+# Goldilocks Field Arithmetic (ztd one and two)
+
+## Overview
+
+All cryptographic operations in Nockchain — hashing (Tip5), signatures (Cheetah/Schnorr), Merkle trees, STARK proofs — operate over the **Goldilocks prime field**: p = 2^64 − 2^32 + 1 = 18,446,744,069,414,584,321.
+
+The foundational arithmetic is defined in two Hoon files:
+- `hoon/common/ztd/one.hoon` (~1390 lines): base field types, operations, array utilities
+- `hoon/common/ztd/two.hoon` (~1716 lines): extension field, polynomial arithmetic, NTT/FFT
+
+With Rust mirrors in `crates/nockchain-math/src/belt.rs`, `felt.rs`, `bpoly.rs`, and `poly.rs`.
+
+## Why Goldilocks?
+
+The choice of p = 2^64 − 2^32 + 1 is driven by four properties:
+
+1. **Fits in a single `u64`**: Despite being a 64-bit prime, it's slightly less than 2^64, so every field element is a native machine word. No multi-limb arithmetic needed for base field operations.
+
+2. **Efficient modular reduction**: The special form p = 2^64 − 2^32 + 1 means modular reduction can use shifts and additions instead of general-purpose division. For a product `a * b mod p`, the 128-bit result can be reduced via the identity `2^64 ≡ 2^32 − 1 (mod p)`.
+
+3. **Large power-of-two subgroup**: The multiplicative group has order p − 1 = 2^64 − 2^32 = 2^32 · (2^32 − 1), containing a subgroup of order 2^32. This enables efficient NTT (Number Theoretic Transform) / FFT for polynomial operations — critical for STARK proof generation.
+
+4. **Ecosystem adoption**: The same field is used by Plonky2 (Polygon), Polygon Miden, and other ZK systems, enabling shared tooling and research.
+
+## ztd/one.hoon: Base Field Types and Operations
+
+### Core Types
+
+```hoon
++$  belt  @                     :: Base field element in [0, p)
++$  felt  @ux                   :: Extension field element (packed atom)
++$  melt  @                     :: Montgomery-space element
++$  bpoly  [len=@ dat=@ux]     :: Base field polynomial
++$  fpoly  [len=@ dat=@ux]     :: Extension field polynomial
++$  poly   (list @)             :: Coefficient list polynomial
++$  array  [len=@ dat=@ux]     :: Fixed-stride u64 array
++$  mary   [step=@ =array]     :: Multi-stride array (step = element width in u64 words)
+```
+
+**Belt** is the fundamental type — a single Goldilocks field element stored as a `u64` atom. All arithmetic ensures results stay in `[0, p)`.
+
+**Felt** is a cubic extension field element — three `belt` values packed into a single atom with a high-bit marker. The extension is Fp[x]/(x³ − x − 1), so each felt represents `a₀ + a₁x + a₂x²` where the aᵢ are belts.
+
+**Melt** is a belt in Montgomery representation (multiplied by R = 2^64 mod p), used for efficient repeated multiplication inside Tip5.
+
+**Mary** is a strided array — a contiguous block of `u64` words where each element occupies `step` words. Used for polynomials, execution traces, and Merkle tree heaps.
+
+### Base Field Operations
+
+```hoon
+++  badd   :: a + b mod p
+++  bneg   :: p - a (additive inverse)
+++  bsub   :: a - b mod p
+++  bmul   :: a * b mod p (128-bit intermediate, then reduce)
+++  bpow   :: a^n mod p (repeated squaring)
+++  binv   :: a^(-1) mod p (Fermat: a^(p-2))
+++  ordered-root  :: primitive root of unity of given order
+```
+
+Rust mirror (`crates/nockchain-math/src/belt.rs`):
+
+```rust
+pub const PRIME: u64 = 18446744069414584321;
+
+pub struct Belt(pub u64);
+
+impl Add for Belt { ... }   // badd
+impl Sub for Belt { ... }   // bsub
+impl Mul for Belt { ... }   // bmul (via u128 intermediate)
+impl Neg for Belt { ... }   // bneg
+impl Belt {
+    pub fn inv(&self) -> Belt { ... }  // binv
+    pub fn pow(&self, exp: u64) -> Belt { ... }  // bpow
+}
+```
+
+The Rust `Belt` type implements standard Rust operator traits, making field arithmetic look like natural integer arithmetic: `a + b`, `a * b`, `-a`.
+
+### Montgomery Arithmetic
+
+For Tip5's permutation (7 rounds of repeated field multiplications), Montgomery multiplication avoids per-operation modular division:
+
+```hoon
+++  montify        :: belt → melt: multiply by R mod p
+++  mont-reduction :: melt → belt: multiply by R^(-1) mod p
+++  montiply       :: a * b * R^(-1) mod p (single operation)
+```
+
+Montgomery multiplication `montiply(a, b)` computes `a · b · R^(-1) mod p` using only shifts and additions (no division), roughly 4× faster than standard modular multiplication for sequences of multiplications.
+
+Rust constants:
+
+```rust
+pub const PRIME: u64 = 18446744069414584321;
+const RP: u128 = 340282366841710300967557013911933812736;  // R·p
+pub const R2: u128 = 18446744065119617025;                  // R² mod p
+pub const H: u64 = 20033703337;                              // Montgomery reduction constant
+pub const ORDER: u64 = 2_u64.pow(32);                       // Order of multiplicative subgroup
+```
+
+### Array Utilities (mary)
+
+The `mary` type and its `ave` core provide array operations central to the STARK proof system:
+
+| Arm | Purpose |
+|---|---|
+| `snag` | Index into array |
+| `scag` | Take first N elements |
+| `slag` | Drop first N elements |
+| `weld` | Concatenate arrays |
+| `flop` | Reverse array |
+| `change-step` | Reinterpret element stride |
+| `snag-as-bpoly` | Extract element as bpoly |
+| `snag-as-fpoly` | Extract element as fpoly |
+| `snag-as-mary` | Extract element as sub-mary |
+
+These operate on packed binary data with stride-based indexing, providing efficient bulk data manipulation for polynomial evaluation tables and execution traces.
+
+### Multivariate Polynomials
+
+ztd/one also defines the `mp-mega` and `mp-graph` types for STARK constraint polynomials:
+
+```hoon
++$  mp-mega  (map bpoly belt)    :: Sparse monomial map
++$  mp-graph                      :: Expression graph
+  $%  [%con a=belt]               :: Constant
+      [%var col=@]                :: Variable (column index)
+      [%rnd t=term]               :: Random challenge
+      [%add a=mp-graph b=mp-graph] :: Addition
+      [%mul a=mp-graph b=mp-graph] :: Multiplication
+      ...
+  ==
+```
+
+The `mp-graph` type represents STARK constraint polynomials as expression trees, preserving semantic structure for efficient evaluation. Variables reference columns in execution trace tables, and random challenges come from the Fiat-Shamir transcript.
+
+### Base58 Encoding
+
+```hoon
+++  en-base58  :: atom → Base58 string
+++  de-base58  :: Base58 string → atom
+```
+
+Used for human-readable encoding of hashes, public keys, and addresses throughout the system.
+
+## ztd/two.hoon: Extension Field and Polynomial Math
+
+ztd/two imports ztd/one and builds the extension field and polynomial infrastructure needed for the STARK proof system.
+
+### Extension Field Fp³
+
+```hoon
+|_  deg=_`@`3  :: Extension degree (default 3)
+```
+
+The extension field is Fp[x]/(x³ − x − 1), configured by the `deg-to-irp` map:
+
+```hoon
+++  deg-to-irp
+  %-  ~(gas by *(map @ bpoly))
+  :~  [1 (init-bpoly ~[0 1])]                          :: x
+      [2 (init-bpoly ~[2 p-1 1])]                      :: x² + (p-1)x + 2
+      [3 (init-bpoly ~[1 p-1 0 1])]                    :: x³ − x − 1 → x³ + (p-1)x + 1
+  ==
+```
+
+The irreducible polynomial is x³ − x − 1 (stored as `[1, p-1, 0, 1]` using the additive inverse of 1 since we're in Fp).
+
+### Extension Field Operations
+
+| Arm | Purpose |
+|---|---|
+| `fadd` | Addition (component-wise mod p) |
+| `fneg` | Negation (component-wise) |
+| `fsub` | Subtraction |
+| `fmul` | Multiplication with reduction by irreducible poly |
+| `finv` | Inversion via extended GCD |
+| `fdiv` | Division (`fmul(a, finv(b))`) |
+| `fpow` | Exponentiation (repeated squaring) |
+| `lift` | Belt → Felt (embed base element) |
+| `drop` | Felt → Belt (project to base element) |
+| `frip` | Felt → list of Belts (decompose) |
+| `frep` | List of Belts → Felt (compose) |
+
+The Rust mirror in `crates/nockchain-math/src/felt.rs` provides equivalent operations. Note that the Cheetah curve uses a *different* extension — Fp^6 = Fp[X]/(X^6 − 7) — implemented directly in `cheetah.rs` rather than through the general felt machinery.
+
+### Polynomial Arithmetic
+
+ztd/two provides full polynomial arithmetic over both base and extension fields:
+
+| Category | Arms |
+|---|---|
+| **Basic** | `fpadd`, `fpsub`, `fpmul`, `fpdiv`, `fpmod`, `fpscal` |
+| **Evaluation** | `fpeval` (evaluate polynomial at a point) |
+| **Interpolation** | `interpolate`, `intercosate` (cosine-domain interpolation) |
+| **NTT/FFT** | `fp-ntt`, `bp-ntt`, `fp-fft`, `fp-ifft` |
+| **Domain** | `zerofier`, `coseword` (evaluation domains) |
+| **GCD** | `fpgcd`, `bpegcd` (extended GCD for inversion) |
+
+### NTT/FFT
+
+The Number Theoretic Transform is the finite-field analogue of FFT:
+
+```hoon
+++  fp-ntt   :: Forward NTT over extension field polynomials
+++  bp-ntt   :: Forward NTT over base field polynomials
+++  fp-fft   :: Forward FFT
+++  fp-ifft  :: Inverse FFT
+```
+
+NTT converts between coefficient and evaluation representations of polynomials in O(n log n) field operations. This is critical for STARK proof generation:
+- Polynomial multiplication via NTT: O(n log n) instead of O(n²)
+- Low-degree extension (LDE): evaluate constraint polynomials on larger domains
+- FRI queries: evaluate committed polynomials at specific points
+
+The Goldilocks field's 2^32-order subgroup enables NTT up to length 2^32, sufficient for practical STARK proof sizes.
+
+### u32 Arithmetic
+
+```hoon
+++  u32-add  :: 32-bit addition with overflow check
+++  u32-sub  :: 32-bit subtraction
+++  u32-mul  :: 32-bit multiplication
+++  u32-dvr  :: 32-bit division with remainder
+```
+
+Used for the Tip5 S-box lookup table addressing, where bytes are manipulated as 32-bit values.
+
+### Bignum Arithmetic
+
+```hoon
+++  chunk   :: Split atom into multi-word representation
+++  merge   :: Combine multi-word back to atom
+++  valid   :: Validate bignum representation
+```
+
+Used for operations that exceed a single field element, such as scalar multiplication on the Cheetah curve.
+
+### Shape Utilities
+
+```hoon
+++  shape
+  ++  grow            :: Expand a Dyck word
+  ++  leaf-sequence   :: Extract leaf atoms from a noun tree
+  ++  num-of-leaves   :: Count leaves in a noun tree
+```
+
+These tree structure utilities are used for noun hashing (extracting the leaf sequence and Dyck word from a noun for Tip5 `hash-noun-varlen`) and for note-data size validation (counting leaves to enforce `max-size` limits).
+
+## Rust Mirror Architecture
+
+| Hoon | Rust File | Key Types/Functions |
+|---|---|---|
+| Belt operations | `crates/nockchain-math/src/belt.rs` | `Belt`, `PRIME`, Add/Sub/Mul/Neg impls, `inv()`, `pow()` |
+| Felt operations | `crates/nockchain-math/src/felt.rs` | `Felt`, Karatsuba multiplication |
+| Polynomial ops | `crates/nockchain-math/src/poly.rs`, `bpoly.rs` | `bpoly_to_vec`, `init_bpoly`, polynomial arithmetic |
+| Mary/array | `crates/nockchain-math/src/structs.rs` | Array manipulation utilities |
+
+The Rust implementations are jets — they accelerate the Hoon computations while maintaining bit-exact compatibility. The Hoon definitions remain authoritative.
+
+## Usage in the Transaction Engine
+
+The field arithmetic from ztd/one and ztd/two underpins every cryptographic operation in the tx-engine:
+
+| Operation | Types Used | Source |
+|---|---|---|
+| Tip5 hashing | Belt (field elements), Melt (Montgomery form) | ztd/one |
+| Z-map/z-set ordering | Belt (hash digest comparison) | ztd/one |
+| Schnorr signatures | Belt (scalars), F6lt (Cheetah point coords) | ztd/one + cheetah.rs |
+| Merkle tree hashing | Belt (Tip5 digests) | ztd/one |
+| Note-data size limits | Shape utilities (num-of-leaves) | ztd/two |
+| STARK proofs | Felt, Bpoly, Fpoly, Mary, NTT/FFT | ztd/one + ztd/two |
+| Transaction ID computation | Belt (hash output) | ztd/one |
+| Base58 addresses | Belt → Base58 encoding | ztd/one |
+
+## Comparison with Other Blockchain Fields
+
+| Blockchain | Field | Size | Special Properties |
+|---|---|---|---|
+| Bitcoin | Binary (SHA-256) | 256-bit | No algebraic structure |
+| Ethereum | Binary (Keccak) | 256-bit | No algebraic structure |
+| Mina (Poseidon) | Pasta curves (Fp, Fq) | 255-bit | SNARK-friendly |
+| Polygon Miden | Goldilocks (2^64 − 2^32 + 1) | 64-bit | Same field as Nockchain |
+| Nockchain | Goldilocks (2^64 − 2^32 + 1) | 64-bit | STARK-friendly, native u64 |
+
+The Goldilocks field is becoming a standard in the ZK space. Its 64-bit size trades off raw security margin (compensated by the cubic extension for signatures and the sponge capacity for hashing) for dramatic improvements in computational efficiency — every field operation is a single machine instruction rather than multi-limb arithmetic.

--- a/docs/architecture/tx-engine/15-ztd-stark-proof-stack.md
+++ b/docs/architecture/tx-engine/15-ztd-stark-proof-stack.md
@@ -1,0 +1,311 @@
+# The ZTD STARK Proof Stack (ztd three through eight)
+
+## Overview
+
+Nockchain's transaction engine sits atop a complete STARK (Scalable Transparent ARgument of Knowledge) proof system, implemented across eight Hoon libraries (`ztd/one.hoon` through `ztd/eight.hoon`). This stack provides:
+- The hash function (Tip5) used for all tx-engine commitments
+- The Merkle tree primitives used for lock proofs
+- The proof-of-work mechanism (proving correct execution of Nock programs)
+
+The tx-engine accesses the full stack via `zeke.hoon` (a 1-line re-export of `ztd/eight.hoon`), which transitively imports the entire hierarchy.
+
+## Import Hierarchy
+
+```
+ztd/one.hoon (~1390 lines)
+  Belt, Felt, Melt, Bpoly, Fpoly, Mary, Base field arithmetic
+    │
+    ▼
+ztd/two.hoon (~1716 lines)
+  Extension field, Polynomial arithmetic, NTT/FFT, Interpolation
+    │
+    ▼
+ztd/three.hoon (~2091 lines)
+  Tip5 hash, Merkle trees, Proof types, u32 arithmetic, Bignum, Cheetah curve
+    │
+    ▼
+ztd/four.hoon (~258 lines)
+  Proof stream, Fiat-Shamir, Constraint utilities
+    │
+    ▼
+ztd/five.hoon (~1026 lines)
+  FRI polynomial commitment scheme
+    │
+    ▼
+ztd/six.hoon (~309 lines)
+  Table/jute interface for execution traces
+    │
+    ▼
+ztd/seven.hoon (~963 lines)
+  STARK constraint organization, Quotient computation
+    │
+    ▼
+ztd/eight.hoon (~1034 lines)
+  STARK prover engine, Proof-of-work integration
+    │
+    ▼
+zeke.hoon (1 line)
+  Re-exports ztd/eight → imported by zoon.hoon and tx-engine
+```
+
+Total: ~8,787 lines of Hoon implementing a complete STARK proof system from field arithmetic through proof generation.
+
+## ztd/three.hoon: Cryptographic Primitives
+
+Covered in detail in files 11 (Tip5) and 13 (Merkle trees). Key components:
+
+| Component | Purpose | Used by tx-engine? |
+|---|---|---|
+| Tip5 hash | Sponge hash over Goldilocks | Yes — all commitments |
+| Merkle trees (merk) | Binary hash trees with proofs | Yes — lock proofs, block commitments |
+| Hashable | Tagged commitment trees | Yes — transaction IDs, lock hashes |
+| Tog (PRNG) | Deterministic randomness from sponge | Indirectly — via STARK proofs |
+| u32 arithmetic | 32-bit operations for S-box | Yes — Tip5 internals |
+| Bignum (chunk/merge) | Multi-word integers | Yes — Cheetah scalar operations |
+| Cheetah curve types | Elliptic curve point operations | Yes — Schnorr signatures |
+
+## ztd/four.hoon: Proof Stream and Fiat-Shamir
+
+~258 lines providing the interactive-to-non-interactive transformation for STARK proofs.
+
+### Proof Stream
+
+The proof stream is the central abstraction for building non-interactive proofs via the Fiat-Shamir heuristic:
+
+```hoon
+++  proof-stream
+  |_  [objects=(list proof-data) read-index=@ sponge=tip5-state]
+```
+
+| Arm | Purpose |
+|---|---|
+| `push` | Append a proof object to the stream |
+| `pull` | Read the next proof object from the stream |
+| `prover-fiat-shamir` | Generate verifier challenges from prover's transcript |
+| `verifier-fiat-shamir` | Regenerate challenges from received proof objects |
+
+The Fiat-Shamir transform converts an interactive proof protocol (where the verifier sends random challenges) into a non-interactive one (where challenges are derived by hashing the transcript). The `sponge` field is a Tip5 sponge state that absorbs proof objects and squeezes out challenges.
+
+### Proof Data Types
+
+```hoon
++$  proof-data
+  $%  [%tip5-digest noun-digest:tip5]
+      [%merk-proof merk-proof:merkle]
+      [%merk-data merk-data:merkle]
+      [%codeword-data codeword-data]
+      [%fp-codeword-data fp-codeword-data]
+      [%deep-point deep-point]
+      [%fp-deep-point fp-deep-point]
+  ==
+```
+
+Each variant carries a different type of proof artifact — hash digests, Merkle proofs, polynomial evaluation data, and deep composition points.
+
+### Constraint Utilities
+
+```hoon
++$  mp-pelt  [a=belt b=belt c=belt]  :: Triple belt for constraint evaluation
+++  mpadd-pelt  :: Add two pelts
+++  mpmul-pelt  :: Multiply two pelts
+++  mpsub-pelt  :: Subtract two pelts
+```
+
+The `mp-pelt` type represents constraint polynomial evaluations as triples, used for efficient batch evaluation of STARK AIR constraints.
+
+## ztd/five.hoon: FRI Commitment Scheme
+
+~1026 lines implementing the **Fast Reed-Solomon Interactive Oracle Proof of Proximity (FRI)** — the polynomial commitment scheme at the heart of STARKs.
+
+### FRI Configuration
+
+```hoon
++$  fri-input
+  $:  offset=belt
+      omega=belt           :: Root of unity for evaluation domain
+      domain-length=@      :: Size of evaluation domain
+      expansion-factor=@   :: LDE blow-up factor
+      num-spot-checks=@    :: Number of random queries
+      folding-degree=@     :: Degree reduction per FRI round
+  ==
+```
+
+### FRI Engine
+
+```hoon
+++  fri-door
+  |_  fri-input
+  ++  prove   :: Generate FRI proof
+  ++  verify  :: Verify FRI proof
+```
+
+FRI proves that a committed polynomial has degree at most `d` by:
+1. Committing to polynomial evaluations via Merkle trees
+2. Iteratively folding the polynomial (reducing degree by `folding-degree` per round)
+3. Providing spot-check openings with Merkle proofs at random positions
+4. The verifier checks that folding was done correctly at the queried positions
+
+The Merkle trees used for FRI commitments are the same `merk-heap` type from ztd/three, using Tip5 for all hash operations.
+
+## ztd/six.hoon: Table/Jute Interface
+
+~309 lines defining the interface between execution traces and STARK constraints.
+
+### Jute (Junction Table) Types
+
+```hoon
++$  jute-data   :: Data for a single junction table column
++$  jute-funcs  :: Functions for a junction table column
++$  row         :: Single row of execution trace
++$  matrix      :: Multiple rows
++$  table       :: Named execution trace table
++$  table-mary  :: Table stored as mary (strided array)
+```
+
+A "jute" (junction table entry) represents a single column in the execution trace — the record of a Nock program's computation step-by-step. Each column captures one aspect of the computation (program counter, stack pointer, memory contents, etc.).
+
+The STARK proof demonstrates that the execution trace satisfies all transition constraints (each step follows from the previous according to the Nock evaluation rules) and boundary constraints (the input/output match the claimed values).
+
+## ztd/seven.hoon: STARK Core
+
+~963 lines implementing the core STARK constraint machinery.
+
+### Constraint Degrees
+
+```hoon
++$  constraint-degrees
+  $:  boundary=(list @)
+      row=(list @)
+      transition=(list @)
+      terminal=(list @)
+      extra=(list @)
+  ==
+```
+
+Constraint types:
+- **Boundary**: Fix values at specific rows (e.g., initial state, final output)
+- **Row**: Must hold at every row independently
+- **Transition**: Relate consecutive rows (e.g., `state[i+1] = f(state[i])`)
+- **Terminal**: Fix values at the last row
+- **Extra**: Additional constraints for cross-table lookups
+
+### STARK Configuration
+
+```hoon
++$  stark-config
++$  stark-input
+```
+
+Configuration includes: the number of trace columns, constraint degrees, FRI parameters, and the evaluation domain specification.
+
+### Quotient Computation
+
+```hoon
+++  quot  :: Quotient polynomial computation
+```
+
+The quotient polynomial is the key object in STARK proofs. Given:
+- An execution trace polynomial `T(x)`
+- A set of constraint polynomials `C_i(T(x))`
+- A zerofier polynomial `Z(x)` that vanishes on the trace domain
+
+The quotient `Q(x) = C(T(x)) / Z(x)` exists as a polynomial (i.e., the division is exact) if and only if the constraints are satisfied. The STARK proof commits to `Q(x)` and uses FRI to prove its degree is bounded.
+
+## ztd/eight.hoon: STARK Prover Engine
+
+~1034 lines implementing the full STARK prover, including proof-of-work integration.
+
+### STARK Engine
+
+```hoon
+++  stark-engine
+++  stark-engine-jet-hook
+```
+
+The prover follows this pipeline:
+
+1. **Trace generation**: Execute the Nock program, recording the execution trace
+2. **Low-Degree Extension (LDE)**: Extend trace polynomials to a larger evaluation domain
+3. **Constraint evaluation**: Evaluate all constraint polynomials over the extended domain
+4. **Quotient computation**: Divide constraint evaluations by the zerofier
+5. **Composition**: Combine quotient columns using random challenges (Fiat-Shamir)
+6. **Deep composition**: Evaluate at a random out-of-domain point
+7. **FRI**: Prove the composed polynomial has the expected degree
+8. **Serialize**: Package all commitments and openings into a proof stream
+
+### Proof-of-Work Integration
+
+```hoon
+++  puzzle-nock  :: Generate a proof-of-work puzzle
+++  powork       :: Verify proof-of-work
+++  gen-tree     :: Generate the execution tree for proof
+++  fock         :: Proof caching mechanism
+```
+
+Nockchain's proof-of-work is unique: instead of finding a hash preimage (like Bitcoin), miners must generate a valid STARK proof that a given Nock computation was executed correctly. This means:
+
+- The "puzzle" is a Nock program to execute
+- The "solution" is a STARK proof of correct execution
+- Verification is efficient (polylogarithmic in computation size)
+- Mining requires actually performing computation, not just hashing
+
+The `fock` arm provides proof caching — previously generated proofs can be stored and reused, avoiding redundant work for repeated computations.
+
+## Connection to the Transaction Engine
+
+The tx-engine does not directly use the STARK prover for transaction validation. Instead, the connection is:
+
+### Direct Usage
+
+| ZTD Component | Tx-Engine Usage |
+|---|---|
+| ztd/one (Belt, Melt) | Field arithmetic for all hash/signature operations |
+| ztd/two (Shape, Felt) | Note-data size limits, Cheetah field operations |
+| ztd/three (Tip5) | Transaction IDs, lock roots, Merkle proofs, z-map ordering |
+| ztd/three (Merkle) | Lock Merkle proofs, block commitments |
+
+### Indirect Usage
+
+| ZTD Component | Role |
+|---|---|
+| ztd/four–eight (STARK prover) | Proof-of-work for block mining |
+
+The STARK stack generates the proofs that secure the blockchain itself. When a miner produces a block, they must include a STARK proof that the block's Nock computation was executed correctly. The tx-engine's validated transactions are *inputs* to this computation.
+
+### The Import Chain
+
+```
+tx-engine-1.hoon
+  └─ imports zoon.hoon (z-map/z-set for all collections)
+       └─ imports zeke.hoon
+            └─ re-exports ztd/eight.hoon
+                 └─ transitively imports one through seven
+```
+
+This means the tx-engine has access to the *entire* ZTD stack through its dependency chain. While it primarily uses ztd/one through ztd/three for field arithmetic, hashing, and Merkle trees, the full stack is available.
+
+## Also: zose.hoon — Vendored Crypto Utilities
+
+`hoon/common/zose.hoon` (~3684 lines) is a vendored copy of Urbit's `zuse` crypto library, providing:
+
+| Component | Purpose |
+|---|---|
+| `base58` | Base58 encoding/decoding (Bitcoin-style) |
+| `fu` | Modular arithmetic (generic prime field operations) |
+| `curt` | Curve25519 scalar multiplication |
+| `ga` | GF polynomial arithmetic (Galois fields) |
+
+These utilities support non-consensus cryptographic operations like key derivation and Ed25519 signatures.
+
+## Comparison with Other Blockchain Proof Systems
+
+| Aspect | Bitcoin | Ethereum | Nockchain |
+|---|---|---|---|
+| Proof of work | SHA-256d hashcash | Ethash (deprecated) → PoS | STARK proof of Nock execution |
+| Verification | Check hash < target | N/A (PoS) | Verify STARK proof |
+| ZK proofs | None (native) | L2 rollups (external) | Native STARK prover (ztd stack) |
+| Hash function | SHA-256 (binary) | Keccak-256 (binary) | Tip5 (algebraic, ZK-friendly) |
+| Signature scheme | ECDSA/Schnorr over secp256k1 | ECDSA over secp256k1 | Schnorr over Cheetah (STARK-friendly) |
+| Field arithmetic | None (no algebraic structure) | None (no algebraic structure) | Goldilocks field (ztd/one–two) |
+
+The distinguishing feature of Nockchain's architecture is the **deep integration** between the proof system and the transaction engine. They share the same field (Goldilocks), the same hash function (Tip5), and the same data structures (z-maps, Merkle trees). This co-design means that verifying transactions *inside* a STARK proof is efficient — no impedance mismatch between the consensus layer's cryptographic primitives and the proof system's arithmetic.


### PR DESCRIPTION
Analyzes the Nockchain transaction engine architecture across 10 sections,
covering UTXO model, SegWit-inspired witness separation, Taproot-inspired
lock Merkle proofs (MAST), eUTXO note data, lock primitives, fee structure,
validation pipeline, protocol evolution, and noun encoding. Hoon is
correctly framed as the source of truth for all type definitions and
consensus logic, with Rust types serving as serialization mirrors.

https://claude.ai/code/session_01FUHJ8VEE1xd6BUTVruZcxm