### PR TITLE
nockchain-wallet: allow configuring the private gRPC client's host

### DIFF
--- a/crates/nockchain-wallet/src/connection.rs
+++ b/crates/nockchain-wallet/src/connection.rs
@@ -19,6 +19,10 @@ pub(crate) struct ConnectionCli {
     #[arg(long, default_value_t = 5555)]
     pub private_grpc_server_port: u16,
 
+    /// Host/IP at which listener connects to private grpc server
+    #[arg(long, default_value = "127.0.0.1")]
+    pub private_grpc_server_host: String,
+
     /// Address of the public server (host[:port] or URI)
     #[arg(long, value_parser = GrpcEndpoint::parse, default_value = "23.252.122.18:5556", global = true)]
     pub public_grpc_server_addr: GrpcEndpoint,
@@ -31,7 +35,10 @@ impl ConnectionCli {
                 endpoint: self.public_grpc_server_addr.to_string(),
             },
             ClientType::Private => GrpcTarget::Private {
-                endpoint: format!("http://127.0.0.1:{}", self.private_grpc_server_port),
+                endpoint: format!(
+                    "http://{}:{}",
+                    self.private_grpc_server_host, self.private_grpc_server_port
+                ),
             },
         }
     }


### PR DESCRIPTION
`--client private` only ever targeted `127.0.0.1` - the port was configurable (`--private-grpc-server-port`) but the host was hardcoded, so the wallet could never reach a private gRPC endpoint outside its own network namespace (a different container by Docker DNS name, a host-mapped address, etc). Adds `--private-grpc-server-host`, defaulting to `127.0.0.1` so existing usage is unaffected.