### PR TITLE
feat(ai-pow-miner): add production Pearl V3 CUDA mining

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.env
+.DS_Store
+**/target
+bazel-*
+.data.*
+.fakenet-ai-pow-data
+nock_fake
+nock_fake_tandem
+pearl
+*.pdf
+*.jam

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,16 @@
 .git
 .env
 .DS_Store
+target
 **/target
+**/target/**
 bazel-*
 .data.*
 .fakenet-ai-pow-data
 nock_fake
 nock_fake_tandem
 pearl
+assets
+hoon
 *.pdf
 *.jam

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "nockvm_macros",
  "num_cpus",
  "once_cell",
+ "rayon",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/ai-pow-miner-cuda/Cargo.toml
+++ b/crates/ai-pow-miner-cuda/Cargo.toml
@@ -21,10 +21,3 @@ clap = { version = "4.6.1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
 tokio-util = "0.7"
 tracing = "0.1"
-
-# CUDA 12.x is required by cuda-bindings. Pin every public cuda-oxide package
-# to one source revision so host and device ABI contracts cannot drift.
-cuda-device = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "0810ba95ff9dcf1ca379b779d3ebe33a8899b15d" }
-cuda-host = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "0810ba95ff9dcf1ca379b779d3ebe33a8899b15d" }
-cuda-core = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "0810ba95ff9dcf1ca379b779d3ebe33a8899b15d" }
-cuda-macros = { git = "https://github.com/NVlabs/cuda-oxide.git", rev = "0810ba95ff9dcf1ca379b779d3ebe33a8899b15d" }

--- a/crates/ai-pow-miner-cuda/build.rs
+++ b/crates/ai-pow-miner-cuda/build.rs
@@ -1,0 +1,49 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.cu");
+    println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.h");
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
+    let object = out_dir.join("ai_pow_gemm.o");
+    let library = out_dir.join("libai_pow_gemm.a");
+    let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
+    let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
+
+    let status = Command::new("nvcc")
+        .args([
+            "-std=c++17",
+            "-O3",
+            "--use_fast_math",
+            "-Xcompiler",
+            "-fPIC",
+            "-gencode",
+            &format!("arch={arch},code={code}"),
+            "-c",
+            "csrc/ai_pow_gemm.cu",
+            "-o",
+        ])
+        .arg(&object)
+        .status()
+        .expect("nvcc must be installed for the gpu feature");
+    assert!(status.success(), "nvcc failed to compile AI-PoW CUDA GEMM");
+
+    let status = Command::new("ar")
+        .args(["crus"])
+        .arg(&library)
+        .arg(&object)
+        .status()
+        .expect("ar must be installed for the gpu feature");
+    assert!(status.success(), "ar failed to archive AI-PoW CUDA GEMM");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=ai_pow_gemm");
+    println!("cargo:rustc-link-lib=dylib=cudart");
+    if let Ok(cuda_home) = env::var("CUDA_HOME") {
+        println!("cargo:rustc-link-search=native={cuda_home}/lib64");
+    } else {
+        println!("cargo:rustc-link-search=native=/usr/local/cuda/lib64");
+    }
+}

--- a/crates/ai-pow-miner-cuda/build.rs
+++ b/crates/ai-pow-miner-cuda/build.rs
@@ -4,39 +4,41 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.cu");
+    println!("cargo:rerun-if-changed=csrc/ai_pow_v3.cu");
     println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.h");
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
-    let object = out_dir.join("ai_pow_gemm.o");
     let library = out_dir.join("libai_pow_gemm.a");
     let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
     let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
-
-    let status = Command::new("nvcc")
-        .args([
-            "-std=c++17",
-            "-O3",
-            "--use_fast_math",
-            "-Xcompiler",
-            "-fPIC",
-            "-gencode",
-            &format!("arch={arch},code={code}"),
-            "-c",
-            "csrc/ai_pow_gemm.cu",
-            "-o",
-        ])
-        .arg(&object)
-        .status()
-        .expect("nvcc must be installed for the gpu feature");
-    assert!(status.success(), "nvcc failed to compile AI-PoW CUDA GEMM");
-
+    let mut objects = Vec::new();
+    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu"] {
+        let object = out_dir.join(format!("{source}.o"));
+        let status = Command::new("nvcc")
+            .args([
+                "-std=c++17",
+                "-O3",
+                "-Xcompiler",
+                "-fPIC",
+                "-gencode",
+                &format!("arch={arch},code={code}"),
+                "-c",
+                &format!("csrc/{source}"),
+                "-o",
+            ])
+            .arg(&object)
+            .status()
+            .expect("nvcc must be installed for the gpu feature");
+        assert!(status.success(), "nvcc failed to compile {source}");
+        objects.push(object);
+    }
     let status = Command::new("ar")
-        .args(["crus"])
+        .arg("crus")
         .arg(&library)
-        .arg(&object)
+        .args(&objects)
         .status()
         .expect("ar must be installed for the gpu feature");
-    assert!(status.success(), "ar failed to archive AI-PoW CUDA GEMM");
+    assert!(status.success(), "ar failed to archive AI-PoW CUDA objects");
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=ai_pow_gemm");

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
@@ -3,12 +3,13 @@
 #include <cuda_runtime.h>
 
 #include <cstddef>
+#include <new>
 
 namespace {
 
 constexpr int kThreads = 256;
 
-__global__ void pearl_tile_state_kernel(
+__global__ void pearl_tile_state_batch_kernel(
     const int8_t* __restrict__ a_rows,
     const int8_t* __restrict__ b_cols,
     uint32_t h,
@@ -16,10 +17,17 @@ __global__ void pearl_tile_state_kernel(
     uint32_t k,
     uint32_t rank,
     uint32_t steps,
-    int32_t* __restrict__ state) {
-  extern __shared__ int32_t accum[];
+    int32_t* __restrict__ states) {
+  extern __shared__ int32_t shared[];
+  int32_t* accum = shared;
+  int32_t* reduction = shared + h * w;
+  int32_t* state = states + static_cast<size_t>(blockIdx.x) * 16;
   const uint32_t cells = h * w;
   const uint32_t tid = threadIdx.x;
+  const size_t a_stride = static_cast<size_t>(h) * k;
+  const size_t b_stride = static_cast<size_t>(w) * k;
+  const int8_t* attempt_a = a_rows + static_cast<size_t>(blockIdx.x) * a_stride;
+  const int8_t* attempt_b = b_cols + static_cast<size_t>(blockIdx.x) * b_stride;
 
   for (uint32_t cell = tid; cell < cells; cell += blockDim.x) {
     accum[cell] = 0;
@@ -35,8 +43,8 @@ __global__ void pearl_tile_state_kernel(
       const uint32_t row = cell / w;
       const uint32_t col = cell - row * w;
       int32_t delta = 0;
-      const int8_t* a = a_rows + static_cast<size_t>(row) * k + lo;
-      const int8_t* b = b_cols + static_cast<size_t>(col) * k + lo;
+      const int8_t* a = attempt_a + static_cast<size_t>(row) * k + lo;
+      const int8_t* b = attempt_b + static_cast<size_t>(col) * k + lo;
       for (uint32_t index = 0; index < rank; ++index) {
         delta += static_cast<int32_t>(a[index]) * static_cast<int32_t>(b[index]);
       }
@@ -48,7 +56,6 @@ __global__ void pearl_tile_state_kernel(
     for (uint32_t cell = tid; cell < cells; cell += blockDim.x) {
       value ^= accum[cell];
     }
-    __shared__ int32_t reduction[kThreads];
     reduction[tid] = value;
     __syncthreads();
     for (uint32_t stride = blockDim.x / 2; stride != 0; stride >>= 1) {
@@ -67,62 +74,124 @@ __global__ void pearl_tile_state_kernel(
   }
 }
 
+bool valid_shape(uint32_t h, uint32_t w, uint32_t k, uint32_t rank,
+                 uint32_t dot_product_len) {
+  return h != 0 && w != 0 && k != 0 && rank != 0 && dot_product_len != 0 &&
+         dot_product_len <= k && dot_product_len % rank == 0 &&
+         static_cast<size_t>(h) * w <= 4096;
+}
+
 }  // namespace
 
-extern "C" int ai_pow_cuda_tile_state(
-    const int8_t* a_rows,
-    const int8_t* b_cols,
-    uint32_t h,
-    uint32_t w,
-    uint32_t k,
-    uint32_t rank,
-    uint32_t dot_product_len,
-    int32_t state_out[16],
-    void* stream_ptr) {
-  if (a_rows == nullptr || b_cols == nullptr || state_out == nullptr || h == 0 ||
-      w == 0 || k == 0 || rank == 0 || dot_product_len == 0 ||
-      dot_product_len > k || dot_product_len % rank != 0) {
+struct AiPowCudaSession {
+  uint32_t max_attempts;
+  uint32_t h;
+  uint32_t w;
+  uint32_t k;
+  uint32_t rank;
+  uint32_t steps;
+  size_t a_attempt_bytes;
+  size_t b_attempt_bytes;
+  cudaStream_t stream;
+  int8_t* d_a;
+  int8_t* d_b;
+  int32_t* d_states;
+};
+
+extern "C" int ai_pow_cuda_session_create(
+    uint32_t max_attempts, uint32_t h, uint32_t w, uint32_t k, uint32_t rank,
+    uint32_t dot_product_len, AiPowCudaSession** session_out) {
+  if (session_out == nullptr || max_attempts == 0 ||
+      !valid_shape(h, w, k, rank, dot_product_len)) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
-  const size_t a_bytes = static_cast<size_t>(h) * k;
-  const size_t b_bytes = static_cast<size_t>(w) * k;
-  const size_t cells = static_cast<size_t>(h) * w;
-  if (cells > 4096) {
-    return static_cast<int>(cudaErrorInvalidValue);
-  }
+  *session_out = nullptr;
+  AiPowCudaSession* session = new (std::nothrow) AiPowCudaSession{};
+  if (session == nullptr) return static_cast<int>(cudaErrorMemoryAllocation);
+  session->max_attempts = max_attempts;
+  session->h = h;
+  session->w = w;
+  session->k = k;
+  session->rank = rank;
+  session->steps = dot_product_len / rank;
+  session->a_attempt_bytes = static_cast<size_t>(h) * k;
+  session->b_attempt_bytes = static_cast<size_t>(w) * k;
 
-  cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
-  int8_t* d_a = nullptr;
-  int8_t* d_b = nullptr;
-  int32_t* d_state = nullptr;
-  cudaError_t error = cudaMallocAsync(&d_a, a_bytes, stream);
-  if (error != cudaSuccess) return static_cast<int>(error);
-  error = cudaMallocAsync(&d_b, b_bytes, stream);
-  if (error != cudaSuccess) goto cleanup_a;
-  error = cudaMallocAsync(&d_state, 16 * sizeof(int32_t), stream);
-  if (error != cudaSuccess) goto cleanup_b;
-  error = cudaMemcpyAsync(d_a, a_rows, a_bytes, cudaMemcpyHostToDevice, stream);
-  if (error != cudaSuccess) goto cleanup_state;
-  error = cudaMemcpyAsync(d_b, b_cols, b_bytes, cudaMemcpyHostToDevice, stream);
-  if (error != cudaSuccess) goto cleanup_state;
+  cudaError_t error = cudaStreamCreateWithFlags(&session->stream, cudaStreamNonBlocking);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_a, session->a_attempt_bytes * max_attempts);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_b, session->b_attempt_bytes * max_attempts);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_states,
+                     static_cast<size_t>(max_attempts) * 16 * sizeof(int32_t));
+  if (error != cudaSuccess) goto fail;
+  *session_out = session;
+  return static_cast<int>(cudaSuccess);
 
-  pearl_tile_state_kernel<<<1, kThreads, cells * sizeof(int32_t), stream>>>(
-      d_a, d_b, h, w, k, rank, dot_product_len / rank, d_state);
-  error = cudaGetLastError();
-  if (error != cudaSuccess) goto cleanup_state;
-  error = cudaMemcpyAsync(
-      state_out, d_state, 16 * sizeof(int32_t), cudaMemcpyDeviceToHost, stream);
-  if (error != cudaSuccess) goto cleanup_state;
-  error = cudaStreamSynchronize(stream);
-
-cleanup_state:
-  cudaFreeAsync(d_state, stream);
-cleanup_b:
-  cudaFreeAsync(d_b, stream);
-cleanup_a:
-  cudaFreeAsync(d_a, stream);
-  if (error == cudaSuccess) {
-    error = cudaStreamSynchronize(stream);
-  }
+fail:
+  if (session->d_states != nullptr) cudaFree(session->d_states);
+  if (session->d_b != nullptr) cudaFree(session->d_b);
+  if (session->d_a != nullptr) cudaFree(session->d_a);
+  if (session->stream != nullptr) cudaStreamDestroy(session->stream);
+  delete session;
   return static_cast<int>(error);
+}
+
+extern "C" int ai_pow_cuda_session_run(
+    AiPowCudaSession* session, const int8_t* a_rows, const int8_t* b_cols,
+    uint32_t attempts, int32_t* states_out) {
+  if (session == nullptr || a_rows == nullptr || b_cols == nullptr ||
+      states_out == nullptr || attempts == 0 || attempts > session->max_attempts) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  const size_t a_bytes = session->a_attempt_bytes * attempts;
+  const size_t b_bytes = session->b_attempt_bytes * attempts;
+  const size_t state_bytes = static_cast<size_t>(attempts) * 16 * sizeof(int32_t);
+  cudaError_t error = cudaMemcpyAsync(session->d_a, a_rows, a_bytes,
+                                      cudaMemcpyHostToDevice, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(session->d_b, b_cols, b_bytes,
+                          cudaMemcpyHostToDevice, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+
+  const size_t shared_bytes =
+      (static_cast<size_t>(session->h) * session->w + kThreads) * sizeof(int32_t);
+  pearl_tile_state_batch_kernel<<<attempts, kThreads, shared_bytes, session->stream>>>(
+      session->d_a, session->d_b, session->h, session->w, session->k,
+      session->rank, session->steps, session->d_states);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(states_out, session->d_states, state_bytes,
+                          cudaMemcpyDeviceToHost, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  return static_cast<int>(cudaStreamSynchronize(session->stream));
+}
+
+extern "C" int ai_pow_cuda_session_destroy(AiPowCudaSession* session) {
+  if (session == nullptr) return static_cast<int>(cudaSuccess);
+  cudaError_t first = cudaSuccess;
+  cudaError_t error = cudaFree(session->d_states);
+  if (first == cudaSuccess) first = error;
+  error = cudaFree(session->d_b);
+  if (first == cudaSuccess) first = error;
+  error = cudaFree(session->d_a);
+  if (first == cudaSuccess) first = error;
+  error = cudaStreamDestroy(session->stream);
+  if (first == cudaSuccess) first = error;
+  delete session;
+  return static_cast<int>(first);
+}
+
+extern "C" int ai_pow_cuda_tile_state(
+    const int8_t* a_rows, const int8_t* b_cols, uint32_t h, uint32_t w,
+    uint32_t k, uint32_t rank, uint32_t dot_product_len,
+    int32_t state_out[16], void*) {
+  AiPowCudaSession* session = nullptr;
+  int status = ai_pow_cuda_session_create(
+      1, h, w, k, rank, dot_product_len, &session);
+  if (status != 0) return status;
+  status = ai_pow_cuda_session_run(session, a_rows, b_cols, 1, state_out);
+  const int destroy_status = ai_pow_cuda_session_destroy(session);
+  return status == 0 ? destroy_status : status;
 }

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
@@ -1,0 +1,128 @@
+#include "ai_pow_gemm.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+
+namespace {
+
+constexpr int kThreads = 256;
+
+__global__ void pearl_tile_state_kernel(
+    const int8_t* __restrict__ a_rows,
+    const int8_t* __restrict__ b_cols,
+    uint32_t h,
+    uint32_t w,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t steps,
+    int32_t* __restrict__ state) {
+  extern __shared__ int32_t accum[];
+  const uint32_t cells = h * w;
+  const uint32_t tid = threadIdx.x;
+
+  for (uint32_t cell = tid; cell < cells; cell += blockDim.x) {
+    accum[cell] = 0;
+  }
+  if (tid < 16) {
+    state[tid] = 0;
+  }
+  __syncthreads();
+
+  for (uint32_t step = 0; step < steps; ++step) {
+    const uint32_t lo = step * rank;
+    for (uint32_t cell = tid; cell < cells; cell += blockDim.x) {
+      const uint32_t row = cell / w;
+      const uint32_t col = cell - row * w;
+      int32_t delta = 0;
+      const int8_t* a = a_rows + static_cast<size_t>(row) * k + lo;
+      const int8_t* b = b_cols + static_cast<size_t>(col) * k + lo;
+      for (uint32_t index = 0; index < rank; ++index) {
+        delta += static_cast<int32_t>(a[index]) * static_cast<int32_t>(b[index]);
+      }
+      accum[cell] += delta;
+    }
+    __syncthreads();
+
+    int32_t value = 0;
+    for (uint32_t cell = tid; cell < cells; cell += blockDim.x) {
+      value ^= accum[cell];
+    }
+    __shared__ int32_t reduction[kThreads];
+    reduction[tid] = value;
+    __syncthreads();
+    for (uint32_t stride = blockDim.x / 2; stride != 0; stride >>= 1) {
+      if (tid < stride) {
+        reduction[tid] ^= reduction[tid + stride];
+      }
+      __syncthreads();
+    }
+    if (tid == 0) {
+      const uint32_t slot = step & 15;
+      const uint32_t prior = static_cast<uint32_t>(state[slot]);
+      state[slot] = static_cast<int32_t>((prior << 13 | prior >> 19) ^
+                                         static_cast<uint32_t>(reduction[0]));
+    }
+    __syncthreads();
+  }
+}
+
+}  // namespace
+
+extern "C" int ai_pow_cuda_tile_state(
+    const int8_t* a_rows,
+    const int8_t* b_cols,
+    uint32_t h,
+    uint32_t w,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t dot_product_len,
+    int32_t state_out[16],
+    void* stream_ptr) {
+  if (a_rows == nullptr || b_cols == nullptr || state_out == nullptr || h == 0 ||
+      w == 0 || k == 0 || rank == 0 || dot_product_len == 0 ||
+      dot_product_len > k || dot_product_len % rank != 0) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  const size_t a_bytes = static_cast<size_t>(h) * k;
+  const size_t b_bytes = static_cast<size_t>(w) * k;
+  const size_t cells = static_cast<size_t>(h) * w;
+  if (cells > 4096) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  cudaStream_t stream = static_cast<cudaStream_t>(stream_ptr);
+  int8_t* d_a = nullptr;
+  int8_t* d_b = nullptr;
+  int32_t* d_state = nullptr;
+  cudaError_t error = cudaMallocAsync(&d_a, a_bytes, stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMallocAsync(&d_b, b_bytes, stream);
+  if (error != cudaSuccess) goto cleanup_a;
+  error = cudaMallocAsync(&d_state, 16 * sizeof(int32_t), stream);
+  if (error != cudaSuccess) goto cleanup_b;
+  error = cudaMemcpyAsync(d_a, a_rows, a_bytes, cudaMemcpyHostToDevice, stream);
+  if (error != cudaSuccess) goto cleanup_state;
+  error = cudaMemcpyAsync(d_b, b_cols, b_bytes, cudaMemcpyHostToDevice, stream);
+  if (error != cudaSuccess) goto cleanup_state;
+
+  pearl_tile_state_kernel<<<1, kThreads, cells * sizeof(int32_t), stream>>>(
+      d_a, d_b, h, w, k, rank, dot_product_len / rank, d_state);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) goto cleanup_state;
+  error = cudaMemcpyAsync(
+      state_out, d_state, 16 * sizeof(int32_t), cudaMemcpyDeviceToHost, stream);
+  if (error != cudaSuccess) goto cleanup_state;
+  error = cudaStreamSynchronize(stream);
+
+cleanup_state:
+  cudaFreeAsync(d_state, stream);
+cleanup_b:
+  cudaFreeAsync(d_b, stream);
+cleanup_a:
+  cudaFreeAsync(d_a, stream);
+  if (error == cudaSuccess) {
+    error = cudaStreamSynchronize(stream);
+  }
+  return static_cast<int>(error);
+}

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
@@ -6,8 +6,30 @@
 extern "C" {
 #endif
 
-// Computes the Pearl rolling tile state for h-by-w opened strips. A is
-// h-by-k row-major. B is w-by-k column-major. Returns a CUDA error code.
+// Opaque reusable CUDA allocation and stream for one opened-strip shape.
+typedef struct AiPowCudaSession AiPowCudaSession;
+
+int ai_pow_cuda_session_create(
+    uint32_t max_attempts,
+    uint32_t h,
+    uint32_t w,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t dot_product_len,
+    AiPowCudaSession** session_out);
+
+// Uploads `attempts` contiguous A/B strip pairs and computes one 16-word state
+// per pair. A is attempts-by-h-by-k row-major. B is attempts-by-w-by-k.
+int ai_pow_cuda_session_run(
+    AiPowCudaSession* session,
+    const int8_t* a_rows,
+    const int8_t* b_cols,
+    uint32_t attempts,
+    int32_t* states_out);
+
+int ai_pow_cuda_session_destroy(AiPowCudaSession* session);
+
+// Compatibility entry point for one attempt.
 int ai_pow_cuda_tile_state(
     const int8_t* a_rows,
     const int8_t* b_cols,

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Computes the Pearl rolling tile state for h-by-w opened strips. A is
+// h-by-k row-major. B is w-by-k column-major. Returns a CUDA error code.
+int ai_pow_cuda_tile_state(
+    const int8_t* a_rows,
+    const int8_t* b_cols,
+    uint32_t h,
+    uint32_t w,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t dot_product_len,
+    int32_t state_out[16],
+    void* stream);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
@@ -6,9 +6,12 @@
 extern "C" {
 #endif
 
-// Opaque reusable CUDA allocation and stream for one opened-strip shape.
+// Opaque persistent allocations and stream for generic and canonical jobs.
 typedef struct AiPowCudaSession AiPowCudaSession;
+typedef struct AiPowCudaV3Session AiPowCudaV3Session;
 
+// Generic opened-strip tile-state session. Retained for dense Pearl jobs and
+// differential tests. Canonical production mining uses the V3 session below.
 int ai_pow_cuda_session_create(
     uint32_t max_attempts,
     uint32_t h,
@@ -18,8 +21,6 @@ int ai_pow_cuda_session_create(
     uint32_t dot_product_len,
     AiPowCudaSession** session_out);
 
-// Uploads `attempts` contiguous A/B strip pairs and computes one 16-word state
-// per pair. A is attempts-by-h-by-k row-major. B is attempts-by-w-by-k.
 int ai_pow_cuda_session_run(
     AiPowCudaSession* session,
     const int8_t* a_rows,
@@ -29,7 +30,50 @@ int ai_pow_cuda_session_run(
 
 int ai_pow_cuda_session_destroy(AiPowCudaSession* session);
 
-// Compatibility entry point for one attempt.
+// Creates the persistent canonical Pearl V3 session. Fixed inputs are copied
+// once. `sigma` is the 76-byte base header and `mu` is the 52-byte mining
+// configuration. The device adds each attempt ordinal to sigma's timestamp.
+int ai_pow_cuda_v3_session_create(
+    uint32_t max_attempts,
+    const int8_t* a_matrix,
+    const int8_t* b_matrix,
+    const uint8_t sigma[76],
+    const uint8_t mu[52],
+    const uint8_t* routing_data,
+    uint32_t routing_data_len,
+    const uint8_t* routing_offsets,
+    uint32_t routing_offsets_len,
+    const uint32_t row_indices[8],
+    const uint32_t col_indices[8],
+    AiPowCudaV3Session** session_out);
+
+// Searches consecutive extranonces and returns the lowest successful local
+// index in `winner_local`; UINT32_MAX means no winner. `jackpot_out` receives
+// the device jackpot for a hit and is ignored for a miss.
+int ai_pow_cuda_v3_session_search(
+    AiPowCudaV3Session* session,
+    uint32_t extranonce_start,
+    uint32_t attempts,
+    const uint8_t target[32],
+    uint32_t* winner_local,
+    uint8_t jackpot_out[32]);
+
+// Copies selected per-attempt V3 intermediates for differential tests.
+int ai_pow_cuda_v3_session_debug(
+    AiPowCudaV3Session* session,
+    uint32_t extranonce,
+    uint8_t kappa[32],
+    uint8_t h_a[32],
+    uint8_t h_b[32],
+    uint8_t s_a[32],
+    uint8_t s_b[32],
+    int8_t a_rows[8192],
+    int8_t b_cols[8192],
+    int32_t state[16],
+    uint8_t jackpot[32]);
+int ai_pow_cuda_v3_session_destroy(AiPowCudaV3Session* session);
+
+// Compatibility entry point for one generic opened-strip attempt.
 int ai_pow_cuda_tile_state(
     const int8_t* a_rows,
     const int8_t* b_cols,

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
@@ -303,15 +303,17 @@ __global__ void noise_kernel(
   const uint32_t* s_a=s_as+attempt*8; const uint32_t* s_b=s_bs+attempt*8;
   for (uint32_t work=tid;work<288;work+=blockDim.x) {
     if (work<16) {
-      uint32_t hash[8]; random_hash(work,false,s_a,0,hash);
+      const uint32_t opened=work/2,chunk=work%2;
+      uint32_t hash[8]; random_hash(rows[opened]*2+chunk,false,s_a,0,hash);
 #pragma unroll
       for (int word=0;word<8;++word) for(int byte=0;byte<4;++byte)
         e_l[work*32+word*4+byte]=int8_t(int((hash[word]>>(byte*8))&63)-32);
     } else if (work<32) {
-      const uint32_t chunk=work-16; uint32_t hash[8]; random_hash(chunk,true,s_b,0,hash);
+      const uint32_t relative=work-16,opened=relative/2,chunk=relative%2;
+      uint32_t hash[8]; random_hash(cols[opened]*2+chunk,true,s_b,0,hash);
 #pragma unroll
       for (int word=0;word<8;++word) for(int byte=0;byte<4;++byte)
-        f_r[chunk*32+word*4+byte]=int8_t(int((hash[word]>>(byte*8))&63)-32);
+        f_r[relative*32+word*4+byte]=int8_t(int((hash[word]>>(byte*8))&63)-32);
     } else if (work<160) {
       const uint32_t chunk=work-32; uint32_t hash[8]; random_hash(chunk,false,s_a,1,hash);
 #pragma unroll

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
@@ -1,0 +1,467 @@
+#include "ai_pow_gemm.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+namespace {
+
+constexpr uint32_t kM = 64;
+constexpr uint32_t kN = 64;
+constexpr uint32_t kK = 1024;
+constexpr uint32_t kRank = 64;
+constexpr uint32_t kOpened = 8;
+constexpr uint32_t kChunks = 64;
+constexpr uint32_t kNoWinner = 0xffffffffu;
+
+constexpr uint32_t kChunkStart = 1u << 0;
+constexpr uint32_t kChunkEnd = 1u << 1;
+constexpr uint32_t kParent = 1u << 2;
+constexpr uint32_t kRoot = 1u << 3;
+constexpr uint32_t kKeyed = 1u << 4;
+__device__ __constant__ uint32_t kIv[8] = {
+    0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+    0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+};
+__device__ __constant__ uint32_t kSaltA[8] = {
+    0x6c404982u, 0x1615eda0u, 0x92f61696u, 0xf876f0fcu,
+    0x2adbdb92u, 0x52b82370u, 0x1977d4f0u, 0x7b0190c3u,
+};
+__device__ __constant__ uint32_t kSaltB[8] = {
+    0x32063011u, 0xca0163ecu, 0x71afe22bu, 0x4f4d3f8bu,
+    0x39c6e91au, 0x04cce888u, 0x1d304448u, 0xa99ab871u,
+};
+
+__device__ __forceinline__ uint32_t rotr(uint32_t value, int shift) {
+  return (value >> shift) | (value << (32 - shift));
+}
+
+#define G(a, b, c, d, mx, my) do { \
+  (a) = (a) + (b) + (mx);                  \
+  (d) = rotr((d) ^ (a), 16);               \
+  (c) = (c) + (d);                         \
+  (b) = rotr((b) ^ (c), 12);               \
+  (a) = (a) + (b) + (my);                  \
+  (d) = rotr((d) ^ (a), 8);                \
+  (c) = (c) + (d);                         \
+  (b) = rotr((b) ^ (c), 7);                \
+} while (0)
+
+template <int Round> struct Schedule;
+template <> struct Schedule<0> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15}; return s[i]; }};
+template <> struct Schedule<1> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {2,6,3,10,7,0,4,13,1,11,12,5,9,14,15,8}; return s[i]; }};
+template <> struct Schedule<2> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {3,4,10,12,13,2,7,14,6,5,9,0,11,15,8,1}; return s[i]; }};
+template <> struct Schedule<3> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {10,7,12,9,14,3,13,15,4,0,11,2,5,8,1,6}; return s[i]; }};
+template <> struct Schedule<4> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {12,13,9,11,15,10,14,8,7,2,5,3,0,1,6,4}; return s[i]; }};
+template <> struct Schedule<5> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {9,14,11,5,8,12,15,1,13,3,0,10,2,6,4,7}; return s[i]; }};
+template <> struct Schedule<6> { static __device__ __forceinline__ int at(int i) {
+  const int s[16] = {11,15,5,0,1,9,8,6,14,10,2,12,3,4,7,13}; return s[i]; }};
+
+template <int Round>
+__device__ __forceinline__ void round(uint32_t v[16], const uint32_t m[16]) {
+#define M(i) m[Schedule<Round>::at(i)]
+  G(v[0],v[4],v[8],v[12],M(0),M(1)); G(v[1],v[5],v[9],v[13],M(2),M(3));
+  G(v[2],v[6],v[10],v[14],M(4),M(5)); G(v[3],v[7],v[11],v[15],M(6),M(7));
+  G(v[0],v[5],v[10],v[15],M(8),M(9)); G(v[1],v[6],v[11],v[12],M(10),M(11));
+  G(v[2],v[7],v[8],v[13],M(12),M(13)); G(v[3],v[4],v[9],v[14],M(14),M(15));
+#undef M
+}
+
+__device__ __forceinline__ void compress(
+    const uint32_t block[16], const uint32_t cv[8], uint64_t counter,
+    uint32_t block_len, uint32_t flags, uint32_t out[8]) {
+  uint32_t v[16];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) v[i] = cv[i];
+  v[8]=kIv[0]; v[9]=kIv[1]; v[10]=kIv[2]; v[11]=kIv[3];
+  v[12]=uint32_t(counter); v[13]=uint32_t(counter >> 32);
+  v[14]=block_len; v[15]=flags;
+  round<0>(v,block); round<1>(v,block); round<2>(v,block); round<3>(v,block);
+  round<4>(v,block); round<5>(v,block); round<6>(v,block);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) out[i] = v[i] ^ v[i+8];
+}
+
+__device__ __forceinline__ uint32_t load32(const uint8_t* p) {
+  return uint32_t(p[0]) | (uint32_t(p[1]) << 8) |
+         (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+}
+
+__device__ __forceinline__ void hash_bytes(
+    const uint8_t* input, uint32_t length, const uint32_t key[8],
+    uint32_t base_flags, uint32_t out[8]) {
+  uint32_t cv[8];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) cv[i] = key[i];
+  const uint32_t blocks = (length + 63u) / 64u;
+  for (uint32_t block_index = 0; block_index < blocks; ++block_index) {
+    uint32_t block[16];
+#pragma unroll
+    for (int word = 0; word < 16; ++word) {
+      uint32_t value = 0;
+#pragma unroll
+      for (int byte = 0; byte < 4; ++byte) {
+        const uint32_t offset = block_index * 64 + word * 4 + byte;
+        if (offset < length) value |= uint32_t(input[offset]) << (byte * 8);
+      }
+      block[word] = value;
+    }
+    const bool first = block_index == 0;
+    const bool last = block_index + 1 == blocks;
+    const uint32_t block_len = last ? length - block_index * 64u : 64u;
+    uint32_t next[8];
+    compress(block, cv, 0, block_len,
+             base_flags | (first ? kChunkStart : 0) |
+             (last ? (kChunkEnd | kRoot) : 0), next);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) cv[i] = next[i];
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) out[i] = cv[i];
+}
+
+__device__ __forceinline__ void single_block(
+    const uint32_t block[16], const uint32_t key[8], uint32_t flags,
+    uint32_t out[8]) {
+  compress(block, key, 0, 64, flags | kChunkStart | kChunkEnd | kRoot, out);
+}
+
+__device__ __forceinline__ void hash_pair(
+    const uint32_t left[8], const uint32_t right[8], uint32_t out[8]) {
+  uint32_t block[16];
+#pragma unroll
+  for (int i=0;i<8;++i) { block[i]=left[i]; block[i+8]=right[i]; }
+  single_block(block, kIv, 0, out);
+}
+
+__device__ __forceinline__ void chunk_cv(
+    const uint8_t* bytes, uint32_t length, uint64_t counter,
+    const uint32_t key[8], bool root, uint32_t out[8]) {
+  uint32_t cv[8];
+#pragma unroll
+  for (int i=0;i<8;++i) cv[i]=key[i];
+  const uint32_t blocks = (length + 63u) / 64u;
+  for (uint32_t block_index=0; block_index<blocks; ++block_index) {
+    uint32_t block[16];
+#pragma unroll
+    for (int word=0;word<16;++word) {
+      uint32_t value=0;
+#pragma unroll
+      for (int byte=0;byte<4;++byte) {
+        const uint32_t off=block_index*64+word*4+byte;
+        if (off<length) value |= uint32_t(bytes[off]) << (byte*8);
+      }
+      block[word]=value;
+    }
+    const bool first=block_index==0;
+    const bool last=block_index+1==blocks;
+    const uint32_t block_len=last ? length-block_index*64u : 64u;
+    uint32_t next[8];
+    compress(block,cv,counter,block_len,kKeyed |
+             (first?kChunkStart:0) | (last?kChunkEnd:0) |
+             (last&&root?kRoot:0),next);
+#pragma unroll
+    for (int i=0;i<8;++i) cv[i]=next[i];
+  }
+#pragma unroll
+  for (int i=0;i<8;++i) out[i]=cv[i];
+}
+
+__device__ __forceinline__ void parent_cv(
+    const uint32_t left[8], const uint32_t right[8], const uint32_t key[8],
+    bool root, uint32_t out[8]) {
+  uint32_t block[16];
+#pragma unroll
+  for (int i=0;i<8;++i) { block[i]=left[i]; block[i+8]=right[i]; }
+  compress(block,key,0,64,kKeyed|kParent|(root?kRoot:0),out);
+}
+
+__device__ __forceinline__ void random_hash(
+    uint32_t index, bool b_side, const uint32_t key[8], uint32_t prepend,
+    uint32_t out[8]) {
+  uint32_t block[16]{};
+  block[prepend]=index+1;
+  block[8]=b_side ? 0x65745f42u : 0x65745f41u;
+  block[9]=0x726f736eu;
+  single_block(block,key,kKeyed,out);
+}
+
+__device__ __forceinline__ bool le_target(
+    const uint32_t hash[8], const uint32_t target[8]) {
+#pragma unroll
+  for (int i=7;i>=0;--i) {
+    if (hash[i]<target[i]) return true;
+    if (hash[i]>target[i]) return false;
+  }
+  return true;
+}
+
+__global__ void commitments_kernel(
+    uint32_t start, const int8_t* a, const int8_t* b,
+    const uint8_t* sigma, const uint8_t* mu,
+    const uint8_t* routing, uint32_t routing_len,
+    const uint8_t* offsets, uint32_t offsets_len,
+    uint32_t* kappas, uint32_t* h_as, uint32_t* h_bs,
+    uint32_t* s_as, uint32_t* s_bs) {
+  __shared__ uint32_t kappa[8];
+  __shared__ uint32_t roots_a[kChunks][8];
+  __shared__ uint32_t roots_b[kChunks][8];
+  __shared__ uint32_t routing_root[8];
+  __shared__ uint32_t offsets_hash[8];
+  const uint32_t attempt=blockIdx.x;
+  const uint32_t tid=threadIdx.x;
+  if (tid==0) {
+    uint8_t input[128];
+#pragma unroll
+    for (int i=0;i<76;++i) input[i]=sigma[i];
+#pragma unroll
+    for (int i=0;i<52;++i) input[76+i]=mu[i];
+    const uint32_t timestamp=load32(input+68)+start+attempt;
+    input[68]=uint8_t(timestamp); input[69]=uint8_t(timestamp>>8);
+    input[70]=uint8_t(timestamp>>16); input[71]=uint8_t(timestamp>>24);
+    hash_bytes(input,128,kIv,0,kappa);
+#pragma unroll
+    for (int i=0;i<8;++i) kappas[attempt*8+i]=kappa[i];
+  }
+  __syncthreads();
+  if (tid<kChunks) {
+    chunk_cv(reinterpret_cast<const uint8_t*>(a)+tid*1024,1024,tid,kappa,false,roots_a[tid]);
+  } else if (tid<2*kChunks) {
+    const uint32_t chunk=tid-kChunks;
+    chunk_cv(reinterpret_cast<const uint8_t*>(b)+chunk*1024,1024,chunk,kappa,false,roots_b[chunk]);
+  } else if (tid==2*kChunks) {
+    chunk_cv(routing,1024,0,kappa,true,routing_root);
+  } else if (tid==2*kChunks+1) {
+    chunk_cv(offsets,1024,0,kappa,true,offsets_hash);
+  }
+  __syncthreads();
+  for (uint32_t count=kChunks;count>1;count>>=1) {
+    const uint32_t pairs=count>>1;
+    const bool active=tid<2*pairs;
+    const bool b_side=tid>=pairs;
+    const uint32_t pair=b_side ? tid-pairs : tid;
+    uint32_t parent[8];
+    if (active) {
+      const uint32_t (*roots)[8]=b_side ? roots_b : roots_a;
+      parent_cv(roots[pair*2],roots[pair*2+1],kappa,pairs==1,parent);
+    }
+    __syncthreads();
+    if (active) {
+      uint32_t (*roots)[8]=b_side ? roots_b : roots_a;
+#pragma unroll
+      for (int i=0;i<8;++i) roots[pair][i]=parent[i];
+    }
+    __syncthreads();
+  }
+  if (tid==0) {
+    (void)routing_len;
+    (void)offsets_len;
+    uint32_t message_a[16]{},message_b[16]{};
+#pragma unroll
+    for (int i=0;i<8;++i) { message_a[i]=roots_a[0][i]; message_b[i]=roots_b[0][i]; }
+    message_a[8]=kM; message_b[8]=kN/2;
+    uint32_t bound_a[8],bound_b[8];
+    single_block(message_a,kSaltA,kKeyed,bound_a);
+    single_block(message_b,kSaltB,kKeyed,bound_b);
+    uint32_t hash_routing[8],activations[8],s_a[8],s_b[8];
+    hash_pair(routing_root,offsets_hash,hash_routing);
+    hash_pair(bound_a,hash_routing,activations);
+    hash_pair(kappa,bound_b,s_b);
+    hash_pair(s_b,activations,s_a);
+#pragma unroll
+    for (int i=0;i<8;++i) {
+      h_as[attempt*8+i]=roots_a[0][i]; h_bs[attempt*8+i]=roots_b[0][i];
+      s_as[attempt*8+i]=s_a[i]; s_bs[attempt*8+i]=s_b[i];
+    }
+  }
+}
+
+__device__ __forceinline__ int32_t dp4a_signed(
+    const int8_t* a, const int8_t* b, int32_t accumulator) {
+  uint32_t a_word, b_word;
+  memcpy(&a_word,a,sizeof(a_word));
+  memcpy(&b_word,b,sizeof(b_word));
+  return __dp4a(int32_t(a_word),int32_t(b_word),accumulator);
+}
+
+__global__ void noise_kernel(
+    const int8_t* a,const int8_t* b,const uint32_t* rows,const uint32_t* cols,
+    const uint32_t* s_as,const uint32_t* s_bs,int8_t* open_a,int8_t* open_b) {
+  __shared__ int8_t e_l[kOpened*kRank];
+  __shared__ int8_t f_r[kOpened*kRank];
+  __shared__ uint8_t e_plus[kK],e_minus[kK],f_plus[kK],f_minus[kK];
+  const uint32_t attempt=blockIdx.x,tid=threadIdx.x;
+  const uint32_t* s_a=s_as+attempt*8; const uint32_t* s_b=s_bs+attempt*8;
+  for (uint32_t work=tid;work<288;work+=blockDim.x) {
+    if (work<16) {
+      uint32_t hash[8]; random_hash(work,false,s_a,0,hash);
+#pragma unroll
+      for (int word=0;word<8;++word) for(int byte=0;byte<4;++byte)
+        e_l[work*32+word*4+byte]=int8_t(int((hash[word]>>(byte*8))&63)-32);
+    } else if (work<32) {
+      const uint32_t chunk=work-16; uint32_t hash[8]; random_hash(chunk,true,s_b,0,hash);
+#pragma unroll
+      for (int word=0;word<8;++word) for(int byte=0;byte<4;++byte)
+        f_r[chunk*32+word*4+byte]=int8_t(int((hash[word]>>(byte*8))&63)-32);
+    } else if (work<160) {
+      const uint32_t chunk=work-32; uint32_t hash[8]; random_hash(chunk,false,s_a,1,hash);
+#pragma unroll
+      for(int slot=0;slot<8;++slot) { const uint32_t r=hash[slot]; const uint32_t p=r&63;
+        e_plus[chunk*8+slot]=uint8_t(p); e_minus[chunk*8+slot]=uint8_t(p^(1+uint32_t((uint64_t(63)*r)>>32))); }
+    } else {
+      const uint32_t chunk=work-160; uint32_t hash[8]; random_hash(chunk,true,s_b,1,hash);
+#pragma unroll
+      for(int slot=0;slot<8;++slot) { const uint32_t r=hash[slot]; const uint32_t p=r&63;
+        f_plus[chunk*8+slot]=uint8_t(p); f_minus[chunk*8+slot]=uint8_t(p^(1+uint32_t((uint64_t(63)*r)>>32))); }
+    }
+  }
+  __syncthreads();
+  const size_t stride=size_t(kOpened)*kK;
+  int8_t* da=open_a+size_t(attempt)*stride; int8_t* db=open_b+size_t(attempt)*stride;
+  for(uint32_t index=tid;index<stride;index+=blockDim.x) {
+    const uint32_t opened=index/kK,l=index%kK;
+    const int en=int(e_l[opened*kRank+e_plus[l]])-int(e_l[opened*kRank+e_minus[l]]);
+    const int fn=int(f_r[opened*kRank+f_plus[l]])-int(f_r[opened*kRank+f_minus[l]]);
+    da[index]=int8_t(int(a[size_t(rows[opened])*kK+l])+en);
+    db[index]=int8_t(int(b[size_t(cols[opened])*kK+l])+fn);
+  }
+}
+
+__global__ void tile_jackpot_kernel(
+    const int8_t* open_a,const int8_t* open_b,const uint32_t* s_as,
+    const uint32_t* target,int32_t* states,uint32_t* jackpots,uint32_t* winner) {
+  __shared__ int32_t accum[64]; __shared__ int32_t reduction[64];
+  const uint32_t attempt=blockIdx.x,tid=threadIdx.x;
+  const size_t stride=size_t(kOpened)*kK;
+  const int8_t* a=open_a+size_t(attempt)*stride; const int8_t* b=open_b+size_t(attempt)*stride;
+  int32_t* state=states+size_t(attempt)*16;
+  if(tid<64) accum[tid]=0; if(tid<16) state[tid]=0; __syncthreads();
+  for(uint32_t step=0;step<16;++step) {
+    if(tid<64) {
+      const uint32_t row=tid/8,col=tid%8; int32_t delta=0;
+#pragma unroll
+      for(uint32_t l=0;l<64;l+=4) {
+        delta=dp4a_signed(a+row*kK+step*64+l,b+col*kK+step*64+l,delta);
+      }
+      accum[tid]+=delta; reduction[tid]=accum[tid];
+    }
+    __syncthreads();
+    for(uint32_t shift=32;shift;shift>>=1) { if(tid<shift) reduction[tid]^=reduction[tid+shift]; __syncthreads(); }
+    if(tid==0) {
+      const uint32_t rotated=(uint32_t(state[step])<<13)|(uint32_t(state[step])>>(32-13));
+      state[step]=int32_t(rotated)^reduction[0];
+    }
+    __syncthreads();
+  }
+  if(tid==0) {
+    uint32_t block[16],hash[8];
+#pragma unroll
+    for(int i=0;i<16;++i) block[i]=uint32_t(state[i]);
+    single_block(block,s_as+size_t(attempt)*8,kKeyed,hash);
+#pragma unroll
+    for(int i=0;i<8;++i) jackpots[size_t(attempt)*8+i]=hash[i];
+    if(le_target(hash,target)) atomicMin(winner,attempt);
+  }
+}
+
+__global__ void copy_winner_kernel(const uint32_t* winner,const uint32_t* jackpots,uint32_t* out) {
+  if(threadIdx.x==0 && *winner!=kNoWinner) for(int i=0;i<8;++i) out[i]=jackpots[size_t(*winner)*8+i];
+}
+
+}  // namespace
+
+struct AiPowCudaV3Session {
+  uint32_t max_attempts;
+  uint32_t routing_len;
+  uint32_t offsets_len;
+  cudaStream_t stream;
+  int8_t *a,*b,*open_a,*open_b;
+  uint8_t *sigma,*mu,*routing,*offsets;
+  uint32_t *rows,*cols,*kappas,*h_as,*h_bs,*s_as,*s_bs,*jackpots,*target,*winner,*winner_hash;
+  int32_t* states;
+  uint32_t *host_winner,*host_hash;
+};
+
+namespace {
+void destroy_v3(AiPowCudaV3Session* s) {
+  if(!s) return;
+#define FREE(field) if(s->field) cudaFree(s->field)
+  FREE(winner_hash);FREE(winner);FREE(target);FREE(jackpots);FREE(states);FREE(s_bs);FREE(s_as);
+  FREE(h_bs);FREE(h_as);FREE(kappas);FREE(cols);FREE(rows);FREE(offsets);FREE(routing);FREE(mu);FREE(sigma);
+  FREE(open_b);FREE(open_a);FREE(b);FREE(a);
+#undef FREE
+  if(s->host_hash) cudaFreeHost(s->host_hash); if(s->host_winner) cudaFreeHost(s->host_winner);
+  if(s->stream) cudaStreamDestroy(s->stream); delete s;
+}
+}
+
+extern "C" int ai_pow_cuda_v3_session_create(
+    uint32_t max_attempts,const int8_t* a_matrix,const int8_t* b_matrix,
+    const uint8_t sigma[76],const uint8_t mu[52],const uint8_t* routing_data,
+    uint32_t routing_data_len,const uint8_t* routing_offsets,uint32_t routing_offsets_len,
+    const uint32_t row_indices[8],const uint32_t col_indices[8],AiPowCudaV3Session** out) {
+  if(!out||!max_attempts||!a_matrix||!b_matrix||!sigma||!mu||!routing_data||!routing_data_len||
+     routing_data_len>1024||!routing_offsets||!routing_offsets_len||routing_offsets_len>1024||!row_indices||!col_indices)
+    return int(cudaErrorInvalidValue);
+  *out=nullptr; auto* s=new(std::nothrow) AiPowCudaV3Session{}; if(!s) return int(cudaErrorMemoryAllocation);
+  const size_t hb=size_t(max_attempts)*32;
+  const size_t strips=size_t(max_attempts)*8192;
+  s->max_attempts=max_attempts;s->routing_len=routing_data_len;s->offsets_len=routing_offsets_len;
+  cudaError_t e=cudaStreamCreateWithFlags(&s->stream,cudaStreamNonBlocking);if(e!=cudaSuccess)goto fail;
+#define ALLOC(field,bytes) do{e=cudaMalloc(reinterpret_cast<void**>(&s->field),(bytes));if(e!=cudaSuccess)goto fail;}while(0)
+  ALLOC(a,65536);ALLOC(b,65536);ALLOC(sigma,76);ALLOC(mu,52);ALLOC(routing,1024);ALLOC(offsets,1024);
+  ALLOC(rows,32);ALLOC(cols,32);
+  ALLOC(kappas,hb);ALLOC(h_as,hb);ALLOC(h_bs,hb);ALLOC(s_as,hb);ALLOC(s_bs,hb);ALLOC(open_a,strips);ALLOC(open_b,strips);
+  ALLOC(states,size_t(max_attempts)*64);ALLOC(jackpots,hb);ALLOC(target,32);ALLOC(winner,4);ALLOC(winner_hash,32);
+#undef ALLOC
+  e=cudaMallocHost(reinterpret_cast<void**>(&s->host_winner),4);if(e!=cudaSuccess)goto fail;e=cudaMallocHost(reinterpret_cast<void**>(&s->host_hash),32);if(e!=cudaSuccess)goto fail;
+  e=cudaMemsetAsync(s->routing,0,1024,s->stream);if(e!=cudaSuccess)goto fail;
+  e=cudaMemsetAsync(s->offsets,0,1024,s->stream);if(e!=cudaSuccess)goto fail;
+#define COPY(field,source,bytes) do{e=cudaMemcpyAsync(s->field,(source),(bytes),cudaMemcpyHostToDevice,s->stream);if(e!=cudaSuccess)goto fail;}while(0)
+  COPY(a,a_matrix,65536);COPY(b,b_matrix,65536);COPY(sigma,sigma,76);COPY(mu,mu,52);COPY(routing,routing_data,routing_data_len);
+  COPY(offsets,routing_offsets,routing_offsets_len);COPY(rows,row_indices,32);COPY(cols,col_indices,32);
+#undef COPY
+  e=cudaStreamSynchronize(s->stream);if(e!=cudaSuccess)goto fail;*out=s;return 0;
+fail:destroy_v3(s);return int(e);
+}
+
+extern "C" int ai_pow_cuda_v3_session_search(
+    AiPowCudaV3Session* s,uint32_t start,uint32_t attempts,const uint8_t target[32],
+    uint32_t* winner_local,uint8_t jackpot_out[32]) {
+  if(!s||!attempts||attempts>s->max_attempts||!target||!winner_local||!jackpot_out||
+     uint64_t(start)+attempts>(uint64_t(1)<<32)) return int(cudaErrorInvalidValue);
+  cudaError_t e=cudaMemcpyAsync(s->target,target,32,cudaMemcpyHostToDevice,s->stream);if(e!=cudaSuccess)return int(e);
+  e=cudaMemsetAsync(s->winner,0xff,4,s->stream);if(e!=cudaSuccess)return int(e);e=cudaMemsetAsync(s->winner_hash,0,32,s->stream);if(e!=cudaSuccess)return int(e);
+  commitments_kernel<<<attempts,160,0,s->stream>>>(start,s->a,s->b,s->sigma,s->mu,s->routing,s->routing_len,s->offsets,s->offsets_len,
+      s->kappas,s->h_as,s->h_bs,s->s_as,s->s_bs);e=cudaGetLastError();if(e!=cudaSuccess)return int(e);
+  noise_kernel<<<attempts,256,0,s->stream>>>(s->a,s->b,s->rows,s->cols,s->s_as,s->s_bs,s->open_a,s->open_b);e=cudaGetLastError();if(e!=cudaSuccess)return int(e);
+  tile_jackpot_kernel<<<attempts,64,0,s->stream>>>(s->open_a,s->open_b,s->s_as,s->target,s->states,s->jackpots,s->winner);
+  e=cudaGetLastError();if(e!=cudaSuccess)return int(e);copy_winner_kernel<<<1,1,0,s->stream>>>(s->winner,s->jackpots,s->winner_hash);
+  e=cudaGetLastError();if(e!=cudaSuccess)return int(e);e=cudaMemcpyAsync(s->host_winner,s->winner,4,cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);
+  e=cudaMemcpyAsync(s->host_hash,s->winner_hash,32,cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);e=cudaStreamSynchronize(s->stream);if(e!=cudaSuccess)return int(e);
+  *winner_local=*s->host_winner;std::memcpy(jackpot_out,s->host_hash,32);return 0;
+}
+
+extern "C" int ai_pow_cuda_v3_session_debug(
+    AiPowCudaV3Session* s,uint32_t extranonce,uint8_t kappa[32],uint8_t h_a[32],uint8_t h_b[32],uint8_t s_a[32],uint8_t s_b[32],
+    int8_t a_rows[8192],int8_t b_cols[8192],int32_t state[16],uint8_t jackpot[32]) {
+  if(!s||!kappa||!h_a||!h_b||!s_a||!s_b||!a_rows||!b_cols||!state||!jackpot)return int(cudaErrorInvalidValue);
+  uint8_t target[32];std::memset(target,0xff,32);uint32_t winner;
+  int status=ai_pow_cuda_v3_session_search(s,extranonce,1,target,&winner,jackpot);if(status)return status;
+#define GET(destination,source,bytes) do{cudaError_t e=cudaMemcpyAsync((destination),(source),(bytes),cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);}while(0)
+  GET(kappa,s->kappas,32);GET(h_a,s->h_as,32);GET(h_b,s->h_bs,32);GET(s_a,s->s_as,32);GET(s_b,s->s_bs,32);
+  GET(a_rows,s->open_a,8192);GET(b_cols,s->open_b,8192);GET(state,s->states,64);
+#undef GET
+  return int(cudaStreamSynchronize(s->stream));
+}
+
+extern "C" int ai_pow_cuda_v3_session_destroy(AiPowCudaV3Session* s) { destroy_v3(s);return 0; }

--- a/crates/ai-pow-miner-cuda/csrc/test_ai_pow_gemm.cu
+++ b/crates/ai-pow-miner-cuda/csrc/test_ai_pow_gemm.cu
@@ -58,6 +58,36 @@ int main() {
       }
     }
   }
+  {
+    constexpr uint32_t h = 16;
+    constexpr uint32_t w = 16;
+    constexpr uint32_t rank = 128;
+    constexpr uint32_t steps = 32;
+    constexpr uint32_t k = rank * steps;
+    std::vector<int8_t> a(h * k), b(w * k);
+    for (size_t index = 0; index < a.size(); ++index) {
+      a[index] = static_cast<int8_t>((index * 73 + index / k * 19) % 255 - 127);
+    }
+    for (size_t index = 0; index < b.size(); ++index) {
+      b[index] = static_cast<int8_t>((index * 151 + index / k * 31) % 255 - 127);
+    }
+    int32_t expected[16], actual[16];
+    cpu_state(a, b, h, w, k, rank, k, expected);
+    const int status = ai_pow_cuda_tile_state(
+        a.data(), b.data(), h, w, k, rank, k, actual, nullptr);
+    if (status != 0) {
+      std::fprintf(stderr, "CUDA error %d in accumulation stress case\n", status);
+      return 1;
+    }
+    for (int slot = 0; slot < 16; ++slot) {
+      if (expected[slot] != actual[slot]) {
+        std::fprintf(stderr,
+                     "stress mismatch slot=%d expected=%08x actual=%08x\n",
+                     slot, uint32_t(expected[slot]), uint32_t(actual[slot]));
+        return 1;
+      }
+    }
+  }
   std::puts("1000 randomized Pearl tile-state differentials passed");
   return 0;
 }

--- a/crates/ai-pow-miner-cuda/csrc/test_ai_pow_gemm.cu
+++ b/crates/ai-pow-miner-cuda/csrc/test_ai_pow_gemm.cu
@@ -1,0 +1,63 @@
+#include "ai_pow_gemm.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <random>
+#include <vector>
+
+static void cpu_state(const std::vector<int8_t>& a, const std::vector<int8_t>& b,
+                      uint32_t h, uint32_t w, uint32_t k, uint32_t rank,
+                      uint32_t dot, int32_t out[16]) {
+  std::vector<int32_t> accum(h * w, 0);
+  for (int i = 0; i < 16; ++i) out[i] = 0;
+  for (uint32_t step = 0; step < dot / rank; ++step) {
+    for (uint32_t row = 0; row < h; ++row) {
+      for (uint32_t col = 0; col < w; ++col) {
+        int32_t delta = 0;
+        for (uint32_t x = 0; x < rank; ++x) {
+          const uint32_t index = step * rank + x;
+          delta += int32_t(a[row * k + index]) * int32_t(b[col * k + index]);
+        }
+        accum[row * w + col] += delta;
+      }
+    }
+    int32_t folded = 0;
+    for (int32_t value : accum) folded ^= value;
+    const uint32_t slot = step & 15;
+    const uint32_t prior = static_cast<uint32_t>(out[slot]);
+    out[slot] = static_cast<int32_t>((prior << 13 | prior >> 19) ^
+                                     static_cast<uint32_t>(folded));
+  }
+}
+
+int main() {
+  std::mt19937 rng(0x4e4f434b);
+  for (uint32_t trial = 0; trial < 1000; ++trial) {
+    const uint32_t h = 1 + rng() % 16;
+    const uint32_t w = 1 + rng() % 16;
+    const uint32_t rank = 1u << (rng() % 7);
+    const uint32_t steps = 1 + rng() % 32;
+    const uint32_t k = rank * steps;
+    std::vector<int8_t> a(h * k), b(w * k);
+    for (int8_t& value : a) value = static_cast<int8_t>(int(rng() % 255) - 127);
+    for (int8_t& value : b) value = static_cast<int8_t>(int(rng() % 255) - 127);
+    int32_t expected[16], actual[16];
+    cpu_state(a, b, h, w, k, rank, k, expected);
+    const int status = ai_pow_cuda_tile_state(
+        a.data(), b.data(), h, w, k, rank, k, actual, nullptr);
+    if (status != 0) {
+      std::fprintf(stderr, "CUDA error %d at trial %u\n", status, trial);
+      return 1;
+    }
+    for (int slot = 0; slot < 16; ++slot) {
+      if (expected[slot] != actual[slot]) {
+        std::fprintf(stderr,
+                     "mismatch trial=%u slot=%d expected=%08x actual=%08x\n",
+                     trial, slot, uint32_t(expected[slot]), uint32_t(actual[slot]));
+        return 1;
+      }
+    }
+  }
+  std::puts("1000 randomized Pearl tile-state differentials passed");
+  return 0;
+}

--- a/crates/ai-pow-miner/Cargo.toml
+++ b/crates/ai-pow-miner/Cargo.toml
@@ -59,6 +59,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 thiserror = { workspace = true }
 num_cpus = { workspace = true }
+rayon = { workspace = true }
 tracing = { workspace = true }
 
 # `node` feature (out-of-process gRPC integration).

--- a/crates/ai-pow-miner/Cargo.toml
+++ b/crates/ai-pow-miner/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 description = "NockApp-compatible AI-PoW miner for Pearl-compatible ticket search and recursive %ai-pow submission."
 publish = false
+build = "build.rs"
 
 [lib]
 name = "ai_pow_miner"
@@ -25,6 +26,9 @@ required-features = ["node"]
 
 [features]
 default = []
+# CUDA builds use nvcc through `build.rs` and link cudart. The implementation
+# remains optional so normal CPU builds have no CUDA toolkit or driver contract.
+gpu = []
 # Out-of-process node-connecting integration: pulls in the gRPC +
 # nockapp stack so `src/run.rs` + `src/wire.rs` + the
 # `ai-pow-mine` binary build. The bare crate (no features) keeps the

--- a/crates/ai-pow-miner/README.md
+++ b/crates/ai-pow-miner/README.md
@@ -46,6 +46,28 @@ Merge mining shares a mineable work unit, not a proof system or chain target. Pe
 
 The miner relies on `ai-pow` for Pearl byte compatibility and attempt binding, and on `ai-pow-zk` for certificate construction. Its security-sensitive obligations are canonical serialization, exact statement construction, fresh per-attempt work, and refusal to substitute prover-controlled setup or public parameters. Cryptographic acceptance properties are documented in [`../ai-pow-zk/docs/SECURITY.md`](../ai-pow-zk/docs/SECURITY.md).
 
+## GPU container configuration
+
+Build the Linux/amd64 production image:
+
+```sh
+docker buildx build \
+  --platform linux/amd64 \
+  -f docker/Dockerfile.ai-pow-miner-gpu \
+  -t ai-pow-miner-gpu .
+```
+
+The image mines to `2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j` by default. Set `MINING_PKH` to direct rewards to a different v1 mining public-key hash. `NODE_ADDR` is required.
+
+```sh
+docker run --rm --gpus all \
+  -e NODE_ADDR=http://node.example:5555 \
+  -e MINING_PKH=<v1-mining-pkh> \
+  ai-pow-miner-gpu
+```
+
+The image uses CUDA device `0`, canonical mode, and batches of 32,768 attempts by default. Set `CUDA_DEVICE`, `CANONICAL`, or `GPU_BATCH_ATTEMPTS` to override these values. Non-canonical mode also requires `PEARL_GATEWAY`.
+
 ## Validation
 
 ```sh

--- a/crates/ai-pow-miner/benches/search.rs
+++ b/crates/ai-pow-miner/benches/search.rs
@@ -116,12 +116,22 @@ fn dense_header() -> PearlIncompleteBlockHeader {
     }
 }
 
-fn print_measurement(name: &str, attempts: u64, workers: usize, measurement: Measurement) {
+fn print_measurement(
+    name: &str,
+    attempts: u64,
+    shape_work_factor: u128,
+    workers: usize,
+    measurement: Measurement,
+) {
     let elapsed_s = measurement.elapsed.as_secs_f64();
     let attempts_per_s = (attempts as f64) / elapsed_s;
+    let macs_per_s = attempts_per_s * shape_work_factor as f64;
     println!(
-        "{name}: attempts={attempts} elapsed_ms={:.3} attempts_per_s={attempts_per_s:.3} allocations={} workers={workers}",
+        "{name}: attempts={attempts} elapsed_ms={:.3} attempts_per_s={attempts_per_s:.3} \
+         macs_per_s={macs_per_s:.3} tera_macs_per_s={:.6} shape_work_factor={shape_work_factor} \
+         allocations={} workers={workers}",
         elapsed_s * 1_000.0,
+        macs_per_s / 1.0e12,
         measurement.allocations,
     );
 }
@@ -139,6 +149,10 @@ fn main() {
         PreparedCanonicalMoeTemplate::new(&canonical, 8, 2, 1, [0x5a; 32])
             .expect("canonical template"),
     );
+    let canonical_shape_work_factor = canonical_template
+        .config()
+        .shape_work_factor()
+        .expect("canonical shape work factor");
     backend
         .search_canonical(
             Arc::clone(&canonical_template),
@@ -156,6 +170,7 @@ fn main() {
     print_measurement(
         "canonical_prepare_scalar",
         u64::from(canonical_attempts),
+        canonical_shape_work_factor,
         1,
         canonical_prepare_measurement,
     );
@@ -172,6 +187,7 @@ fn main() {
     print_measurement(
         "canonical_prepared_scalar",
         u64::from(canonical_attempts),
+        canonical_shape_work_factor,
         1,
         canonical_measurement,
     );
@@ -189,6 +205,7 @@ fn main() {
     print_measurement(
         "canonical_prepared_dedicated",
         u64::from(canonical_attempts),
+        canonical_shape_work_factor,
         workers,
         canonical_parallel_measurement,
     );
@@ -217,6 +234,7 @@ fn main() {
         print_measurement(
             "canonical_prepared_cuda",
             u64::from(canonical_attempts),
+            canonical_shape_work_factor,
             1,
             canonical_gpu_measurement,
         );
@@ -229,6 +247,7 @@ fn main() {
         prepare_pearl_pattern_job(&header, &config, &DENSE_PRODUCTION_PARAMS, &a, &b, 8)
             .expect("prepared dense Pearl job"),
     );
+    let dense_shape_work_factor = config.shape_work_factor().expect("dense shape work factor");
     backend
         .search_dense(
             Arc::clone(&dense_prepared),
@@ -257,7 +276,8 @@ fn main() {
         }
     });
     print_measurement(
-        "dense_prepared_scalar_full_sweep", dense_attempts, 1, dense_measurement,
+        "dense_prepared_scalar_full_sweep", dense_attempts, dense_shape_work_factor, 1,
+        dense_measurement,
     );
     let dense_parallel_measurement = measure(|| {
         std::hint::black_box(
@@ -270,6 +290,7 @@ fn main() {
         );
     });
     print_measurement(
-        "dense_prepared_dedicated_full_sweep", dense_attempts, workers, dense_parallel_measurement,
+        "dense_prepared_dedicated_full_sweep", dense_attempts, dense_shape_work_factor, workers,
+        dense_parallel_measurement,
     );
 }

--- a/crates/ai-pow-miner/benches/search.rs
+++ b/crates/ai-pow-miner/benches/search.rs
@@ -19,6 +19,8 @@ use ai_pow::pearl_compat::{
 };
 use ai_pow::synth::{synth_matrices, AI_POW_PROD_SYNTH_SEED};
 use ai_pow_miner::canonical::PreparedCanonicalMoeTemplate;
+#[cfg(feature = "gpu")]
+use ai_pow_miner::gpu::GpuSearchBackend;
 use ai_pow_miner::search::{CpuSearchBackend, SearchBackend, SearchBatch};
 use ai_pow_miner::DENSE_PRODUCTION_PARAMS;
 
@@ -143,6 +145,20 @@ fn main() {
             SearchBatch::new(0, 1, [0; 32]).expect("canonical warmup batch"),
         )
         .expect("canonical dedicated warmup");
+    let mut canonical_prepare_scratch = canonical_template.scratch();
+    let canonical_prepare_measurement = measure(|| {
+        for extranonce in 0..canonical_attempts {
+            std::hint::black_box(
+                canonical_template.prepare_attempt(extranonce, &mut canonical_prepare_scratch),
+            );
+        }
+    });
+    print_measurement(
+        "canonical_prepare_scalar",
+        u64::from(canonical_attempts),
+        1,
+        canonical_prepare_measurement,
+    );
     let mut canonical_scratch = canonical_template.scratch();
     let canonical_measurement = measure(|| {
         for extranonce in 0..canonical_attempts {
@@ -176,6 +192,35 @@ fn main() {
         workers,
         canonical_parallel_measurement,
     );
+
+    #[cfg(feature = "gpu")]
+    {
+        let gpu_backend =
+            GpuSearchBackend::new(0, u64::from(canonical_attempts)).expect("CUDA search backend");
+        gpu_backend
+            .search_canonical(
+                Arc::clone(&canonical_template),
+                SearchBatch::new(0, 1, [0; 32]).expect("CUDA warmup batch"),
+            )
+            .expect("CUDA warmup");
+        let canonical_gpu_measurement = measure(|| {
+            std::hint::black_box(
+                gpu_backend
+                    .search_canonical(
+                        Arc::clone(&canonical_template),
+                        SearchBatch::new(0, u64::from(canonical_attempts), [0; 32])
+                            .expect("CUDA canonical batch"),
+                    )
+                    .expect("CUDA canonical search"),
+            );
+        });
+        print_measurement(
+            "canonical_prepared_cuda",
+            u64::from(canonical_attempts),
+            1,
+            canonical_gpu_measurement,
+        );
+    }
 
     let header = dense_header();
     let config = dense_config();

--- a/crates/ai-pow-miner/build.rs
+++ b/crates/ai-pow-miner/build.rs
@@ -1,0 +1,49 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.cu");
+    println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.h");
+    println!("cargo:rerun-if-env-changed=AI_POW_CUDA_ARCH");
+    println!("cargo:rerun-if-env-changed=AI_POW_CUDA_CODE");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    if env::var_os("CARGO_FEATURE_GPU").is_none() {
+        return;
+    }
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
+    let object = out_dir.join("ai_pow_gemm.o");
+    let library = out_dir.join("libai_pow_gemm.a");
+    let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
+    let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
+    let status = Command::new("nvcc")
+        .args([
+            "-std=c++17",
+            "-O3",
+            "-Xcompiler",
+            "-fPIC",
+            "-gencode",
+            &format!("arch={arch},code={code}"),
+            "-c",
+            "../ai-pow-miner-cuda/csrc/ai_pow_gemm.cu",
+            "-o",
+        ])
+        .arg(&object)
+        .status()
+        .expect("nvcc must be installed for the gpu feature");
+    assert!(status.success(), "nvcc failed to compile AI-PoW CUDA GEMM");
+    let status = Command::new("ar")
+        .args(["crus"])
+        .arg(&library)
+        .arg(&object)
+        .status()
+        .expect("ar must be installed for the gpu feature");
+    assert!(status.success(), "ar failed to archive AI-PoW CUDA GEMM");
+
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=ai_pow_gemm");
+    println!("cargo:rustc-link-lib=dylib=cudart");
+    let cuda_home = env::var("CUDA_HOME").unwrap_or_else(|_| "/usr/local/cuda".to_owned());
+    println!("cargo:rustc-link-search=native={cuda_home}/lib64");
+}

--- a/crates/ai-pow-miner/build.rs
+++ b/crates/ai-pow-miner/build.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.cu");
+    println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_v3.cu");
     println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.h");
     println!("cargo:rerun-if-env-changed=AI_POW_CUDA_ARCH");
     println!("cargo:rerun-if-env-changed=AI_POW_CUDA_CODE");
@@ -13,33 +14,37 @@ fn main() {
     }
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
-    let object = out_dir.join("ai_pow_gemm.o");
     let library = out_dir.join("libai_pow_gemm.a");
     let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
     let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
-    let status = Command::new("nvcc")
-        .args([
-            "-std=c++17",
-            "-O3",
-            "-Xcompiler",
-            "-fPIC",
-            "-gencode",
-            &format!("arch={arch},code={code}"),
-            "-c",
-            "../ai-pow-miner-cuda/csrc/ai_pow_gemm.cu",
-            "-o",
-        ])
-        .arg(&object)
-        .status()
-        .expect("nvcc must be installed for the gpu feature");
-    assert!(status.success(), "nvcc failed to compile AI-PoW CUDA GEMM");
+    let mut objects = Vec::new();
+    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu"] {
+        let object = out_dir.join(format!("{source}.o"));
+        let status = Command::new("nvcc")
+            .args([
+                "-std=c++17",
+                "-O3",
+                "-Xcompiler",
+                "-fPIC",
+                "-gencode",
+                &format!("arch={arch},code={code}"),
+                "-c",
+                &format!("../ai-pow-miner-cuda/csrc/{source}"),
+                "-o",
+            ])
+            .arg(&object)
+            .status()
+            .expect("nvcc must be installed for the gpu feature");
+        assert!(status.success(), "nvcc failed to compile {source}");
+        objects.push(object);
+    }
     let status = Command::new("ar")
-        .args(["crus"])
+        .arg("crus")
         .arg(&library)
-        .arg(&object)
+        .args(&objects)
         .status()
         .expect("ar must be installed for the gpu feature");
-    assert!(status.success(), "ar failed to archive AI-PoW CUDA GEMM");
+    assert!(status.success(), "ar failed to archive AI-PoW CUDA objects");
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=ai_pow_gemm");

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -73,7 +73,7 @@ struct AcceleratorArgs {
 
     /// Attempts dispatched through CUDA before the scheduler checks cancellation.
     #[cfg(feature = "gpu")]
-    #[arg(long, default_value_t = 256)]
+    #[arg(long, default_value_t = 1024)]
     gpu_batch_attempts: u64,
 }
 

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -44,6 +44,9 @@ use clap::{Args as ClapArgs, Parser};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
+#[cfg(feature = "gpu")]
+const DEFAULT_GPU_BATCH_ATTEMPTS: u64 = 32_768;
+
 /// `ai-pow-mine` — standalone AI-PoW block miner.
 #[derive(Parser, Debug)]
 #[command(
@@ -73,7 +76,7 @@ struct AcceleratorArgs {
 
     /// Attempts dispatched through CUDA before the scheduler checks cancellation.
     #[cfg(feature = "gpu")]
-    #[arg(long, default_value_t = 1024)]
+    #[arg(long, default_value_t = DEFAULT_GPU_BATCH_ATTEMPTS)]
     gpu_batch_attempts: u64,
 }
 

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 
 use ai_pow_miner::cli::{init_tracing, CommonArgs};
 use ai_pow_miner::run::{run_canonical_with_backend, run_with_backend, MinerError};
-use ai_pow_miner::search::{CpuSearchBackend, SearchBackend};
+use ai_pow_miner::search::{CpuSearchBackend, MeteredSearchBackend, SearchBackend};
 use clap::{Args as ClapArgs, Parser};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -89,14 +89,16 @@ fn search_backend(args: &Args) -> Result<Arc<dyn SearchBackend>, String> {
             gpu_batch_attempts = backend.batch_attempts(),
             "ai-pow-mine: CUDA search enabled"
         );
-        return Ok(Arc::new(backend));
+        return Ok(MeteredSearchBackend::new("cuda", Arc::new(backend)));
     }
     let workers = args
         .common
         .mining_threads()
         .map_err(|error| error.to_string())?;
     CpuSearchBackend::new(workers)
-        .map(|backend| Arc::new(backend) as Arc<dyn SearchBackend>)
+        .map(|backend| {
+            MeteredSearchBackend::new("cpu", Arc::new(backend)) as Arc<dyn SearchBackend>
+        })
         .map_err(|error| error.to_string())
 }
 

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -38,9 +38,9 @@ use std::process::ExitCode;
 use std::sync::Arc;
 
 use ai_pow_miner::cli::{init_tracing, CommonArgs};
-use ai_pow_miner::run::{run, run_canonical_with_backend, MinerError};
+use ai_pow_miner::run::{run_canonical_with_backend, run_with_backend, MinerError};
 use ai_pow_miner::search::{CpuSearchBackend, SearchBackend};
-use clap::Parser;
+use clap::{Args as ClapArgs, Parser};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -54,6 +54,50 @@ use tracing::{error, info};
 struct Args {
     #[command(flatten)]
     common: CommonArgs,
+
+    #[command(flatten)]
+    accelerator: AcceleratorArgs,
+}
+
+#[derive(ClapArgs, Debug)]
+struct AcceleratorArgs {
+    /// Use CUDA for Pearl opened-tile GEMM search.
+    #[cfg(feature = "gpu")]
+    #[arg(long)]
+    gpu: bool,
+
+    /// CUDA device ordinal. The current backend supports device 0.
+    #[cfg(feature = "gpu")]
+    #[arg(long, default_value_t = 0)]
+    cuda_device: usize,
+
+    /// Attempts dispatched through CUDA before the scheduler checks cancellation.
+    #[cfg(feature = "gpu")]
+    #[arg(long, default_value_t = 256)]
+    gpu_batch_attempts: u64,
+}
+
+fn search_backend(args: &Args) -> Result<Arc<dyn SearchBackend>, String> {
+    #[cfg(feature = "gpu")]
+    if args.accelerator.gpu {
+        let backend = ai_pow_miner::gpu::GpuSearchBackend::new(
+            args.accelerator.cuda_device, args.accelerator.gpu_batch_attempts,
+        )
+        .map_err(|error| error.to_string())?;
+        info!(
+            cuda_device = backend.device_ordinal(),
+            gpu_batch_attempts = backend.batch_attempts(),
+            "ai-pow-mine: CUDA search enabled"
+        );
+        return Ok(Arc::new(backend));
+    }
+    let workers = args
+        .common
+        .mining_threads()
+        .map_err(|error| error.to_string())?;
+    CpuSearchBackend::new(workers)
+        .map(|backend| Arc::new(backend) as Arc<dyn SearchBackend>)
+        .map_err(|error| error.to_string())
 }
 
 fn main() -> ExitCode {
@@ -72,10 +116,10 @@ fn main() -> ExitCode {
     };
 
     let result = if args.common.canonical {
-        let mining_threads = match args.common.mining_threads() {
-            Ok(threads) => threads,
+        let backend = match search_backend(&args) {
+            Ok(backend) => backend,
             Err(error) => {
-                eprintln!("ai-pow-mine: invalid search config: {error:#}");
+                eprintln!("ai-pow-mine: cannot initialize search backend: {error}");
                 return ExitCode::from(1);
             }
         };
@@ -86,16 +130,9 @@ fn main() -> ExitCode {
                 return ExitCode::from(1);
             }
         };
-        let backend: Arc<dyn SearchBackend> = match CpuSearchBackend::new(mining_threads) {
-            Ok(backend) => Arc::new(backend),
-            Err(error) => {
-                eprintln!("ai-pow-mine: cannot initialize search backend: {error}");
-                return ExitCode::from(1);
-            }
-        };
         let node_addr = args.common.node_addr.clone();
         rt.block_on(async move {
-            info!(node = %node_addr, "ai-pow-mine: starting (canonical, gateway-free CPU miner)");
+            info!(node = %node_addr, "ai-pow-mine: starting canonical miner");
             let shutdown = CancellationToken::new();
             let shutdown_clone = shutdown.clone();
             tokio::spawn(async move {
@@ -111,6 +148,13 @@ fn main() -> ExitCode {
             Ok(cfg) => cfg,
             Err(error) => {
                 eprintln!("ai-pow-mine: invalid puzzle config: {error:#}");
+                return ExitCode::from(1);
+            }
+        };
+        let backend = match search_backend(&args) {
+            Ok(backend) => backend,
+            Err(error) => {
+                eprintln!("ai-pow-mine: cannot initialize search backend: {error}");
                 return ExitCode::from(1);
             }
         };
@@ -130,7 +174,7 @@ fn main() -> ExitCode {
                     shutdown_clone.cancel();
                 }
             });
-            run(cfg, shutdown).await
+            run_with_backend(cfg, shutdown, backend).await
         })
     };
 

--- a/crates/ai-pow-miner/src/canonical.rs
+++ b/crates/ai-pow-miner/src/canonical.rs
@@ -323,12 +323,15 @@ impl PreparedCanonicalMoeTemplate {
         }
     }
 
-    /// Recompute the complete attempt-dependent canonical transcript in reusable storage.
-    pub fn evaluate(
+    /// Recompute attempt-dependent commitments and noised opened strips.
+    ///
+    /// Search backends can upload the resulting strips to an accelerator. The
+    /// storage belongs to `scratch` and is overwritten by the next attempt.
+    pub fn prepare_attempt(
         &self,
         extranonce: u32,
         scratch: &mut PreparedCanonicalMoeScratch,
-    ) -> CanonicalMoeSearchResult {
+    ) -> PearlWorkCommitments {
         let header = self.header_for(extranonce);
         let kappa = pearl_kappa(&header.to_bytes(), &self.mu);
         let (h_a, h_b) = pearl_matrix_commitments(&self.a, &self.b, &kappa);
@@ -355,6 +358,31 @@ impl PreparedCanonicalMoeTemplate {
                 *out = (value as i16 + noise as i16) as i8;
             }
         }
+        PearlWorkCommitments {
+            kappa,
+            h_a,
+            h_b,
+            s_a,
+            s_b,
+        }
+    }
+
+    /// Opened noised strips produced by [`Self::prepare_attempt`].
+    pub fn prepared_strips<'a>(
+        &self,
+        scratch: &'a PreparedCanonicalMoeScratch,
+    ) -> (&'a [i8], &'a [i8]) {
+        (&scratch.a_prime_rows, &scratch.b_prime_cols)
+    }
+
+    /// Recompute the complete attempt-dependent canonical transcript in reusable storage.
+    pub fn evaluate(
+        &self,
+        extranonce: u32,
+        scratch: &mut PreparedCanonicalMoeScratch,
+    ) -> CanonicalMoeSearchResult {
+        let commitments = self.prepare_attempt(extranonce, scratch);
+        let k = self.params.k as usize;
         let tile_state = compute_pattern_tile_state_from_slices(
             &scratch.a_prime_rows,
             &scratch.b_prime_cols,
@@ -365,17 +393,10 @@ impl PreparedCanonicalMoeTemplate {
             k,
             &mut scratch.tile,
         );
-        let commitments = PearlWorkCommitments {
-            kappa,
-            h_a,
-            h_b,
-            s_a,
-            s_b,
-        };
         CanonicalMoeSearchResult {
             commitments,
             tile_state,
-            jackpot_hash: pearl_jackpot_hash(&tile_state, &s_a),
+            jackpot_hash: pearl_jackpot_hash(&tile_state, &commitments.s_a),
         }
     }
 

--- a/crates/ai-pow-miner/src/canonical.rs
+++ b/crates/ai-pow-miner/src/canonical.rs
@@ -726,6 +726,44 @@ pub(crate) fn prove_canonical_moe_block_at_for_miner(
     nock_commit: [u8; 32],
     extranonce: u32,
 ) -> Result<CanonicalBlock, CanonicalProveError> {
+    prove_canonical_moe_block_at_inner(params, hw, e, top_k, nock_commit, extranonce)
+        .map(|(block, _)| block)
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prove_canonical_moe_block_at_with_verifier_context(
+    params: &MatmulParams,
+    hw: u32,
+    e: usize,
+    top_k: usize,
+    nock_commit: [u8; 32],
+    extranonce: u32,
+) -> Result<
+    (
+        CanonicalBlock,
+        ai_pow_zk::recursion::AiPowCompactBatchVerifierContext,
+    ),
+    CanonicalProveError,
+> {
+    prove_canonical_moe_block_at_inner(params, hw, e, top_k, nock_commit, extranonce)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prove_canonical_moe_block_at_inner(
+    params: &MatmulParams,
+    hw: u32,
+    e: usize,
+    top_k: usize,
+    nock_commit: [u8; 32],
+    extranonce: u32,
+) -> Result<
+    (
+        CanonicalBlock,
+        ai_pow_zk::recursion::AiPowCompactBatchVerifierContext,
+    ),
+    CanonicalProveError,
+> {
     let CanonicalMoeInputs {
         a,
         b,
@@ -750,7 +788,7 @@ pub(crate) fn prove_canonical_moe_block_at_for_miner(
 
     let PearlMoeCompactProveRun {
         compact_cert,
-        verifier_context: _,
+        verifier_context,
         pis,
         zk_params,
         trace_height,
@@ -798,14 +836,17 @@ pub(crate) fn prove_canonical_moe_block_at_for_miner(
         routing_data: routing.routing_data.clone(),
     };
 
-    Ok(CanonicalBlock {
-        statement,
-        aux_inclusion,
-        moe_art,
-        certificate,
-        commit: nock_commit,
-        jackpot_hash: ticket.jackpot_hash,
-    })
+    Ok((
+        CanonicalBlock {
+            statement,
+            aux_inclusion,
+            moe_art,
+            certificate,
+            commit: nock_commit,
+            jackpot_hash: ticket.jackpot_hash,
+        },
+        verifier_context,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/ai-pow-miner/src/canonical.rs
+++ b/crates/ai-pow-miner/src/canonical.rs
@@ -280,6 +280,35 @@ impl PreparedCanonicalMoeTemplate {
         &self.aux_inclusion
     }
 
+    /// Fixed canonical inputs used to derive Pearl V3 commitments on an accelerator.
+    ///
+    /// The returned values are immutable for this template. Attempt-dependent
+    /// values, including `kappa`, matrix commitments, seeds, and noised strips,
+    /// must still be derived for every extranonce.
+    pub fn gpu_inputs(
+        &self,
+    ) -> (
+        &[i8],
+        &[i8],
+        &[u8],
+        &[u8],
+        &[u32],
+        &[u32],
+        [u8; ai_pow::pearl_compat::PEARL_INCOMPLETE_BLOCK_HEADER_SIZE],
+        [u8; ai_pow::pearl_compat::PEARL_MINING_CONFIG_SIZE],
+    ) {
+        (
+            &self.a,
+            &self.b,
+            &self.routing_data,
+            &self.routing_offsets,
+            &self.outer_indices,
+            &self.b_cols_global,
+            self.header.to_bytes(),
+            self.mu,
+        )
+    }
+
     pub fn scratch(&self) -> PreparedCanonicalMoeScratch {
         let k = self.params.k as usize;
         PreparedCanonicalMoeScratch {

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -471,18 +471,51 @@ mod tests {
         let template = PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x42; 32])
             .expect("canonical template");
         let session = CudaSession::canonical(&template, 4).expect("CUDA V3 session");
-        let debug = session.debug_canonical(7).expect("CUDA V3 evaluation");
-        let mut scratch = template.scratch();
-        let scalar = template.evaluate(7, &mut scratch);
-        let (a_rows, b_cols) = template.prepared_strips(&scratch);
-        assert_eq!(debug.kappa, scalar.commitments.kappa);
-        assert_eq!(debug.h_a, scalar.commitments.h_a);
-        assert_eq!(debug.h_b, scalar.commitments.h_b);
-        assert_eq!(debug.s_a, scalar.commitments.s_a);
-        assert_eq!(debug.s_b, scalar.commitments.s_b);
-        assert_eq!(&debug.a_rows, a_rows);
-        assert_eq!(&debug.b_cols, b_cols);
-        assert_eq!(TileState(debug.state), scalar.tile_state);
-        assert_eq!(debug.jackpot, scalar.jackpot_hash);
+        for extranonce in [0, 1, 7, u32::MAX - 1, u32::MAX] {
+            let debug = session
+                .debug_canonical(extranonce)
+                .expect("CUDA V3 evaluation");
+            let mut scratch = template.scratch();
+            let scalar = template.evaluate(extranonce, &mut scratch);
+            let (a_rows, b_cols) = template.prepared_strips(&scratch);
+            assert_eq!(debug.kappa, scalar.commitments.kappa);
+            assert_eq!(debug.h_a, scalar.commitments.h_a);
+            assert_eq!(debug.h_b, scalar.commitments.h_b);
+            assert_eq!(debug.s_a, scalar.commitments.s_a);
+            assert_eq!(debug.s_b, scalar.commitments.s_b);
+            assert_eq!(&debug.a_rows, a_rows);
+            assert_eq!(&debug.b_cols, b_cols);
+            assert_eq!(TileState(debug.state), scalar.tile_state);
+            assert_eq!(debug.jackpot, scalar.jackpot_hash);
+        }
+    }
+
+    #[test]
+    fn canonical_search_obeys_targets_and_lowest_winner_order() {
+        let template = Arc::new(
+            PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x24; 32])
+                .expect("canonical template"),
+        );
+        let backend = GpuSearchBackend::new(0, 4).expect("GPU backend");
+        let winner = backend
+            .search_canonical(
+                Arc::clone(&template),
+                SearchBatch::new(41, 4, [u8::MAX; 32]).expect("maximum target batch"),
+            )
+            .expect("maximum target search")
+            .expect("ordinal zero is a winner");
+        assert_eq!(winner.ordinal, 41);
+        assert_eq!(
+            winner.jackpot_hash,
+            template.evaluate(41, &mut template.scratch()).jackpot_hash
+        );
+
+        assert!(backend
+            .search_canonical(
+                template,
+                SearchBatch::new(45, 4, [0; 32]).expect("zero target batch"),
+            )
+            .expect("zero target search")
+            .is_none());
     }
 }

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -11,6 +11,7 @@ use ai_pow::matmul::TileState;
 use ai_pow::pearl_compat::pearl_jackpot_hash;
 use ai_pow::tile_hash::hash_le_target;
 use anyhow::{bail, Result};
+use rayon::prelude::*;
 
 use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
 
@@ -169,18 +170,26 @@ impl SearchBackend for GpuSearchBackend {
         let w = config.cols_pattern.size()? as usize;
         let k = params.k as usize;
         let rank = params.noise_rank as usize;
+        let attempt_bytes_a = h * k;
+        let attempt_bytes_b = w * k;
         let dot = config.dot_product_length()? as usize;
-        let mut all_a = Vec::with_capacity(attempts * h * k);
-        let mut all_b = Vec::with_capacity(attempts * w * k);
-        let mut scratch = template.scratch();
-        for ordinal in batch.start..batch.end_exclusive() {
-            let (row, col) = template
-                .offsets_at_ordinal(ordinal)
-                .ok_or(SearchBackendError::DenseOrdinalOutOfRange(ordinal))?;
-            let (a, b) = template.prepare_offset(row, col, &mut scratch)?;
-            all_a.extend_from_slice(a);
-            all_b.extend_from_slice(b);
-        }
+        let mut all_a = vec![0; attempts * attempt_bytes_a];
+        let mut all_b = vec![0; attempts * attempt_bytes_b];
+        all_a
+            .par_chunks_mut(attempt_bytes_a)
+            .zip(all_b.par_chunks_mut(attempt_bytes_b))
+            .enumerate()
+            .try_for_each(|(offset, (destination_a, destination_b))| {
+                let ordinal = batch.start + offset as u64;
+                let (row, col) = template
+                    .offsets_at_ordinal(ordinal)
+                    .ok_or(SearchBackendError::DenseOrdinalOutOfRange(ordinal))?;
+                let mut scratch = template.scratch();
+                let (a, b) = template.prepare_offset(row, col, &mut scratch)?;
+                destination_a.copy_from_slice(a);
+                destination_b.copy_from_slice(b);
+                Ok::<_, SearchBackendError>(())
+            })?;
         let states =
             CudaBatchSession::new(attempts, h, w, k, rank, dot)?.run(&all_a, &all_b, attempts)?;
         for (offset, state) in states.iter().enumerate() {
@@ -211,19 +220,28 @@ impl SearchBackend for GpuSearchBackend {
         let w = local_b.len();
         let k = config.common_dim as usize;
         let rank = config.rank as usize;
-        let mut all_a = Vec::with_capacity(attempts * h * k);
-        let mut all_b = Vec::with_capacity(attempts * w * k);
-        let mut keys = Vec::with_capacity(attempts);
-        let mut scratch = template.scratch();
-        for ordinal in batch.start..batch.end_exclusive() {
-            let extranonce = u32::try_from(ordinal)
-                .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
-            let commitments = template.prepare_attempt(extranonce, &mut scratch);
-            let (a, b) = template.prepared_strips(&scratch);
-            all_a.extend_from_slice(a);
-            all_b.extend_from_slice(b);
-            keys.push(commitments.s_a);
-        }
+        let attempt_bytes_a = h * k;
+        let attempt_bytes_b = w * k;
+        let mut all_a = vec![0; attempts * attempt_bytes_a];
+        let mut all_b = vec![0; attempts * attempt_bytes_b];
+        let mut keys = vec![[0; 32]; attempts];
+        all_a
+            .par_chunks_mut(attempt_bytes_a)
+            .zip(all_b.par_chunks_mut(attempt_bytes_b))
+            .zip(keys.par_iter_mut())
+            .enumerate()
+            .try_for_each(|(offset, ((destination_a, destination_b), key))| {
+                let ordinal = batch.start + offset as u64;
+                let extranonce = u32::try_from(ordinal)
+                    .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
+                let mut scratch = template.scratch();
+                let commitments = template.prepare_attempt(extranonce, &mut scratch);
+                let (a, b) = template.prepared_strips(&scratch);
+                destination_a.copy_from_slice(a);
+                destination_b.copy_from_slice(b);
+                *key = commitments.s_a;
+                Ok::<_, SearchBackendError>(())
+            })?;
         let states =
             CudaBatchSession::new(attempts, h, w, k, rank, k)?.run(&all_a, &all_b, attempts)?;
         for (offset, (state, key)) in states.iter().zip(&keys).enumerate() {
@@ -236,6 +254,10 @@ impl SearchBackend for GpuSearchBackend {
             }
         }
         Ok(None)
+    }
+
+    fn batch_attempts(&self) -> u64 {
+        self.batch_attempts
     }
 }
 

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -1,8 +1,8 @@
-//! CUDA GEMM search backend.
+//! CUDA Pearl V3 search backend.
 //!
-//! Rust owns Pearl V3 transcript derivation, salted seeds, noise, scheduling,
-//! target checks, and scalar winner rechecks. CUDA computes batches of opened
-//! noised GEMMs and Pearl rolling tile states in one launch.
+//! The canonical path derives commitments, noised opened strips, rolling tile
+//! state, jackpot hashes, target comparisons, and the lowest winner on the GPU.
+//! Rust validates every reported winner before proof construction.
 
 use std::ffi::{c_int, c_void};
 use std::sync::{Arc, Mutex};
@@ -13,7 +13,10 @@ use ai_pow::tile_hash::hash_le_target;
 use anyhow::{bail, Result};
 use rayon::prelude::*;
 
+use crate::canonical::PreparedCanonicalMoeTemplate;
 use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
+
+const NO_WINNER: u32 = u32::MAX;
 
 unsafe extern "C" {
     fn ai_pow_cuda_session_create(
@@ -33,22 +36,69 @@ unsafe extern "C" {
         states_out: *mut i32,
     ) -> c_int;
     fn ai_pow_cuda_session_destroy(session: *mut c_void) -> c_int;
+    fn ai_pow_cuda_v3_session_create(
+        max_attempts: u32,
+        a_matrix: *const i8,
+        b_matrix: *const i8,
+        sigma: *const u8,
+        mu: *const u8,
+        routing_data: *const u8,
+        routing_data_len: u32,
+        routing_offsets: *const u8,
+        routing_offsets_len: u32,
+        row_indices: *const u32,
+        col_indices: *const u32,
+        session_out: *mut *mut c_void,
+    ) -> c_int;
+    fn ai_pow_cuda_v3_session_search(
+        session: *mut c_void,
+        extranonce_start: u32,
+        attempts: u32,
+        target: *const u8,
+        winner_local: *mut u32,
+        jackpot_out: *mut u8,
+    ) -> c_int;
+    fn ai_pow_cuda_v3_session_destroy(session: *mut c_void) -> c_int;
+    #[cfg(test)]
+    fn ai_pow_cuda_v3_session_debug(
+        session: *mut c_void,
+        extranonce: u32,
+        kappa: *mut u8,
+        h_a: *mut u8,
+        h_b: *mut u8,
+        s_a: *mut u8,
+        s_b: *mut u8,
+        a_rows: *mut i8,
+        b_cols: *mut i8,
+        state: *mut i32,
+        jackpot: *mut u8,
+    ) -> c_int;
 }
 
 #[derive(Debug)]
 pub struct GpuSearchBackend {
     device_ordinal: usize,
     batch_attempts: u64,
-    dispatch: Mutex<()>,
+    dispatch: Mutex<CanonicalDispatch>,
+}
+
+#[derive(Debug, Default)]
+struct CanonicalDispatch {
+    template: Option<Arc<PreparedCanonicalMoeTemplate>>,
+    session: Option<CudaSession>,
 }
 
 #[derive(Debug)]
-struct CudaBatchSession {
+struct CudaSession {
     raw: *mut c_void,
+    canonical_v3: bool,
 }
 
-impl CudaBatchSession {
-    fn new(
+// Access to the owned CUDA stream and allocations is serialized by `dispatch`.
+unsafe impl Send for CudaSession {}
+
+impl CudaSession {
+    fn generic(
         attempts: usize,
         h: usize,
         w: usize,
@@ -57,8 +107,7 @@ impl CudaBatchSession {
         dot: usize,
     ) -> Result<Self, SearchBackendError> {
         let mut raw = std::ptr::null_mut();
-        // SAFETY: `raw` is writable, and all values are checked before crossing
-        // the ABI. A successful call returns sole ownership of the session.
+        // SAFETY: `raw` is writable. Dimensions are checked before crossing the ABI.
         let status = unsafe {
             ai_pow_cuda_session_create(
                 u32::try_from(attempts).map_err(unavailable)?,
@@ -73,19 +122,54 @@ impl CudaBatchSession {
         if status != 0 {
             return Err(cuda_error("session creation", status));
         }
-        Ok(Self { raw })
+        Ok(Self {
+            raw,
+            canonical_v3: false,
+        })
     }
 
-    fn run(
-        &mut self,
+    fn canonical(
+        template: &PreparedCanonicalMoeTemplate,
+        max_attempts: u32,
+    ) -> Result<Self, SearchBackendError> {
+        let (a, b, routing, offsets, rows, cols, sigma, mu) = template.gpu_inputs();
+        let rows: &[u32; 8] = rows.try_into().map_err(|_| unavailable("canonical row count"))?;
+        let cols: &[u32; 8] = cols.try_into().map_err(|_| unavailable("canonical column count"))?;
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: CUDA copies all fixed template inputs before returning.
+        let status = unsafe {
+            ai_pow_cuda_v3_session_create(
+                max_attempts,
+                a.as_ptr(),
+                b.as_ptr(),
+                sigma.as_ptr(),
+                mu.as_ptr(),
+                routing.as_ptr(),
+                u32::try_from(routing.len()).map_err(unavailable)?,
+                offsets.as_ptr(),
+                u32::try_from(offsets.len()).map_err(unavailable)?,
+                rows.as_ptr(),
+                cols.as_ptr(),
+                &mut raw,
+            )
+        };
+        if status != 0 {
+            return Err(cuda_error("V3 session creation", status));
+        }
+        Ok(Self {
+            raw,
+            canonical_v3: true,
+        })
+    }
+
+    fn run_generic(
+        &self,
         a_rows: &[i8],
         b_cols: &[i8],
         attempts: usize,
     ) -> Result<Vec<TileState>, SearchBackendError> {
         let mut words = vec![0i32; attempts * 16];
-        // SAFETY: the session owns device storage sized for `attempts`; both
-        // input slices contain the packed shape passed at creation; the output
-        // holds exactly 16 words per attempt. The call synchronizes its stream.
+        // SAFETY: session dimensions define input lengths and the output has 16 words per attempt.
         let status = unsafe {
             ai_pow_cuda_session_run(
                 self.raw,
@@ -107,13 +191,67 @@ impl CudaBatchSession {
             })
             .collect())
     }
+
+    fn search_canonical(
+        &self,
+        start: u32,
+        attempts: u32,
+        threshold: &[u8; 32],
+    ) -> Result<Option<(u32, [u8; 32])>, SearchBackendError> {
+        let mut local = NO_WINNER;
+        let mut jackpot = [0u8; 32];
+        // SAFETY: all buffers remain valid for the synchronous ABI call.
+        let status = unsafe {
+            ai_pow_cuda_v3_session_search(
+                self.raw,
+                start,
+                attempts,
+                threshold.as_ptr(),
+                &mut local,
+                jackpot.as_mut_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(cuda_error("V3 search", status));
+        }
+        Ok((local != NO_WINNER).then_some((local, jackpot)))
+    }
+
+    #[cfg(test)]
+    fn debug_canonical(&self, extranonce: u32) -> Result<CanonicalDebug, SearchBackendError> {
+        let mut debug = CanonicalDebug::default();
+        // SAFETY: every output buffer has the fixed ABI length.
+        let status = unsafe {
+            ai_pow_cuda_v3_session_debug(
+                self.raw,
+                extranonce,
+                debug.kappa.as_mut_ptr(),
+                debug.h_a.as_mut_ptr(),
+                debug.h_b.as_mut_ptr(),
+                debug.s_a.as_mut_ptr(),
+                debug.s_b.as_mut_ptr(),
+                debug.a_rows.as_mut_ptr(),
+                debug.b_cols.as_mut_ptr(),
+                debug.state.as_mut_ptr(),
+                debug.jackpot.as_mut_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(cuda_error("V3 debug evaluation", status));
+        }
+        Ok(debug)
+    }
 }
 
-impl Drop for CudaBatchSession {
+impl Drop for CudaSession {
     fn drop(&mut self) {
         // SAFETY: `raw` is owned by this value and destroyed exactly once.
         unsafe {
-            ai_pow_cuda_session_destroy(self.raw);
+            if self.canonical_v3 {
+                ai_pow_cuda_v3_session_destroy(self.raw);
+            } else {
+                ai_pow_cuda_session_destroy(self.raw);
+            }
         }
     }
 }
@@ -132,7 +270,7 @@ impl GpuSearchBackend {
         Ok(Self {
             device_ordinal,
             batch_attempts,
-            dispatch: Mutex::new(()),
+            dispatch: Mutex::new(CanonicalDispatch::default()),
         })
     }
 
@@ -159,10 +297,6 @@ impl SearchBackend for GpuSearchBackend {
         template: Arc<ai_pow::pearl_compat::PreparedPearlPatternJob>,
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError> {
-        let _guard = self
-            .dispatch
-            .lock()
-            .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
         let attempts = usize::try_from(batch.len).map_err(unavailable)?;
         let params = template.params();
         let config = template.config();
@@ -190,8 +324,8 @@ impl SearchBackend for GpuSearchBackend {
                 destination_b.copy_from_slice(b);
                 Ok::<_, SearchBackendError>(())
             })?;
-        let states =
-            CudaBatchSession::new(attempts, h, w, k, rank, dot)?.run(&all_a, &all_b, attempts)?;
+        let session = CudaSession::generic(attempts, h, w, k, rank, dot)?;
+        let states = session.run_generic(&all_a, &all_b, attempts)?;
         for (offset, state) in states.iter().enumerate() {
             let jackpot = pearl_jackpot_hash(state, &template.commitments().s_a);
             if hash_le_target(&jackpot, &batch.threshold) {
@@ -206,54 +340,63 @@ impl SearchBackend for GpuSearchBackend {
 
     fn search_canonical(
         &self,
-        template: Arc<crate::canonical::PreparedCanonicalMoeTemplate>,
+        template: Arc<PreparedCanonicalMoeTemplate>,
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError> {
-        let _guard = self
+        let start = u32::try_from(batch.start)
+            .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(batch.start))?;
+        let attempts = u32::try_from(batch.len).map_err(unavailable)?;
+        if u64::from(start) + u64::from(attempts) > u64::from(u32::MAX) + 1 {
+            return Err(SearchBackendError::CanonicalOrdinalOutOfRange(
+                batch.end_exclusive() - 1,
+            ));
+        }
+        let mut dispatch = self
             .dispatch
             .lock()
             .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
-        let attempts = usize::try_from(batch.len).map_err(unavailable)?;
-        let config = template.config();
-        let (_, inner, local_b, _, _) = template.schedule();
-        let h = inner.len();
-        let w = local_b.len();
-        let k = config.common_dim as usize;
-        let rank = config.rank as usize;
-        let attempt_bytes_a = h * k;
-        let attempt_bytes_b = w * k;
-        let mut all_a = vec![0; attempts * attempt_bytes_a];
-        let mut all_b = vec![0; attempts * attempt_bytes_b];
-        let mut keys = vec![[0; 32]; attempts];
-        all_a
-            .par_chunks_mut(attempt_bytes_a)
-            .zip(all_b.par_chunks_mut(attempt_bytes_b))
-            .zip(keys.par_iter_mut())
-            .enumerate()
-            .try_for_each(|(offset, ((destination_a, destination_b), key))| {
-                let ordinal = batch.start + offset as u64;
-                let extranonce = u32::try_from(ordinal)
-                    .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
-                let mut scratch = template.scratch();
-                let commitments = template.prepare_attempt(extranonce, &mut scratch);
-                let (a, b) = template.prepared_strips(&scratch);
-                destination_a.copy_from_slice(a);
-                destination_b.copy_from_slice(b);
-                *key = commitments.s_a;
-                Ok::<_, SearchBackendError>(())
-            })?;
-        let states =
-            CudaBatchSession::new(attempts, h, w, k, rank, k)?.run(&all_a, &all_b, attempts)?;
-        for (offset, (state, key)) in states.iter().zip(&keys).enumerate() {
-            let jackpot = pearl_jackpot_hash(state, key);
-            if hash_le_target(&jackpot, &batch.threshold) {
-                return Ok(Some(SearchWinner {
-                    ordinal: batch.start + offset as u64,
-                    jackpot_hash: jackpot,
-                }));
-            }
+        if dispatch
+            .template
+            .as_ref()
+            .is_none_or(|active| !Arc::ptr_eq(active, &template))
+        {
+            dispatch.session = Some(CudaSession::canonical(
+                &template,
+                u32::try_from(self.batch_attempts).map_err(unavailable)?,
+            )?);
+            dispatch.template = Some(Arc::clone(&template));
         }
-        Ok(None)
+        let (local, gpu_jackpot) = match dispatch
+            .session
+            .as_ref()
+            .expect("canonical session is initialized")
+            .search_canonical(start, attempts, &batch.threshold)?
+        {
+            Some(winner) => winner,
+            None => return Ok(None),
+        };
+        if local >= attempts {
+            return Err(SearchBackendError::WinnerOutsideBatch {
+                winner: batch.start + u64::from(local),
+                batch_start: batch.start,
+                batch_end_exclusive: batch.end_exclusive(),
+            });
+        }
+        let ordinal = batch.start + u64::from(local);
+        let extranonce = u32::try_from(ordinal)
+            .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
+        let scalar = template.evaluate(extranonce, &mut template.scratch());
+        if scalar.jackpot_hash != gpu_jackpot
+            || !hash_le_target(&scalar.jackpot_hash, &batch.threshold)
+        {
+            return Err(unavailable(format!(
+                "GPU winner {ordinal} failed Pearl V3 scalar validation"
+            )));
+        }
+        Ok(Some(SearchWinner {
+            ordinal,
+            jackpot_hash: scalar.jackpot_hash,
+        }))
     }
 
     fn batch_attempts(&self) -> u64 {
@@ -262,14 +405,43 @@ impl SearchBackend for GpuSearchBackend {
 }
 
 #[cfg(test)]
+#[derive(Debug)]
+struct CanonicalDebug {
+    kappa: [u8; 32],
+    h_a: [u8; 32],
+    h_b: [u8; 32],
+    s_a: [u8; 32],
+    s_b: [u8; 32],
+    a_rows: [i8; 8192],
+    b_cols: [i8; 8192],
+    state: [i32; 16],
+    jackpot: [u8; 32],
+}
+
+#[cfg(test)]
+impl Default for CanonicalDebug {
+    fn default() -> Self {
+        Self {
+            kappa: [0; 32],
+            h_a: [0; 32],
+            h_b: [0; 32],
+            s_a: [0; 32],
+            s_b: [0; 32],
+            a_rows: [0; 8192],
+            b_cols: [0; 8192],
+            state: [0; 16],
+            jackpot: [0; 32],
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use super::*;
     use ai_pow::params::MatmulParams;
 
-    use super::*;
-
-    #[test]
-    fn canonical_gpu_batch_matches_scalar_oracle() {
-        let params = MatmulParams {
+    fn canonical_params() -> MatmulParams {
+        MatmulParams {
             m: 64,
             k: 1024,
             n: 64,
@@ -277,33 +449,42 @@ mod tests {
             tile: 8,
             spot_checks: 1,
             difficulty_bits: 0,
-        };
-        let template = Arc::new(
-            crate::canonical::PreparedCanonicalMoeTemplate::new(&params, 8, 2, 1, [0x42; 32])
-                .expect("canonical template"),
-        );
-        let expected = template.evaluate(9, &mut template.scratch()).jackpot_hash;
-        let mut threshold = expected;
-        threshold[0] = threshold[0].saturating_add(1);
-        let winner = GpuSearchBackend::new(0, 8)
-            .expect("GPU backend")
-            .search_canonical(
-                Arc::clone(&template),
-                SearchBatch::new(9, 1, threshold).expect("search batch"),
-            )
-            .expect("GPU search")
-            .expect("winner");
+        }
+    }
 
-        assert_eq!(winner.ordinal, 9);
-        assert_eq!(winner.jackpot_hash, expected);
+    #[test]
+    fn rejects_zero_batch() {
+        assert!(GpuSearchBackend::new(0, 0).is_err());
+    }
 
-        let no_winner = GpuSearchBackend::new(0, 8)
-            .expect("GPU backend")
-            .search_canonical(
-                template,
-                SearchBatch::new(7, 8, [0; 32]).expect("search batch"),
-            )
-            .expect("GPU search");
-        assert!(no_winner.is_none());
+    #[test]
+    fn rejects_unsupported_device() {
+        assert!(GpuSearchBackend::new(1, 1).is_err());
+    }
+
+    #[test]
+    fn canonical_v3_device_pipeline_matches_scalar() {
+        let template = PreparedCanonicalMoeTemplate::new(
+            &canonical_params(),
+            8,
+            2,
+            1,
+            [0x42; 32],
+        )
+        .expect("canonical template");
+        let session = CudaSession::canonical(&template, 4).expect("CUDA V3 session");
+        let debug = session.debug_canonical(7).expect("CUDA V3 evaluation");
+        let mut scratch = template.scratch();
+        let scalar = template.evaluate(7, &mut scratch);
+        let (a_rows, b_cols) = template.prepared_strips(&scratch);
+        assert_eq!(debug.kappa, scalar.commitments.kappa);
+        assert_eq!(debug.h_a, scalar.commitments.h_a);
+        assert_eq!(debug.h_b, scalar.commitments.h_b);
+        assert_eq!(debug.s_a, scalar.commitments.s_a);
+        assert_eq!(debug.s_b, scalar.commitments.s_b);
+        assert_eq!(&debug.a_rows, a_rows);
+        assert_eq!(&debug.b_cols, b_cols);
+        assert_eq!(TileState(debug.state), scalar.tile_state);
+        assert_eq!(debug.jackpot, scalar.jackpot_hash);
     }
 }

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -528,4 +528,73 @@ mod tests {
             .expect("zero target search")
             .is_none());
     }
+
+    #[test]
+    #[ignore = "real compact recursive proof generation is opt-in"]
+    fn gpu_winner_builds_and_verifies_production_certificate() {
+        use crate::canonical::prove_canonical_moe_block_at_with_verifier_context;
+        use crate::certificate_noun::{
+            build_ai_pow_pearl_merge_moe_artifact_noun_from_node, verify_ai_pow_block_artifact_jam,
+            AiPowBlockVerifyOutcome, AiProofNode, CertificateNounLimits,
+        };
+
+        let params = canonical_params();
+        let commit = [0x42; 32];
+        let template = Arc::new(
+            PreparedCanonicalMoeTemplate::new(&params, 8, 2, 1, commit)
+                .expect("canonical template"),
+        );
+        let backend = GpuSearchBackend::new(0, 4).expect("GPU backend");
+        let winner = backend
+            .search_canonical(
+                Arc::clone(&template),
+                SearchBatch::new(7, 4, [u8::MAX; 32]).expect("maximum target batch"),
+            )
+            .expect("GPU search")
+            .expect("maximum target accepts the first GPU ticket");
+        assert_eq!(winner.ordinal, 7);
+        assert_eq!(
+            winner.jackpot_hash,
+            template.evaluate(7, &mut template.scratch()).jackpot_hash
+        );
+
+        let (block, verifier_context) =
+            prove_canonical_moe_block_at_with_verifier_context(&params, 8, 2, 1, commit, 7)
+                .expect("compact recursive proof");
+        assert_eq!(block.jackpot_hash, winner.jackpot_hash);
+        let AiProofNode::Bytes(certificate_bytes) = &block.certificate.certificate else {
+            panic!("production compact certificate must use the canonical byte node");
+        };
+        let decoded_certificate =
+            ai_pow_zk::recursion::decode_compact_batch_recursive_certificate(certificate_bytes)
+                .expect("canonical compact certificate bytes");
+        assert_eq!(
+            ai_pow_zk::recursion::encode_compact_batch_recursive_certificate(&decoded_certificate)
+                .expect("encode compact certificate"),
+            *certificate_bytes
+        );
+
+        let artifact = build_ai_pow_pearl_merge_moe_artifact_noun_from_node(
+            &block.statement, &block.aux_inclusion, &block.moe_art, &block.certificate.zk_params,
+            block.certificate.found_idx, block.certificate.trace_height,
+            &block.certificate.commitments, &block.certificate.public_inputs,
+            &block.certificate.certificate,
+        )
+        .expect("production MoE artifact");
+        let expected_digest_bytes =
+            ai_pow_zk::recursion::compact_batch_verifier_key_digest_to_bytes(
+                verifier_context.verifier_key_digest(),
+            );
+        let outcome = verify_ai_pow_block_artifact_jam(
+            &artifact.jam(),
+            CertificateNounLimits::default(),
+            &commit,
+            &[u8::MAX; 32],
+            4096,
+            &verifier_context,
+            &expected_digest_bytes,
+        )
+        .expect("production V3 verifier accepts the GPU winner certificate");
+        assert!(matches!(outcome, AiPowBlockVerifyOutcome::Moe(_)));
+    }
 }

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -75,14 +75,13 @@ unsafe extern "C" {
     ) -> c_int;
 }
 
-#[derive(Debug)]
 pub struct GpuSearchBackend {
     device_ordinal: usize,
     batch_attempts: u64,
     dispatch: Mutex<CanonicalDispatch>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct CanonicalDispatch {
     template: Option<Arc<PreparedCanonicalMoeTemplate>>,
     session: Option<CudaSession>,
@@ -133,8 +132,12 @@ impl CudaSession {
         max_attempts: u32,
     ) -> Result<Self, SearchBackendError> {
         let (a, b, routing, offsets, rows, cols, sigma, mu) = template.gpu_inputs();
-        let rows: &[u32; 8] = rows.try_into().map_err(|_| unavailable("canonical row count"))?;
-        let cols: &[u32; 8] = cols.try_into().map_err(|_| unavailable("canonical column count"))?;
+        let rows: &[u32; 8] = rows
+            .try_into()
+            .map_err(|_| unavailable("canonical row count"))?;
+        let cols: &[u32; 8] = cols
+            .try_into()
+            .map_err(|_| unavailable("canonical column count"))?;
         let mut raw = std::ptr::null_mut();
         // SAFETY: CUDA copies all fixed template inputs before returning.
         let status = unsafe {
@@ -437,8 +440,9 @@ impl Default for CanonicalDebug {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ai_pow::params::MatmulParams;
+
+    use super::*;
 
     fn canonical_params() -> MatmulParams {
         MatmulParams {
@@ -464,14 +468,8 @@ mod tests {
 
     #[test]
     fn canonical_v3_device_pipeline_matches_scalar() {
-        let template = PreparedCanonicalMoeTemplate::new(
-            &canonical_params(),
-            8,
-            2,
-            1,
-            [0x42; 32],
-        )
-        .expect("canonical template");
+        let template = PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x42; 32])
+            .expect("canonical template");
         let session = CudaSession::canonical(&template, 4).expect("CUDA V3 session");
         let debug = session.debug_canonical(7).expect("CUDA V3 evaluation");
         let mut scratch = template.scratch();

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -1,8 +1,8 @@
 //! CUDA GEMM search backend.
 //!
 //! Rust owns Pearl V3 transcript derivation, salted seeds, noise, scheduling,
-//! target checks, and scalar winner rechecks. CUDA computes only the opened
-//! noised GEMM and Pearl rolling tile state.
+//! target checks, and scalar winner rechecks. CUDA computes batches of opened
+//! noised GEMMs and Pearl rolling tile states in one launch.
 
 use std::ffi::{c_int, c_void};
 use std::sync::{Arc, Mutex};
@@ -15,17 +15,23 @@ use anyhow::{bail, Result};
 use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
 
 unsafe extern "C" {
-    fn ai_pow_cuda_tile_state(
-        a_rows: *const i8,
-        b_cols: *const i8,
+    fn ai_pow_cuda_session_create(
+        max_attempts: u32,
         h: u32,
         w: u32,
         k: u32,
         rank: u32,
         dot_product_len: u32,
-        state_out: *mut i32,
-        stream: *mut c_void,
+        session_out: *mut *mut c_void,
     ) -> c_int;
+    fn ai_pow_cuda_session_run(
+        session: *mut c_void,
+        a_rows: *const i8,
+        b_cols: *const i8,
+        attempts: u32,
+        states_out: *mut i32,
+    ) -> c_int;
+    fn ai_pow_cuda_session_destroy(session: *mut c_void) -> c_int;
 }
 
 #[derive(Debug)]
@@ -35,6 +41,82 @@ pub struct GpuSearchBackend {
     dispatch: Mutex<()>,
 }
 
+#[derive(Debug)]
+struct CudaBatchSession {
+    raw: *mut c_void,
+}
+
+impl CudaBatchSession {
+    fn new(
+        attempts: usize,
+        h: usize,
+        w: usize,
+        k: usize,
+        rank: usize,
+        dot: usize,
+    ) -> Result<Self, SearchBackendError> {
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: `raw` is writable, and all values are checked before crossing
+        // the ABI. A successful call returns sole ownership of the session.
+        let status = unsafe {
+            ai_pow_cuda_session_create(
+                u32::try_from(attempts).map_err(unavailable)?,
+                u32::try_from(h).map_err(unavailable)?,
+                u32::try_from(w).map_err(unavailable)?,
+                u32::try_from(k).map_err(unavailable)?,
+                u32::try_from(rank).map_err(unavailable)?,
+                u32::try_from(dot).map_err(unavailable)?,
+                &mut raw,
+            )
+        };
+        if status != 0 {
+            return Err(cuda_error("session creation", status));
+        }
+        Ok(Self { raw })
+    }
+
+    fn run(
+        &mut self,
+        a_rows: &[i8],
+        b_cols: &[i8],
+        attempts: usize,
+    ) -> Result<Vec<TileState>, SearchBackendError> {
+        let mut words = vec![0i32; attempts * 16];
+        // SAFETY: the session owns device storage sized for `attempts`; both
+        // input slices contain the packed shape passed at creation; the output
+        // holds exactly 16 words per attempt. The call synchronizes its stream.
+        let status = unsafe {
+            ai_pow_cuda_session_run(
+                self.raw,
+                a_rows.as_ptr(),
+                b_cols.as_ptr(),
+                u32::try_from(attempts).map_err(unavailable)?,
+                words.as_mut_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(cuda_error("batch execution", status));
+        }
+        Ok(words
+            .chunks_exact(16)
+            .map(|chunk| {
+                let mut state = [0i32; 16];
+                state.copy_from_slice(chunk);
+                TileState(state)
+            })
+            .collect())
+    }
+}
+
+impl Drop for CudaBatchSession {
+    fn drop(&mut self) {
+        // SAFETY: `raw` is owned by this value and destroyed exactly once.
+        unsafe {
+            ai_pow_cuda_session_destroy(self.raw);
+        }
+    }
+}
+
 impl GpuSearchBackend {
     pub fn new(device_ordinal: usize, batch_attempts: u64) -> Result<Self> {
         if batch_attempts == 0 {
@@ -42,6 +124,9 @@ impl GpuSearchBackend {
         }
         if device_ordinal != 0 {
             bail!("the GPU backend currently supports CUDA device 0 only");
+        }
+        if batch_attempts > u64::from(u32::MAX) {
+            bail!("--gpu-batch-attempts must fit in u32");
         }
         Ok(Self {
             device_ordinal,
@@ -57,43 +142,14 @@ impl GpuSearchBackend {
     pub const fn batch_attempts(&self) -> u64 {
         self.batch_attempts
     }
-
-    fn tile_state(
-        a_rows: &[i8],
-        b_cols: &[i8],
-        h: usize,
-        w: usize,
-        k: usize,
-        rank: usize,
-        dot: usize,
-    ) -> Result<TileState, SearchBackendError> {
-        let mut state = [0i32; 16];
-        // SAFETY: prepared templates validate every shape and slice length. The
-        // C wrapper synchronizes before returning and does not retain pointers.
-        let status = unsafe {
-            ai_pow_cuda_tile_state(
-                a_rows.as_ptr(),
-                b_cols.as_ptr(),
-                u32::try_from(h).map_err(unavailable)?,
-                u32::try_from(w).map_err(unavailable)?,
-                u32::try_from(k).map_err(unavailable)?,
-                u32::try_from(rank).map_err(unavailable)?,
-                u32::try_from(dot).map_err(unavailable)?,
-                state.as_mut_ptr(),
-                std::ptr::null_mut(),
-            )
-        };
-        if status != 0 {
-            return Err(SearchBackendError::BackendUnavailable(format!(
-                "CUDA tile kernel failed with error {status}"
-            )));
-        }
-        Ok(TileState(state))
-    }
 }
 
 fn unavailable(error: impl std::fmt::Display) -> SearchBackendError {
     SearchBackendError::BackendUnavailable(error.to_string())
+}
+
+fn cuda_error(operation: &str, status: c_int) -> SearchBackendError {
+    unavailable(format!("CUDA {operation} failed with error {status}"))
 }
 
 impl SearchBackend for GpuSearchBackend {
@@ -106,24 +162,32 @@ impl SearchBackend for GpuSearchBackend {
             .dispatch
             .lock()
             .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
+        let attempts = usize::try_from(batch.len).map_err(unavailable)?;
         let params = template.params();
         let config = template.config();
         let h = config.rows_pattern.size()? as usize;
         let w = config.cols_pattern.size()? as usize;
+        let k = params.k as usize;
+        let rank = params.noise_rank as usize;
         let dot = config.dot_product_length()? as usize;
+        let mut all_a = Vec::with_capacity(attempts * h * k);
+        let mut all_b = Vec::with_capacity(attempts * w * k);
         let mut scratch = template.scratch();
         for ordinal in batch.start..batch.end_exclusive() {
             let (row, col) = template
                 .offsets_at_ordinal(ordinal)
                 .ok_or(SearchBackendError::DenseOrdinalOutOfRange(ordinal))?;
             let (a, b) = template.prepare_offset(row, col, &mut scratch)?;
-            let state = Self::tile_state(
-                a, b, h, w, params.k as usize, params.noise_rank as usize, dot,
-            )?;
-            let jackpot = pearl_jackpot_hash(&state, &template.commitments().s_a);
+            all_a.extend_from_slice(a);
+            all_b.extend_from_slice(b);
+        }
+        let states =
+            CudaBatchSession::new(attempts, h, w, k, rank, dot)?.run(&all_a, &all_b, attempts)?;
+        for (offset, state) in states.iter().enumerate() {
+            let jackpot = pearl_jackpot_hash(state, &template.commitments().s_a);
             if hash_le_target(&jackpot, &batch.threshold) {
                 return Ok(Some(SearchWinner {
-                    ordinal,
+                    ordinal: batch.start + offset as u64,
                     jackpot_hash: jackpot,
                 }));
             }
@@ -140,23 +204,33 @@ impl SearchBackend for GpuSearchBackend {
             .dispatch
             .lock()
             .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
+        let attempts = usize::try_from(batch.len).map_err(unavailable)?;
         let config = template.config();
         let (_, inner, local_b, _, _) = template.schedule();
         let h = inner.len();
         let w = local_b.len();
         let k = config.common_dim as usize;
         let rank = config.rank as usize;
+        let mut all_a = Vec::with_capacity(attempts * h * k);
+        let mut all_b = Vec::with_capacity(attempts * w * k);
+        let mut keys = Vec::with_capacity(attempts);
         let mut scratch = template.scratch();
         for ordinal in batch.start..batch.end_exclusive() {
             let extranonce = u32::try_from(ordinal)
                 .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
             let commitments = template.prepare_attempt(extranonce, &mut scratch);
             let (a, b) = template.prepared_strips(&scratch);
-            let state = Self::tile_state(a, b, h, w, k, rank, k)?;
-            let jackpot = pearl_jackpot_hash(&state, &commitments.s_a);
+            all_a.extend_from_slice(a);
+            all_b.extend_from_slice(b);
+            keys.push(commitments.s_a);
+        }
+        let states =
+            CudaBatchSession::new(attempts, h, w, k, rank, k)?.run(&all_a, &all_b, attempts)?;
+        for (offset, (state, key)) in states.iter().zip(&keys).enumerate() {
+            let jackpot = pearl_jackpot_hash(state, key);
             if hash_le_target(&jackpot, &batch.threshold) {
                 return Ok(Some(SearchWinner {
-                    ordinal,
+                    ordinal: batch.start + offset as u64,
                     jackpot_hash: jackpot,
                 }));
             }
@@ -172,7 +246,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn canonical_gpu_search_matches_scalar_oracle() {
+    fn canonical_gpu_batch_matches_scalar_oracle() {
         let params = MatmulParams {
             m: 64,
             k: 1024,
@@ -186,17 +260,28 @@ mod tests {
             crate::canonical::PreparedCanonicalMoeTemplate::new(&params, 8, 2, 1, [0x42; 32])
                 .expect("canonical template"),
         );
-        let expected = template.evaluate(7, &mut template.scratch()).jackpot_hash;
-        let winner = GpuSearchBackend::new(0, 1)
+        let expected = template.evaluate(9, &mut template.scratch()).jackpot_hash;
+        let mut threshold = expected;
+        threshold[0] = threshold[0].saturating_add(1);
+        let winner = GpuSearchBackend::new(0, 8)
             .expect("GPU backend")
             .search_canonical(
-                template,
-                SearchBatch::new(7, 1, [0xff; 32]).expect("search batch"),
+                Arc::clone(&template),
+                SearchBatch::new(9, 1, threshold).expect("search batch"),
             )
             .expect("GPU search")
             .expect("winner");
 
-        assert_eq!(winner.ordinal, 7);
+        assert_eq!(winner.ordinal, 9);
         assert_eq!(winner.jackpot_hash, expected);
+
+        let no_winner = GpuSearchBackend::new(0, 8)
+            .expect("GPU backend")
+            .search_canonical(
+                template,
+                SearchBatch::new(7, 8, [0; 32]).expect("search batch"),
+            )
+            .expect("GPU search");
+        assert!(no_winner.is_none());
     }
 }

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -491,29 +491,39 @@ mod tests {
     }
 
     #[test]
-    fn canonical_search_obeys_targets_and_lowest_winner_order() {
-        let template = Arc::new(
+    fn canonical_search_obeys_targets_and_session_lifetime() {
+        let first = Arc::new(
             PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x24; 32])
-                .expect("canonical template"),
+                .expect("first canonical template"),
+        );
+        let second = Arc::new(
+            PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x25; 32])
+                .expect("second canonical template"),
         );
         let backend = GpuSearchBackend::new(0, 4).expect("GPU backend");
-        let winner = backend
-            .search_canonical(
-                Arc::clone(&template),
-                SearchBatch::new(41, 4, [u8::MAX; 32]).expect("maximum target batch"),
-            )
-            .expect("maximum target search")
-            .expect("ordinal zero is a winner");
-        assert_eq!(winner.ordinal, 41);
-        assert_eq!(
-            winner.jackpot_hash,
-            template.evaluate(41, &mut template.scratch()).jackpot_hash
-        );
+        for (template, start) in
+            [(Arc::clone(&first), 41), (Arc::clone(&first), 45), (Arc::clone(&second), 49)]
+        {
+            let winner = backend
+                .search_canonical(
+                    Arc::clone(&template),
+                    SearchBatch::new(start, 4, [u8::MAX; 32]).expect("maximum target batch"),
+                )
+                .expect("maximum target search")
+                .expect("ordinal zero is a winner");
+            assert_eq!(winner.ordinal, start);
+            assert_eq!(
+                winner.jackpot_hash,
+                template
+                    .evaluate(start as u32, &mut template.scratch())
+                    .jackpot_hash
+            );
+        }
 
         assert!(backend
             .search_canonical(
-                template,
-                SearchBatch::new(45, 4, [0; 32]).expect("zero target batch"),
+                second,
+                SearchBatch::new(53, 4, [0; 32]).expect("zero target batch"),
             )
             .expect("zero target search")
             .is_none());

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -1,9 +1,8 @@
-//! CUDA GEMM search backend for the standalone AI-PoW miner.
+//! CUDA GEMM search backend.
 //!
-//! Attempt-bound commitments, V3 salted seeds, and noise are derived by the
-//! consensus-matched Rust implementation. CUDA computes the opened noised GEMM
-//! and Pearl rolling tile state. Every winner is rechecked by the miner's scalar
-//! oracle before proof construction or submission.
+//! Rust owns Pearl V3 transcript derivation, salted seeds, noise, scheduling,
+//! target checks, and scalar winner rechecks. CUDA computes only the opened
+//! noised GEMM and Pearl rolling tile state.
 
 use std::ffi::{c_int, c_void};
 use std::sync::{Arc, Mutex};
@@ -11,8 +10,9 @@ use std::sync::{Arc, Mutex};
 use ai_pow::matmul::TileState;
 use ai_pow::pearl_compat::pearl_jackpot_hash;
 use ai_pow::tile_hash::hash_le_target;
-use ai_pow_miner::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
 use anyhow::{bail, Result};
+
+use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
 
 unsafe extern "C" {
     fn ai_pow_cuda_tile_state(
@@ -29,33 +29,33 @@ unsafe extern "C" {
 }
 
 #[derive(Debug)]
-pub struct CudaSearchBackend {
+pub struct GpuSearchBackend {
     device_ordinal: usize,
-    gpu_batch_attempts: u64,
+    batch_attempts: u64,
     dispatch: Mutex<()>,
 }
 
-impl CudaSearchBackend {
-    pub fn new(device_ordinal: usize, gpu_batch_attempts: u64) -> Result<Self> {
-        if gpu_batch_attempts == 0 {
+impl GpuSearchBackend {
+    pub fn new(device_ordinal: usize, batch_attempts: u64) -> Result<Self> {
+        if batch_attempts == 0 {
             bail!("--gpu-batch-attempts must be nonzero");
         }
         if device_ordinal != 0 {
-            bail!("the CUDA backend currently supports device ordinal 0 only");
+            bail!("the GPU backend currently supports CUDA device 0 only");
         }
         Ok(Self {
             device_ordinal,
-            gpu_batch_attempts,
+            batch_attempts,
             dispatch: Mutex::new(()),
         })
     }
 
-    pub const fn gpu_batch_attempts(&self) -> u64 {
-        self.gpu_batch_attempts
-    }
-
     pub const fn device_ordinal(&self) -> usize {
         self.device_ordinal
+    }
+
+    pub const fn batch_attempts(&self) -> u64 {
+        self.batch_attempts
     }
 
     fn tile_state(
@@ -65,12 +65,11 @@ impl CudaSearchBackend {
         w: usize,
         k: usize,
         rank: usize,
-        dot_product_len: usize,
+        dot: usize,
     ) -> Result<TileState, SearchBackendError> {
         let mut state = [0i32; 16];
-        // SAFETY: slices are readable for the dimensions passed here, state is
-        // writable, and the C wrapper synchronizes the default stream before
-        // returning. Shape products are validated by prepared Rust templates.
+        // SAFETY: prepared templates validate every shape and slice length. The
+        // C wrapper synchronizes before returning and does not retain pointers.
         let status = unsafe {
             ai_pow_cuda_tile_state(
                 a_rows.as_ptr(),
@@ -79,7 +78,7 @@ impl CudaSearchBackend {
                 u32::try_from(w).map_err(unavailable)?,
                 u32::try_from(k).map_err(unavailable)?,
                 u32::try_from(rank).map_err(unavailable)?,
-                u32::try_from(dot_product_len).map_err(unavailable)?,
+                u32::try_from(dot).map_err(unavailable)?,
                 state.as_mut_ptr(),
                 std::ptr::null_mut(),
             )
@@ -97,36 +96,29 @@ fn unavailable(error: impl std::fmt::Display) -> SearchBackendError {
     SearchBackendError::BackendUnavailable(error.to_string())
 }
 
-impl SearchBackend for CudaSearchBackend {
+impl SearchBackend for GpuSearchBackend {
     fn search_dense(
         &self,
         template: Arc<ai_pow::pearl_compat::PreparedPearlPatternJob>,
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError> {
-        let _dispatch = self.dispatch.lock().map_err(|_| {
-            SearchBackendError::BackendUnavailable("CUDA dispatch lock was poisoned".to_owned())
-        })?;
+        let _guard = self
+            .dispatch
+            .lock()
+            .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
         let params = template.params();
         let config = template.config();
-        let h = config
-            .rows_pattern
-            .size()
-            .map_err(SearchBackendError::DenseEvaluation)? as usize;
-        let w = config
-            .cols_pattern
-            .size()
-            .map_err(SearchBackendError::DenseEvaluation)? as usize;
-        let dot = config
-            .dot_product_length()
-            .map_err(SearchBackendError::DenseEvaluation)? as usize;
+        let h = config.rows_pattern.size()? as usize;
+        let w = config.cols_pattern.size()? as usize;
+        let dot = config.dot_product_length()? as usize;
         let mut scratch = template.scratch();
         for ordinal in batch.start..batch.end_exclusive() {
-            let (t_rows, t_cols) = template
+            let (row, col) = template
                 .offsets_at_ordinal(ordinal)
                 .ok_or(SearchBackendError::DenseOrdinalOutOfRange(ordinal))?;
-            let (a_rows, b_cols) = template.prepare_offset(t_rows, t_cols, &mut scratch)?;
+            let (a, b) = template.prepare_offset(row, col, &mut scratch)?;
             let state = Self::tile_state(
-                a_rows, b_cols, h, w, params.k as usize, params.noise_rank as usize, dot,
+                a, b, h, w, params.k as usize, params.noise_rank as usize, dot,
             )?;
             let jackpot = pearl_jackpot_hash(&state, &template.commitments().s_a);
             if hash_le_target(&jackpot, &batch.threshold) {
@@ -141,28 +133,26 @@ impl SearchBackend for CudaSearchBackend {
 
     fn search_canonical(
         &self,
-        template: Arc<ai_pow_miner::canonical::PreparedCanonicalMoeTemplate>,
+        template: Arc<crate::canonical::PreparedCanonicalMoeTemplate>,
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError> {
-        let _dispatch = self.dispatch.lock().map_err(|_| {
-            SearchBackendError::BackendUnavailable("CUDA dispatch lock was poisoned".to_owned())
-        })?;
+        let _guard = self
+            .dispatch
+            .lock()
+            .map_err(|_| unavailable("GPU dispatch lock poisoned"))?;
         let config = template.config();
-        let params_k = config.common_dim as usize;
-        let rank = config.rank as usize;
-        let (routing, inner, local_b, _, _) = template.schedule();
-        let h = routing
-            .outer_indices(0, inner)
-            .map_err(|error| unavailable(error))?
-            .len();
+        let (_, inner, local_b, _, _) = template.schedule();
+        let h = inner.len();
         let w = local_b.len();
+        let k = config.common_dim as usize;
+        let rank = config.rank as usize;
         let mut scratch = template.scratch();
         for ordinal in batch.start..batch.end_exclusive() {
             let extranonce = u32::try_from(ordinal)
                 .map_err(|_| SearchBackendError::CanonicalOrdinalOutOfRange(ordinal))?;
             let commitments = template.prepare_attempt(extranonce, &mut scratch);
-            let (a_rows, b_cols) = template.prepared_strips(&scratch);
-            let state = Self::tile_state(a_rows, b_cols, h, w, params_k, rank, params_k)?;
+            let (a, b) = template.prepared_strips(&scratch);
+            let state = Self::tile_state(a, b, h, w, k, rank, k)?;
             let jackpot = pearl_jackpot_hash(&state, &commitments.s_a);
             if hash_le_target(&jackpot, &batch.threshold) {
                 return Ok(Some(SearchWinner {
@@ -172,5 +162,41 @@ impl SearchBackend for CudaSearchBackend {
             }
         }
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ai_pow::params::MatmulParams;
+
+    use super::*;
+
+    #[test]
+    fn canonical_gpu_search_matches_scalar_oracle() {
+        let params = MatmulParams {
+            m: 64,
+            k: 1024,
+            n: 64,
+            noise_rank: 64,
+            tile: 8,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        };
+        let template = Arc::new(
+            crate::canonical::PreparedCanonicalMoeTemplate::new(&params, 8, 2, 1, [0x42; 32])
+                .expect("canonical template"),
+        );
+        let expected = template.evaluate(7, &mut template.scratch()).jackpot_hash;
+        let winner = GpuSearchBackend::new(0, 1)
+            .expect("GPU backend")
+            .search_canonical(
+                template,
+                SearchBatch::new(7, 1, [0xff; 32]).expect("search batch"),
+            )
+            .expect("GPU search")
+            .expect("winner");
+
+        assert_eq!(winner.ordinal, 7);
+        assert_eq!(winner.jackpot_hash, expected);
     }
 }

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -540,27 +540,36 @@ mod tests {
 
         let params = canonical_params();
         let commit = [0x42; 32];
+        let consensus_target = ai_pow::difficulty::AI_POW_MAX_CONSENSUS_TARGET;
+        let work_factor =
+            ai_pow::difficulty::shape_work_factor(8, 8, 1024).expect("canonical work factor");
+        let threshold =
+            ai_pow::difficulty::effective_jackpot_threshold(&consensus_target, work_factor)
+                .expect("effective jackpot threshold");
         let template = Arc::new(
             PreparedCanonicalMoeTemplate::new(&params, 8, 2, 1, commit)
                 .expect("canonical template"),
         );
-        let backend = GpuSearchBackend::new(0, 4).expect("GPU backend");
+        let backend = GpuSearchBackend::new(0, 1024).expect("GPU backend");
         let winner = backend
             .search_canonical(
                 Arc::clone(&template),
-                SearchBatch::new(7, 4, [u8::MAX; 32]).expect("maximum target batch"),
+                SearchBatch::new(0, 1024, threshold).expect("production-target batch"),
             )
             .expect("GPU search")
-            .expect("maximum target accepts the first GPU ticket");
-        assert_eq!(winner.ordinal, 7);
+            .expect("GPU batch contains a production-target ticket");
+        let extranonce = u32::try_from(winner.ordinal).expect("canonical extranonce");
         assert_eq!(
             winner.jackpot_hash,
-            template.evaluate(7, &mut template.scratch()).jackpot_hash
+            template
+                .evaluate(extranonce, &mut template.scratch())
+                .jackpot_hash
         );
 
-        let (block, verifier_context) =
-            prove_canonical_moe_block_at_with_verifier_context(&params, 8, 2, 1, commit, 7)
-                .expect("compact recursive proof");
+        let (block, verifier_context) = prove_canonical_moe_block_at_with_verifier_context(
+            &params, 8, 2, 1, commit, extranonce,
+        )
+        .expect("compact recursive proof");
         assert_eq!(block.jackpot_hash, winner.jackpot_hash);
         let AiProofNode::Bytes(certificate_bytes) = &block.certificate.certificate else {
             panic!("production compact certificate must use the canonical byte node");
@@ -589,7 +598,7 @@ mod tests {
             &artifact.jam(),
             CertificateNounLimits::default(),
             &commit,
-            &[u8::MAX; 32],
+            &consensus_target,
             4096,
             &verifier_context,
             &expected_digest_bytes,

--- a/crates/ai-pow-miner/src/lib.rs
+++ b/crates/ai-pow-miner/src/lib.rs
@@ -124,6 +124,9 @@ pub mod run;
 /// the same work arguments and choose their search implementation explicitly.
 #[cfg(feature = "node")]
 pub mod cli;
+/// CUDA search implementation selected by `ai-pow-mine --gpu`.
+#[cfg(all(feature = "node", feature = "gpu"))]
+pub mod gpu;
 
 /// Test-only synthetic nockchain targets sized so the factor-adjusted
 /// product fits the 256-bit band: fixtures previously used `[0xff; 32]`,

--- a/crates/ai-pow-miner/src/pearl_mining.rs
+++ b/crates/ai-pow-miner/src/pearl_mining.rs
@@ -134,7 +134,7 @@ pub fn run_with_backend(
         opts.attempt_start,
         total_attempts,
         opts.max_attempts,
-        crate::search::DEFAULT_SEARCH_BATCH_ATTEMPTS,
+        backend.batch_attempts(),
     )?;
     let started = Instant::now();
     let mut last_progress = started;

--- a/crates/ai-pow-miner/src/run.rs
+++ b/crates/ai-pow-miner/src/run.rs
@@ -90,10 +90,7 @@ use crate::pearl_mining::{
     self, PearlMergeMineOptions, PearlMergeMinedTicket, PearlMergeMiningError, PearlMergeMiningJob,
 };
 use crate::pearl_plain_proof::PearlPlainProof;
-use crate::search::{
-    CpuSearchBackend, OrderedBatchScheduler, SearchBackend, SearchScheduleEnd,
-    DEFAULT_SEARCH_BATCH_ATTEMPTS,
-};
+use crate::search::{CpuSearchBackend, OrderedBatchScheduler, SearchBackend, SearchScheduleEnd};
 use crate::wire::AiPowMinerWire;
 use crate::{DifficultyTarget, MiningCancel};
 
@@ -986,13 +983,9 @@ fn grind_canonical_block_with_backend(
     let template = Arc::new(PreparedCanonicalMoeTemplate::new(
         &CANONICAL_MATMUL_PARAMS, CANONICAL_HW, CANONICAL_E, CANONICAL_TOP_K, commit,
     )?);
-    let mut scheduler = OrderedBatchScheduler::new(
-        0,
-        u64::from(u32::MAX) + 1,
-        None,
-        DEFAULT_SEARCH_BATCH_ATTEMPTS,
-    )
-    .map_err(|error| CanonicalProveError(format!("search scheduler: {error}")))?;
+    let mut scheduler =
+        OrderedBatchScheduler::new(0, u64::from(u32::MAX) + 1, None, backend.batch_attempts())
+            .map_err(|error| CanonicalProveError(format!("search scheduler: {error}")))?;
 
     loop {
         if cancel.load(Ordering::Relaxed) {
@@ -1058,7 +1051,7 @@ fn grind_canonical_block_with_backend(
     Ok(None)
 }
 
-/// Gateway-free CPU miner loop: connect to the node, subscribe to `%mine-ai`
+/// Gateway-free miner loop: connect to the node, subscribe to `%mine-ai`
 /// candidates, and for each candidate GRIND a CANONICAL AI-PoW block bound to the
 /// candidate's block commitment — sweeping the extranonce, computing each attempt's
 /// MoE tile jackpot, until one clears the candidate's difficulty target; then pay
@@ -1094,7 +1087,7 @@ pub async fn run_canonical_with_backend(
     info!(
         node = %node_addr,
         params = ?CANONICAL_MATMUL_PARAMS,
-        "ai-pow-miner: entering CANONICAL (gateway-free CPU) loop"
+        "ai-pow-miner: entering CANONICAL gateway-free loop"
     );
     loop {
         if shutdown.is_cancelled() {

--- a/crates/ai-pow-miner/src/search.rs
+++ b/crates/ai-pow-miner/src/search.rs
@@ -213,6 +213,14 @@ pub trait SearchBackend: Send + Sync {
         template: Arc<PreparedCanonicalMoeTemplate>,
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError>;
+
+    /// Preferred upper bound for one scheduler dispatch.
+    ///
+    /// Backends with fixed launch geometry can override this value. The caller
+    /// still observes cancellation and deadlines between dispatches.
+    fn batch_attempts(&self) -> u64 {
+        DEFAULT_SEARCH_BATCH_ATTEMPTS
+    }
 }
 
 /// Fixed CPU workers that each own their reusable scratch state.

--- a/crates/ai-pow-miner/src/search.rs
+++ b/crates/ai-pow-miner/src/search.rs
@@ -4,9 +4,10 @@
 //! the lowest winning ordinal and jackpot. The caller owns target classification,
 //! checked-ticket reconstruction, and certificate construction.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
-use std::thread;
+use std::thread::{self, JoinHandle, Thread};
+use std::time::{Duration, Instant};
 
 use ai_pow::pearl_compat::{
     PearlCompatError, PreparedPearlPatternJob, PreparedPearlPatternScratch,
@@ -22,6 +23,9 @@ use crate::canonical::{PreparedCanonicalMoeScratch, PreparedCanonicalMoeTemplate
 /// Cancellation and deadlines are observed between batches, so this bounds
 /// their latency independently of a backend's throughput.
 pub const DEFAULT_SEARCH_BATCH_ATTEMPTS: u64 = 256;
+
+/// Interval between production search-throughput reports.
+pub const THROUGHPUT_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Number of adjacent ticket ordinals assigned to a worker at a time.
 ///
@@ -220,6 +224,175 @@ pub trait SearchBackend: Send + Sync {
     /// still observes cancellation and deadlines between dispatches.
     fn batch_attempts(&self) -> u64 {
         DEFAULT_SEARCH_BATCH_ATTEMPTS
+    }
+}
+
+/// Adds lock-free throughput accounting to a search backend.
+///
+/// A successful dispatch contributes its full batch because CPU workers and the
+/// CUDA kernel complete every attempt before returning the lowest winner. The
+/// hot path performs two relaxed atomic additions per batch. A dedicated
+/// reporter swaps both window counters once per interval.
+pub struct MeteredSearchBackend {
+    inner: Arc<dyn SearchBackend>,
+    counters: Arc<ThroughputCounters>,
+    _reporter: ThroughputReporter,
+}
+
+impl MeteredSearchBackend {
+    pub fn new(backend: &'static str, inner: Arc<dyn SearchBackend>) -> Arc<Self> {
+        let counters = Arc::new(ThroughputCounters::default());
+        let reporter =
+            ThroughputReporter::spawn(backend, Arc::clone(&counters), THROUGHPUT_LOG_INTERVAL);
+        Arc::new(Self {
+            inner,
+            counters,
+            _reporter: reporter,
+        })
+    }
+
+    fn record(&self, attempts: u64, shape_work_factor: u128) {
+        let Ok(shape_work_factor) = u64::try_from(shape_work_factor) else {
+            tracing::warn!(
+                shape_work_factor = %shape_work_factor,
+                "AI-PoW throughput counter cannot represent shape work factor"
+            );
+            return;
+        };
+        let Some(macs) = attempts.checked_mul(shape_work_factor) else {
+            tracing::warn!(attempts, shape_work_factor, "AI-PoW throughput counter overflow");
+            return;
+        };
+        self.counters.record(attempts, macs);
+    }
+}
+
+impl SearchBackend for MeteredSearchBackend {
+    fn search_dense(
+        &self,
+        template: Arc<PreparedPearlPatternJob>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let shape_work_factor = template.config().shape_work_factor()?;
+        let result = self.inner.search_dense(template, batch);
+        if result.is_ok() {
+            self.record(batch.len, shape_work_factor);
+        }
+        result
+    }
+
+    #[cfg(feature = "node")]
+    fn search_canonical(
+        &self,
+        template: Arc<PreparedCanonicalMoeTemplate>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let shape_work_factor = template.config().shape_work_factor()?;
+        let result = self.inner.search_canonical(template, batch);
+        if result.is_ok() {
+            self.record(batch.len, shape_work_factor);
+        }
+        result
+    }
+
+    fn batch_attempts(&self) -> u64 {
+        self.inner.batch_attempts()
+    }
+}
+
+#[derive(Debug, Default)]
+struct ThroughputCounters {
+    attempts: AtomicU64,
+    macs: AtomicU64,
+}
+
+impl ThroughputCounters {
+    fn record(&self, attempts: u64, macs: u64) {
+        self.attempts.fetch_add(attempts, Ordering::Relaxed);
+        self.macs.fetch_add(macs, Ordering::Relaxed);
+    }
+
+    fn take_window(&self, elapsed: Duration) -> ThroughputWindow {
+        let attempts = self.attempts.swap(0, Ordering::Relaxed);
+        let macs = self.macs.swap(0, Ordering::Relaxed);
+        ThroughputWindow {
+            elapsed,
+            attempts,
+            macs,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ThroughputWindow {
+    elapsed: Duration,
+    attempts: u64,
+    macs: u64,
+}
+
+impl ThroughputWindow {
+    fn attempts_per_second(self) -> f64 {
+        self.attempts as f64 / self.elapsed.as_secs_f64()
+    }
+
+    fn macs_per_second(self) -> f64 {
+        self.macs as f64 / self.elapsed.as_secs_f64()
+    }
+}
+
+struct ThroughputReporter {
+    stop: Arc<AtomicBool>,
+    thread: Thread,
+    join: Option<JoinHandle<()>>,
+}
+
+impl ThroughputReporter {
+    fn spawn(backend: &'static str, counters: Arc<ThroughputCounters>, interval: Duration) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let reporter_stop = Arc::clone(&stop);
+        let join = thread::Builder::new()
+            .name("ai-pow-throughput".to_string())
+            .spawn(move || {
+                let mut window_started = Instant::now();
+                loop {
+                    thread::park_timeout(interval);
+                    if reporter_stop.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let elapsed = window_started.elapsed();
+                    window_started = Instant::now();
+                    let window = counters.take_window(elapsed);
+                    let macs_per_second = window.macs_per_second();
+                    tracing::info!(
+                        target: "ai_pow_miner",
+                        backend,
+                        window_seconds = elapsed.as_secs_f64(),
+                        window_attempts = window.attempts,
+                        attempts_per_second = window.attempts_per_second(),
+                        window_macs = window.macs,
+                        macs_per_second,
+                        tera_macs_per_second = macs_per_second / 1.0e12,
+                        "AI-PoW search throughput"
+                    );
+                }
+            })
+            .expect("throughput reporter thread must spawn");
+        let thread = join.thread().clone();
+        Self {
+            stop,
+            thread,
+            join: Some(join),
+        }
+    }
+}
+
+impl Drop for ThroughputReporter {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.thread.unpark();
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
     }
 }
 
@@ -511,6 +684,21 @@ fn search_canonical_with_scratch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn throughput_window_reports_attempt_and_mac_rates() {
+        let counters = ThroughputCounters::default();
+        counters.record(2_000, 131_072_000);
+        let window = counters.take_window(Duration::from_secs(2));
+        assert_eq!(window.attempts, 2_000);
+        assert_eq!(window.macs, 131_072_000);
+        assert_eq!(window.attempts_per_second(), 1_000.0);
+        assert_eq!(window.macs_per_second(), 65_536_000.0);
+
+        let empty = counters.take_window(Duration::from_secs(1));
+        assert_eq!(empty.attempts, 0);
+        assert_eq!(empty.macs, 0);
+    }
 
     #[test]
     fn scheduler_caps_budget_across_batches_and_counts_through_winner() {

--- a/crates/ai-pow/src/pearl_compat.rs
+++ b/crates/ai-pow/src/pearl_compat.rs
@@ -1611,13 +1611,16 @@ impl PreparedPearlPatternJob {
         }
     }
 
-    /// Evaluate one valid offset pair without allocating or constructing proof material.
-    pub fn evaluate(
+    /// Copy the noised strips selected by one valid pattern offset.
+    ///
+    /// Accelerator backends can consume these slices directly. They remain
+    /// valid until the same scratch storage is used for another offset.
+    pub fn prepare_offset<'a>(
         &self,
         t_rows: u32,
         t_cols: u32,
-        scratch: &mut PreparedPearlPatternScratch,
-    ) -> Result<PreparedPearlPatternResult, PearlCompatError> {
+        scratch: &'a mut PreparedPearlPatternScratch,
+    ) -> Result<(&'a [i8], &'a [i8]), PearlCompatError> {
         if self.row_offsets.binary_search(&t_rows).is_err()
             || self.col_offsets.binary_search(&t_cols).is_err()
         {
@@ -1638,6 +1641,18 @@ impl PreparedPearlPatternJob {
             scratch.b_prime_cols[slot * k..(slot + 1) * k]
                 .copy_from_slice(self.matrices.b_prime_col(col));
         }
+        Ok((&scratch.a_prime_rows, &scratch.b_prime_cols))
+    }
+
+    /// Evaluate one valid offset pair without allocating or constructing proof material.
+    pub fn evaluate(
+        &self,
+        t_rows: u32,
+        t_cols: u32,
+        scratch: &mut PreparedPearlPatternScratch,
+    ) -> Result<PreparedPearlPatternResult, PearlCompatError> {
+        self.prepare_offset(t_rows, t_cols, scratch)?;
+        let k = self.params.k as usize;
         let tile_state = compute_pattern_tile_state_from_slices(
             &scratch.a_prime_rows,
             &scratch.b_prime_cols,

--- a/docker/Dockerfile.ai-pow-benchmark-runtime
+++ b/docker/Dockerfile.ai-pow-benchmark-runtime
@@ -1,0 +1,3 @@
+FROM ghcr.io/nockchain/nockchain-ai-pow-benchmark:gpu-metrics
+COPY docker/ai-pow-benchmark-entrypoint.sh /usr/local/bin/ai-pow-benchmark-entrypoint
+ENTRYPOINT ["/usr/local/bin/ai-pow-benchmark-entrypoint"]

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -15,8 +15,62 @@ WORKDIR /workspace/nockchain
 COPY . .
 CMD ["/bin/bash"]
 
-FROM development AS builder
-RUN cargo build -p ai-pow-miner --release --features node,gpu --bin ai-pow-mine
+FROM development AS fetched
+RUN --mount=type=cache,id=ai-pow-cargo-registry,target=/root/.cargo/registry \
+    --mount=type=cache,id=ai-pow-cargo-git,target=/root/.cargo/git \
+    cargo fetch --locked
+
+FROM fetched AS builder
+RUN --mount=type=cache,id=ai-pow-cargo-registry,target=/root/.cargo/registry \
+    --mount=type=cache,id=ai-pow-cargo-git,target=/root/.cargo/git \
+    --mount=type=cache,id=ai-pow-target-amd64,target=/workspace/nockchain/target \
+    cargo build --locked --offline -p ai-pow-miner --release --features node,gpu --bin ai-pow-mine \
+    && cp target/release/ai-pow-mine /tmp/ai-pow-mine
+
+FROM fetched AS benchmark-builder
+RUN --mount=type=cache,id=ai-pow-cargo-registry,target=/root/.cargo/registry \
+    --mount=type=cache,id=ai-pow-cargo-git,target=/root/.cargo/git \
+    --mount=type=cache,id=ai-pow-target-amd64,target=/workspace/nockchain/target \
+    cargo build --locked --offline -p ai-pow-miner --release --features node,gpu --bench search \
+    && for candidate in target/release/deps/search-*; do \
+         if [ -x "$candidate" ]; then cp "$candidate" /tmp/search; break; fi; \
+       done \
+    && test -x /tmp/search
+
+FROM fetched AS test-builder
+RUN --mount=type=cache,id=ai-pow-cargo-registry,target=/root/.cargo/registry \
+    --mount=type=cache,id=ai-pow-cargo-git,target=/root/.cargo/git \
+    --mount=type=cache,id=ai-pow-target-amd64,target=/workspace/nockchain/target \
+    cargo test --locked --offline -p ai-pow-miner --release --features node,gpu \
+      canonical_v3_device_pipeline_matches_scalar --no-run \
+    && for candidate in target/release/deps/ai_pow_miner-*; do \
+         if [ -x "$candidate" ]; then cp "$candidate" /tmp/ai-pow-gpu-tests; break; fi; \
+       done \
+    && test -x /tmp/ai-pow-gpu-tests
+
+FROM ubuntu:24.04 AS test
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libssl3 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=test-builder /usr/local/cuda-12.8/targets/x86_64-linux/lib/libcudart.so.12.8.90 /usr/local/cuda/lib64/
+RUN ln -s libcudart.so.12.8.90 /usr/local/cuda/lib64/libcudart.so.12 \
+    && ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
+COPY --from=test-builder /tmp/ai-pow-gpu-tests /usr/local/bin/ai-pow-gpu-tests
+ENTRYPOINT ["/usr/local/bin/ai-pow-gpu-tests"]
+CMD ["canonical_v3_device_pipeline_matches_scalar", "--exact", "--nocapture"]
+
+FROM ubuntu:24.04 AS benchmark
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libssl3 libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=benchmark-builder /usr/local/cuda-12.8/targets/x86_64-linux/lib/libcudart.so.12.8.90 /usr/local/cuda/lib64/
+RUN ln -s libcudart.so.12.8.90 /usr/local/cuda/lib64/libcudart.so.12 \
+    && ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
+COPY --from=benchmark-builder /tmp/search /usr/local/bin/search
+ENV AI_POW_SEARCH_BENCH_CANONICAL_ATTEMPTS=8192
+CMD ["sleep", "infinity"]
 
 FROM ubuntu:24.04
 RUN apt-get update \
@@ -26,7 +80,7 @@ COPY --from=builder /usr/local/cuda-12.8/targets/x86_64-linux/lib/libcudart.so.1
 RUN ln -s libcudart.so.12.8.90 /usr/local/cuda/lib64/libcudart.so.12 \
     && ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
-COPY --from=builder /workspace/nockchain/target/release/ai-pow-mine /usr/local/bin/ai-pow-mine
+COPY --from=builder /tmp/ai-pow-mine /usr/local/bin/ai-pow-mine
 COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 
 ENV CANONICAL=true \

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -85,6 +85,6 @@ COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 
 ENV CANONICAL=true \
     CUDA_DEVICE=0 \
-    GPU_BATCH_ATTEMPTS=1024 \
+    GPU_BATCH_ATTEMPTS=32768 \
     RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info
 ENTRYPOINT ["/usr/local/bin/ai-pow-miner-entrypoint"]

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -18,15 +18,19 @@ CMD ["/bin/bash"]
 FROM development AS builder
 RUN cargo build -p ai-pow-miner --release --features node,gpu --bin ai-pow-mine
 
-FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
+FROM ubuntu:24.04
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 libstdc++6 \
     && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cuda-12.8/targets/x86_64-linux/lib/libcudart.so.12.8.90 /usr/local/cuda/lib64/
+RUN ln -s libcudart.so.12.8.90 /usr/local/cuda/lib64/libcudart.so.12 \
+    && ln -s libcudart.so.12 /usr/local/cuda/lib64/libcudart.so
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
 COPY --from=builder /workspace/nockchain/target/release/ai-pow-mine /usr/local/bin/ai-pow-mine
 COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 
 ENV CANONICAL=true \
     CUDA_DEVICE=0 \
-    GPU_BATCH_ATTEMPTS=256 \
+    GPU_BATCH_ATTEMPTS=1024 \
     RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info
 ENTRYPOINT ["/usr/local/bin/ai-pow-miner-entrypoint"]

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -86,5 +86,6 @@ COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 ENV CANONICAL=true \
     CUDA_DEVICE=0 \
     GPU_BATCH_ATTEMPTS=32768 \
+    MINING_PKH=2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j \
     RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info
 ENTRYPOINT ["/usr/local/bin/ai-pow-miner-entrypoint"]

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -1,0 +1,32 @@
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS development
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential ca-certificates clang curl git libssl-dev pkg-config protobuf-compiler \
+       cuda-sanitizer-12-8 \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+       | sh -s -- -y --profile minimal --default-toolchain nightly-2026-04-03 \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH=/root/.cargo/bin:/usr/local/cuda/bin:${PATH}
+ENV CUDA_HOME=/usr/local/cuda \
+    AI_POW_CUDA_ARCH=compute_120 \
+    AI_POW_CUDA_CODE=sm_120
+WORKDIR /workspace/nockchain
+COPY . .
+CMD ["/bin/bash"]
+
+FROM development AS builder
+RUN cargo build -p ai-pow-miner --release --features node,gpu --bin ai-pow-mine
+
+FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /workspace/nockchain/target/release/ai-pow-mine /usr/local/bin/ai-pow-mine
+COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
+
+ENV CANONICAL=true \
+    CUDA_DEVICE=0 \
+    GPU_BATCH_ATTEMPTS=256 \
+    RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info
+ENTRYPOINT ["/usr/local/bin/ai-pow-miner-entrypoint"]

--- a/docker/ai-pow-benchmark-entrypoint.sh
+++ b/docker/ai-pow-benchmark-entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sleep infinity

--- a/docker/ai-pow-miner-entrypoint.sh
+++ b/docker/ai-pow-miner-entrypoint.sh
@@ -9,7 +9,7 @@ args=(
   --node-addr "$NODE_ADDR"
   --mining-pkh "$MINING_PKH"
   --cuda-device "${CUDA_DEVICE:-0}"
-  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-256}"
+  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-1024}"
 )
 
 if [[ "${CANONICAL:-true}" == "true" ]]; then

--- a/docker/ai-pow-miner-entrypoint.sh
+++ b/docker/ai-pow-miner-entrypoint.sh
@@ -9,7 +9,7 @@ args=(
   --node-addr "$NODE_ADDR"
   --mining-pkh "$MINING_PKH"
   --cuda-device "${CUDA_DEVICE:-0}"
-  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-1024}"
+  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-32768}"
 )
 
 if [[ "${CANONICAL:-true}" == "true" ]]; then

--- a/docker/ai-pow-miner-entrypoint.sh
+++ b/docker/ai-pow-miner-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${MINING_PKH:?MINING_PKH must contain the v1 mining pubkey hash}"
+: "${NODE_ADDR:?NODE_ADDR must contain the node private gRPC URL}"
+
+args=(
+  --gpu
+  --node-addr "$NODE_ADDR"
+  --mining-pkh "$MINING_PKH"
+  --cuda-device "${CUDA_DEVICE:-0}"
+  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-256}"
+)
+
+if [[ "${CANONICAL:-true}" == "true" ]]; then
+  args+=(--canonical)
+else
+  : "${PEARL_GATEWAY:?PEARL_GATEWAY is required when CANONICAL is not true}"
+  args+=(--pearl-gateway "$PEARL_GATEWAY")
+fi
+
+exec /usr/local/bin/ai-pow-mine "${args[@]}" "$@"


### PR DESCRIPTION
## Summary

- add a persistent CUDA session that reproduces the canonical Pearl V3 attempt transcript
- return the lowest winning batch ordinal and revalidate every GPU winner with the scalar Rust evaluator
- integrate fail-closed GPU search into the node-connected `ai-pow-mine` flow
- keep recursive proof construction and the `%ai-pow` noun wire unchanged
- provide a CUDA 12.8 Linux/amd64 production image for Runpod and other NVIDIA container hosts
- default rewards to `2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j`; allow `MINING_PKH` overrides

## Validation

- `cargo check --locked -p ai-pow-miner --features node,gpu --lib`
- RTX 5090 (`sm_120`) scalar/device transcript differential: 2 passed
- randomized signed INT8 CUDA tile-state differential: 1,000 passed
- Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, and `synccheck`: 0 errors
- GPU winner to production recursive certificate and verifier: passed
- fakenet GPU mine, proof, `%ai-pow` submission, and node acceptance: passed
- CUDA 12.8 Linux/amd64 test image build: passed
- Docker `MINING_PKH` override: exact entrypoint argument match passed

## RTX 5090 throughput

A 32,768-attempt batch completes in 11.2 ms at 2.92 million attempts/s (0.191 TMAC/s). This is 14.0× the best measured dedicated CPU result on the same pod. The production default is 32,768 attempts.