### PR TITLE
Fix empty-core parse rejection and DIRECT_MAX axis panic

### DIFF
--- a/crates/hatch/src/utils.rs
+++ b/crates/hatch/src/utils.rs
@@ -11780,7 +11780,12 @@ pub fn hoon_to_noun(slab: &mut NounSlab, hoon: &Hoon) -> Noun {
             T(slab, &[p, q])
         }
         ZapZap => T(slab, &[D(tas!(b"zpzp")), D(0)]),
-        Axis(a) => T(slab, &[D(0), D(*a)]),
+        Axis(a) => {
+            // Compiler-synthesized axes (e.g. lowering ^~ bakes) can exceed
+            // DIRECT_MAX; D() panics on those.
+            let a_noun = Atom::new(slab, *a).as_noun();
+            T(slab, &[D(0), a_noun])
+        }
         Base(bt) => {
             let bt_noun = basetype_to_noun(slab, bt);
             T(slab, &[D(tas!(b"base")), bt_noun])
@@ -13061,7 +13066,11 @@ fn limb_to_noun(slab: &mut NounSlab, limb: &Limb) -> Noun {
     match limb {
         Limb::Term(s) => term_to_noun(slab, s),
 
-        Limb::Axis(n) => T(slab, &[D(0), D(*n)]),
+        Limb::Axis(n) => {
+            // Same DIRECT_MAX hazard as Hoon::Axis in hoon_to_noun.
+            let n_noun = Atom::new(slab, *n).as_noun();
+            T(slab, &[D(0), n_noun])
+        }
 
         Limb::Parent(n, opt) => {
             let opt_noun = match opt {

--- a/crates/hatch/src/utils.rs
+++ b/crates/hatch/src/utils.rs
@@ -4652,9 +4652,10 @@ pub fn chapters<'src>(
             .collect::<Vec<_>>(),
     );
 
+    // Zero chapters is legal: `|%  --` is a valid empty core (hoon.hoon's
+    // wisp accepts an empty battery, and every battery rune shares it).
     chapter
         .repeated()
-        .at_least(1)
         .collect::<Vec<_>>()
         .then_ignore(just("--"))
         .map(
@@ -15301,6 +15302,28 @@ mod tests {
             matches!(spec.as_ref(), Spec::Gist(_, _)),
             "postfix doc should decorate the named sample spec"
         );
+    }
+
+    #[test]
+    fn empty_core_battery_parses() {
+        let src = "|%\n--\n";
+        let linemap = Arc::new(LineMap::new_with_docs(src, true));
+        let parsed = crate::native_parser(
+            vec!["test".into(), "empty-core.hoon".into()],
+            false,
+            linemap,
+        )
+        .parse(src)
+        .into_result()
+        .expect("|%  -- is a valid empty core");
+
+        let Hoon::TisSig(items) = parsed else {
+            panic!("expected top-level TisSig");
+        };
+        let [Hoon::BarCen(None, tomes)] = items.as_slice() else {
+            panic!("expected one |% expression");
+        };
+        assert!(tomes.is_empty(), "empty battery should have no tomes");
     }
 
     #[test]

--- a/crates/honk/src/native/ut/test.rs
+++ b/crates/honk/src/native/ut/test.rs
@@ -2865,3 +2865,22 @@ fn limb_axis_above_direct_max_does_not_panic() {
     let n = hoon_to_noun(&mut slab, &Hoon::Wing(vec![Limb::Axis(big)]));
     assert!(n.is_cell(), "limb axis node should be a cell");
 }
+
+// Bug 1 from the downstream honk report: `|%  --` (an empty battery) is
+// valid Hoon; hoonc compiles it to [[1 0] 0 1].
+#[test]
+fn empty_core_battery_mints() {
+    let mut slab = NounSlab::new();
+    let noun_ty = ty_noun(&mut slab);
+    let mut ut = Ut::new(&mut slab);
+    let (_ty, formula) = ut
+        .mint_noun(noun_ty, noun_ty, &Hoon::BarCen(None, HashMap::new()))
+        .expect("empty |% core should mint");
+    let battery = T(&mut slab, &[D(1), D(0)]);
+    let payload = T(&mut slab, &[D(0), D(1)]);
+    let expected = T(&mut slab, &[battery, payload]);
+    assert!(
+        noun_eq(formula, expected, &slab.noun_space()).expect("noun_eq"),
+        "empty core should compile to [[1 0] 0 1]"
+    );
+}

--- a/crates/honk/src/native/ut/test.rs
+++ b/crates/honk/src/native/ut/test.rs
@@ -2846,3 +2846,22 @@ fn wet_gate_function_sample_mint_deterministic() {
         "wet-gate mint must be deterministic run-to-run (fresh Context per compile)"
     );
 }
+
+// Bug 2 from the downstream honk report: hoon_to_noun builds axis nodes with
+// the panicking direct-atom constructor D(), so any axis > DIRECT_MAX aborts
+// the compile instead of allocating an indirect atom.
+#[test]
+fn hoon_to_noun_axis_above_direct_max_does_not_panic() {
+    let mut slab = NounSlab::new();
+    let big = nockvm::noun::DIRECT_MAX + 1; // 2^63
+    let n = hoon_to_noun(&mut slab, &Hoon::Axis(big));
+    assert!(n.is_cell(), "axis node should be the cell [0 axis]");
+}
+
+#[test]
+fn limb_axis_above_direct_max_does_not_panic() {
+    let mut slab = NounSlab::new();
+    let big = nockvm::noun::DIRECT_MAX + 1; // 2^63
+    let n = hoon_to_noun(&mut slab, &Hoon::Wing(vec![Limb::Axis(big)]));
+    assert!(n.is_cell(), "limb axis node should be a cell");
+}


### PR DESCRIPTION
Fixes the two bugs still open from the report sobchek filed against `31b8a015`, on top of the import-scanner fix in `d7c39611`. sobchek used Fable (Anthropic's Claude) to assess the patched branch and prepare the fixes in this PR; the findings below are from that assessment.

Closing the loop on the branch itself: the `d7c39611` import fix verified clean — confirmed fixed, and output-neutral (byte-identical jams old-vs-new) on `outer`, `wallet`, and `hoonc` kernel compiles.

## Bug 1 — parser rejects an empty core `|%  --`

`chapters()` in `crates/hatch/src/utils.rs` required at least one chapter, and each chapter separately requires at least one arm, so an empty battery could never parse:

```
native hoon compile failed: parse error: native parser failed:
  found '-' expected Comments, Space or NewLine, Chapter Label +|, Arm ++, or Arm +$
```

`|%  --` is valid Hoon (hoon.hoon's `wisp` accepts an empty battery) and hoonc compiles it.

**Fix:** drop the `.at_least(1)` on the chapter repetition. Every battery rune (`|%`, `|_`, `|@`, `|^`) routes through the shared `chapters()` — the same structure as the shared `wisp` upstream — so they all get the same behavior. The downstream mint path already handled an empty battery (`build_tomes_battery_from_maps` returns `0` for an empty tomes map); only the parser refused.

**Scope check:** a label-only chapter (`|%  +|  %chap  --`) is rejected by hoonc (`syntax error`) and remains rejected by patched honk — the relaxation admits exactly what hoonc admits, no more.

**Tests:**
- hatch `empty_core_battery_parses` — `|%  --` parses to `BarCen` with zero tomes.
- honk `empty_core_battery_mints` — an empty `|%` mints to the canonical `[[1 0] 0 1]`.

**Confirmed against the code that originally hit this.** The real-world trigger lives in vesl, a downstream project whose Hoon kernels build against this tree (https://github.com/zkvesl/vesl-core): a pure re-export library whose entire body is an import line followed by `|%  --`. Compiling the kernel that imports that library: parse error at `d7c39611`, compiles with this branch. Sibling kernels that never hit the bug (up to an 18 MB jam) compile byte-identically under both binaries.

## Bug 2 — `DIRECT_MAX` panic in `hoon_to_noun` / `limb_to_noun`

Both axis-node constructors in `crates/hatch/src/utils.rs` built `[0 axis]` with the panicking direct-atom constructor `D()`:

```rust
Axis(a) => T(slab, &[D(0), D(*a)]),          // hoon_to_noun
Limb::Axis(n) => T(slab, &[D(0), D(*n)]),    // limb_to_noun
```

so any axis above `2^63-1` aborts the compile:

```
thread '...' panicked at crates/nockvm/rust/nockvm/src/noun.rs:1168:13:
Number is greater than DIRECT_MAX
```

**Fix:** route both arms through nockvm's `Atom::new`, which picks direct vs indirect by value. For axes ≤ `DIRECT_MAX` the emitted noun is bit-identical to before, so previously-succeeding compiles cannot change.

**Tests:** `hoon_to_noun_axis_above_direct_max_does_not_panic`, `limb_axis_above_direct_max_does_not_panic` — both panic at `d7c39611`, both pass with the fix. The `^~`-heavy downstream code that originally triggered the panic (compiler-synthesized axes while lowering baked verifier tables) has since been deleted on the downstream side, so these unit tests are the canonical regression — the offending axis is generated by the compiler, never written in source.

## Output-neutrality

Same discipline used to verify `d7c39611`: production kernels compiled with the patched and unpatched honk from the same worktree with identical relative paths, jams compared byte-for-byte.

| kernel | patched vs `d7c39611` |
| --- | --- |
| `hoon/apps/dumbnet/outer.hoon` | byte-identical (sha256 `0aca92b5…`) |
| `hoon/apps/wallet/wallet.hoon` | byte-identical |
| `hoon/apps/hoonc/hoonc.hoon` | byte-identical |
| three downstream vesl kernels (unaffected by bug 1) | byte-identical |

`cargo test -p honk` (132 passed) and `cargo test -p hatch` (271 passed) are green.

## Small suggestion

Orthogonal to this PR: the shipped `comments_do_not_terminate_leading_import_block` test covers only `::` comments, but the old condition also dropped imports after a bare **blank line**. A blank-line variant of that test would keep a future refactor from reintroducing half the bug.
