### PR TITLE
Gate tx re-gossip by submission wire

### DIFF
--- a/hoon/apps/dumbnet/inner.hoon
+++ b/hoon/apps/dumbnet/inner.hoon
@@ -1096,15 +1096,34 @@
       ::
       ::  check if we already have raw-tx
       ?:  (has-raw-tx:con ~(id get:raw-tx:t raw))
-        :: do almost nothing (idempotency), we already have it
-        :: but do tell the runtime we've already seen it
+        ::  we already hold this tx, so we never re-add it to the mempool.
+        ::  whether we re-announce it depends on who told us about it.
+        ::
+        ::  from a peer (%libp2p): stay silent apart from %seen. this is the
+        ::  gossip-loop terminator -- if we re-gossiped every tx a peer sent
+        ::  us that we already had, the tx would bounce between peers forever.
+        ::
+        ::  from the local grpc driver (%grpc): this is an operator
+        ::  re-submission (`nockchain-wallet send-tx`), so re-gossip it. no
+        ::  peer sent it to us, so no loop can form. this is the only way to
+        ::  re-announce a tx the network has since dropped: a non-mining node
+        ::  otherwise never re-gossips a tx it already holds (the excluded-txs
+        ::  and candidate-block re-gossip paths are both mining-only), so
+        ::  without this every resend is a silent no-op and a tx stuck in our
+        ::  mempool can never be revived.
+        =/  re-gossip=?  (local-tx-submission wir)
         =/  log-message
           %^  cat  3
-           'heard-tx: Transaction id already seen: '
+            ?:  re-gossip
+              'heard-tx: Transaction id already seen, re-broadcasting: '
+            'heard-tx: Transaction id already seen: '
           id-b58
         ~>  %slog.[1 log-message]
+        =/  seen=(list effect:dk)
+          [%seen %tx ~(id get:raw-tx:t raw)]~
         :_  k
-        [%seen %tx ~(id get:raw-tx:t raw)]~
+        ?.  re-gossip  seen
+        [[%gossip %0 %heard-tx raw] seen]
       ::
       ::  check if the raw-tx contents are in base field
       ?.  (based:raw-tx:t raw)
@@ -1432,6 +1451,21 @@
       ?.  ?=([%poke %libp2p ver=@ typ=?(%gossip %response) %peer-id id=@ *] pole)
         ~
       (some id.pole)
+    ::
+    ::  +local-tx-submission: did this poke come from the local grpc driver?
+    ::
+    ::    true only for the %grpc wire, which the grpc driver stamps on pokes
+    ::    it makes on behalf of a local client (e.g. `nockchain-wallet
+    ::    send-tx`). a tx gossiped to us by a peer arrives on a %libp2p wire
+    ::    and is never a local submission. used by +heard-tx to decide whether
+    ::    re-hearing a tx we already hold should re-announce it; answering
+    ::    %.y for a peer-sourced wire would create an infinite gossip loop.
+    ++  local-tx-submission
+      ~/  %local-tx-submission
+      |=  wir=wire
+      ^-  ?
+      =/  =(pole)  wir
+      ?=([%poke %grpc ver=@ *] pole)
     ::
     ++  handle-command
       ~/  %handle-command

--- a/hoon/tests/dumb/helpers.hoon
+++ b/hoon/tests/dumb/helpers.hoon
@@ -781,6 +781,25 @@
   =/  =input  *input
   [/poke/sys/0 input(cause cau)]
 ::
+++  build-ovum-on-wire
+  |=  [wir=path cau=cause]
+  ^-  ovum
+  =/  =input  *input
+  [wir input(cause cau)]
+::
+::  the wire the grpc driver stamps on a poke it makes for a local client,
+::  e.g. `nockchain-wallet send-tx` (cf. +create-grpc-wire in the rust
+::  nockapp-grpc crate, which yields source %grpc / version 1). +heard-tx
+::  treats this as an operator submission and will re-gossip a tx it already
+::  holds. cf. +local-tx-submission in apps/dumbnet/inner.hoon.
+++  grpc-wire  `path`/poke/grpc/1
+::
+::  the wire the libp2p driver stamps on a tx a peer gossiped to us (cf.
+::  +Libp2pWire in the rust nockchain-libp2p-io crate: source %libp2p,
+::  version 1, tags [verb %peer-id <base58 peer id>]). +heard-tx must NOT
+::  re-gossip a tx it already holds when it arrives on this wire.
+++  libp2p-gossip-wire  `path`/poke/libp2p/1/gossip/peer-id/peer
+::
 ++  pok
   |=  [cau=cause nockchain=_nockchain]
   =^  effs=(list *)  nockchain
@@ -789,6 +808,16 @@
   ::  the wally desk-hash is type u(@uvI)
   =<  [- +(desk-hash.outer [~ *@uvI])]
   (poke:nockchain *@ (build-ovum cau))
+  [;;((list effect) effs) nockchain]
+::
+::  +pok-on-wire: +pok, but stamping a caller-chosen wire on the ovum, so a
+::  test can exercise the kernel's wire-dependent behaviour (which driver a
+::  poke came from) rather than always speaking on the default %sys wire.
+++  pok-on-wire
+  |=  [wir=path cau=cause nockchain=_nockchain]
+  =^  effs=(list *)  nockchain
+  =<  [- +(desk-hash.outer [~ *@uvI])]
+  (poke:nockchain *@ (build-ovum-on-wire wir cau))
   [;;((list effect) effs) nockchain]
 ::
 ++  init-nockchain

--- a/hoon/tests/dumb/mod/integration/mempool.hoon
+++ b/hoon/tests/dumb/mod/integration/mempool.hoon
@@ -243,4 +243,92 @@
   %+  expect-eq
     !>(%.n)
   !>((~(has-raw-tx k-by:h-med nockchain) tx-id))
+::
+::  re-broadcast gating for a tx we already hold. see +heard-tx and
+::  +local-tx-submission in apps/dumbnet/inner.hoon: re-hearing a tx that is
+::  already in raw-txs never re-adds it to the mempool, but whether we
+::  re-announce it depends on which driver the poke came from.
+::
+::  +setup-v1-spendable-tx: a valid v1 tx spending the coinbase of a 2-block
+::  chain, plus the kernel that chain lives in. same construction as
+::  +test-v1-mempool-accept-valid above, factored out so the re-broadcast
+::  tests below start from a tx the mempool is known to accept.
+++  setup-v1-spendable-tx
+  ^-  [_nockchain:h raw-tx:t]
+  =+  [nockchain genesis]=init-nockchain:h
+  =^  pages  nockchain
+    (add-n-pages-integration:h genesis 2 nockchain)
+  =/  page-v1=page:t  (snag 1 pages)
+  =/  bal  ~(get-cur-balance k-by:h nockchain)
+  =/  coin=nnote:t
+    (get-coinbase-from-balance:v1:h page-v1 bal)
+  =/  pks=(list schnorr-pubkey:t)
+    ~(tap z-in:zoon pubkeys.p:default-keys-1:h)
+  =/  m=@  (lent pks)
+  =/  [root=hash:t sc=spend-condition:v1:t *]
+    (make-coinbase-lock:v1:h m pks)
+  =/  fee=coins:t  0
+  =/  sed=seed:v1:t
+    (make-seed:v1:h root (sub assets.coin fee) (hash:nnote:t coin))
+  =/  seds=seeds:v1:t  (~(put z-in:zoon *seeds:v1:t) sed)
+  =/  sp1=spend-1:v1:t
+    %*  .  *spend-1:v1:t
+      witness  *witness:v1:t
+      seeds    seds
+      fee  fee
+    ==
+  =/  sig-h=hash:t  (sig-hash:spend-1:v1:t sp1)
+  =/  pk=schnorr-pubkey:t  (snag 0 pks)
+  =/  wit=witness:t
+    (make-pkh-witness:v1:h root sc sig-h ~[[s:default-keys-1:h pk]])
+  =/  sp1=spend-1:v1:t  sp1(witness wit)
+  =/  nam=nname:t  ~(name get:nnote:t coin)
+  =/  sps=spends:v1:t  (~(put z-by:zoon *spends:v1:t) nam [%1 sp1])
+  [nockchain (new:raw-tx:v1:t sps)]
+::
+::  an operator re-submitting a tx over grpc (`nockchain-wallet send-tx` on a
+::  tx that is already in our mempool) MUST re-gossip it. this is the only way
+::  to re-announce a tx the rest of the network has dropped -- a non-mining
+::  node never otherwise re-gossips a tx it already holds, so without this the
+::  tx is stuck in our mempool forever and every resend is a silent no-op.
+++  test-v1-mempool-grpc-resend-re-gossips
+  =+  [nockchain raw]=setup-v1-spendable-tx
+  =/  =cause:h  [%fact %0 %heard-tx raw]
+  =/  tx-id=tx-id:t  ~(id get:raw-tx:t raw)
+  ::  first submission: a new tx, so it is accepted and gossiped
+  =^  effs-1=(list effect:h)  nockchain
+    (pok-on-wire:h grpc-wire:h cause nockchain)
+  ::  we now hold it, so the resend takes the already-seen branch
+  ?>  (~(has-raw-tx k-by:h nockchain) tx-id)
+  ::  resend over the same grpc wire: must gossip again
+  =^  effs-2=(list effect:h)  nockchain
+    (pok-on-wire:h grpc-wire:h cause nockchain)
+  %+  expect-eq
+    !>([%.y %.y %.y])
+  !>  :*  (~(has z-in:zoon (filter-heard-tx-effects:h effs-1)) raw)
+          (~(has z-in:zoon (filter-heard-tx-effects:h effs-2)) raw)
+          ::  still in the mempool, and never double-added
+          (~(has-raw-tx k-by:h nockchain) tx-id)
+      ==
+::
+::  a peer re-gossiping a tx we already hold MUST NOT be re-gossiped back out.
+::  this dedup is what terminates gossip loops: if we re-announced every tx a
+::  peer sent us that we already had, it would bounce between peers forever.
+++  test-v1-mempool-peer-resend-does-not-re-gossip
+  =+  [nockchain raw]=setup-v1-spendable-tx
+  =/  =cause:h  [%fact %0 %heard-tx raw]
+  =/  tx-id=tx-id:t  ~(id get:raw-tx:t raw)
+  ::  first time we hear it from a peer: new tx, accepted and gossiped onward
+  =^  effs-1=(list effect:h)  nockchain
+    (pok-on-wire:h libp2p-gossip-wire:h cause nockchain)
+  ?>  (~(has-raw-tx k-by:h nockchain) tx-id)
+  ::  peer sends it again: we must stay silent
+  =^  effs-2=(list effect:h)  nockchain
+    (pok-on-wire:h libp2p-gossip-wire:h cause nockchain)
+  %+  expect-eq
+    !>([%.y %.n %.y])
+  !>  :*  (~(has z-in:zoon (filter-heard-tx-effects:h effs-1)) raw)
+          (~(has z-in:zoon (filter-heard-tx-effects:h effs-2)) raw)
+          (~(has-raw-tx k-by:h nockchain) tx-id)
+      ==
 --


### PR DESCRIPTION
Update `heard-tx` to treat already-seen transactions differently based on wire source: re-broadcast on local `%grpc` resubmissions, but suppress re-gossip for peer `%libp2p` repeats to prevent gossip loops. Added `local-tx-submission` detection in dumbnet, plus test helpers for custom poke wires and new integration tests covering both grpc resend (re-gossips) and peer resend (does not re-gossip) behavior.