### PR TITLE
nockup: make the package registry configurable (--registry / NOCKUP_REGISTRY)

### DIFF
--- a/crates/nockup/src/cli.rs
+++ b/crates/nockup/src/cli.rs
@@ -7,6 +7,11 @@ use clap::{Parser, Subcommand};
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
+
+    /// Registry to resolve packages from: a URL or a local file path.
+    /// Overrides the default (sigilante/typhoon) and the NOCKUP_REGISTRY env var.
+    #[arg(long, global = true, value_name = "URL_OR_PATH")]
+    pub registry: Option<String>,
 }
 
 #[derive(Subcommand)]

--- a/crates/nockup/src/main.rs
+++ b/crates/nockup/src/main.rs
@@ -9,6 +9,12 @@ use nockup::{commands, version};
 async fn main() {
     let cli = Cli::parse();
 
+    // Optional registry override (URL or local path); falls back to the
+    // NOCKUP_REGISTRY env var and then the built-in default when unset.
+    if let Some(source) = cli.registry.as_deref() {
+        nockup::resolver::registry::set_registry_source(source);
+    }
+
     let result = match cli.command {
         // Hierarchical commands
         Some(Commands::Project(cmd)) => commands::build::run(cmd).await,

--- a/crates/nockup/src/resolver/registry.rs
+++ b/crates/nockup/src/resolver/registry.rs
@@ -1,5 +1,7 @@
-/// Package registry system using typhoon registry format
-/// Fetches registry from https://github.com/sigilante/typhoon
+/// Package registry system using typhoon registry format.
+/// Fetches the registry from https://github.com/sigilante/typhoon by default;
+/// override with the `--registry` flag or the `NOCKUP_REGISTRY` env var (a URL
+/// or a local file path).
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -199,17 +201,53 @@ static REGISTRY: Lazy<HashMap<&'static str, RegistryEntry>> = Lazy::new(|| {
 /// Cached online registry
 static ONLINE_REGISTRY: Lazy<RwLock<Option<RegistryToml>>> = Lazy::new(|| RwLock::new(None));
 
-const REGISTRY_URL: &str =
+/// Default registry, used when neither `--registry` nor `$NOCKUP_REGISTRY` is set.
+const DEFAULT_REGISTRY_URL: &str =
     "https://raw.githubusercontent.com/sigilante/typhoon/master/registry.toml";
 
-/// Fetch and parse the online registry (blocking - use spawn_blocking in async context)
-fn fetch_registry_sync() -> Result<RegistryToml> {
-    let response =
-        reqwest::blocking::get(REGISTRY_URL).context("Failed to fetch registry from GitHub")?;
+/// Optional override for the registry source, set once at startup (e.g. from the
+/// `--registry` CLI flag). `None` means fall back to the env var / default.
+static REGISTRY_SOURCE: RwLock<Option<String>> = RwLock::new(None);
 
-    let content = response
-        .text()
-        .context("Failed to read registry response")?;
+/// Set the registry source: a remote URL (`http`/`https`) or a local file path.
+/// Takes precedence over `$NOCKUP_REGISTRY` and the built-in default. Call this
+/// before any package resolution happens.
+pub fn set_registry_source(source: impl Into<String>) {
+    if let Ok(mut guard) = REGISTRY_SOURCE.write() {
+        *guard = Some(source.into());
+    }
+}
+
+/// Resolve the active registry source.
+/// Precedence: explicit override (CLI) > `$NOCKUP_REGISTRY` > built-in default.
+fn registry_source() -> String {
+    if let Ok(guard) = REGISTRY_SOURCE.read() {
+        if let Some(src) = guard.as_ref() {
+            return src.clone();
+        }
+    }
+    match std::env::var("NOCKUP_REGISTRY") {
+        Ok(src) if !src.is_empty() => src,
+        _ => DEFAULT_REGISTRY_URL.to_string(),
+    }
+}
+
+/// Fetch and parse the registry (blocking - use spawn_blocking in async context).
+/// The source may be a remote URL or a local file path (an optional `file://`
+/// prefix is accepted), so a registry can be served over HTTP or read from disk.
+fn fetch_registry_sync() -> Result<RegistryToml> {
+    let source = registry_source();
+
+    let content = if source.starts_with("http://") || source.starts_with("https://") {
+        reqwest::blocking::get(source.as_str())
+            .with_context(|| format!("Failed to fetch registry from {source}"))?
+            .text()
+            .context("Failed to read registry response")?
+    } else {
+        let path = source.strip_prefix("file://").unwrap_or(&source);
+        std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read registry file '{path}'"))?
+    };
 
     let registry: RegistryToml =
         toml::from_str(&content).context("Failed to parse registry TOML")?;


### PR DESCRIPTION
## Summary

Nockup resolves packages from a single **hardcoded** registry URL
(`sigilante/typhoon` `master`), with no way to point it elsewhere. That means:

- registry changes can't be tested without publishing them to the public
  `master` branch first, and
- a private or local registry can't be used at all.

This PR makes the registry source configurable while leaving the default
behavior completely unchanged.

## Changes

- Add a global `--registry <URL_OR_PATH>` flag and a `NOCKUP_REGISTRY` env var.
- The source may be a **remote URL** (`http`/`https`) or a **local file path**
  (an optional `file://` prefix is accepted), so a registry can be served over
  HTTP or read straight from disk.
- Precedence: `--registry` flag > `NOCKUP_REGISTRY` env var > built-in default
  URL. When neither is set, nothing changes.

All three touched functions are in `crates/nockup`: a new flag in `cli.rs`, a
one-line wiring in `main.rs`, and the source-resolution logic in
`resolver/registry.rs` (the existing `REGISTRY_URL` const becomes
`DEFAULT_REGISTRY_URL`, used as the fallback).

## Behavior

```sh
# unchanged: uses the default sigilante/typhoon registry
nockup project init

# resolve against a local file (great for testing registry edits pre-publish)
nockup --registry ./registry.toml project init

# or an alternate URL / via env var
NOCKUP_REGISTRY=https://example.com/registry.toml nockup project init
```

## Testing

- `cargo check -p nockup` and `cargo build -p nockup` both clean.
- Functional check with a local registry file containing an alias that does **not**
  exist on the public registry: `nockup --registry <local file> project init`
  resolved and installed that alias, confirming the local file (not the network)
  was used. Default runs (no flag) continue to fetch the built-in URL.

## Notes

This is intentionally minimal and additive. One pre-existing behavior is left
as-is: when a registry fetch fails, `lookup()` silently falls back to the small
hardcoded `REGISTRY` map, so a bad `--registry` surfaces as a downstream
resolution error rather than the underlying read error. Happy to tighten that
in a follow-up if desired.
