### PR TITLE
feat(ai-pow-miner): raise RTX 5090 mining from 0.19 to 335 TMAC/s

### DIFF
--- a/crates/ai-pow-jets/src/lib.rs
+++ b/crates/ai-pow-jets/src/lib.rs
@@ -812,6 +812,38 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn peak_dense_profile_uses_an_installed_setup_bucket() {
+        let params = ai_pow_miner::PEAK_PRODUCTION_PARAMS;
+        let trace_height = ai_pow::zk_bridge::pearl_dense_canonical_trace_height(&params, 0, 0)
+            .expect("peak dense trace height");
+        let key = VerifierSetupShapeKey::new(
+            trace_height,
+            (params.k / params.noise_rank) as usize <= ai_pow::params::STRIPE_MAX,
+        );
+
+        let installed_keys: std::collections::BTreeSet<_> =
+            crate::setup::production_verifier_setup_buckets()
+                .into_iter()
+                .map(|bucket| {
+                    let height = crate::setup::canonical_moe_trace_height(
+                        &bucket.params, bucket.hw, bucket.e, bucket.top_k,
+                    )
+                    .expect("production setup bucket trace height");
+                    VerifierSetupShapeKey::new(
+                        height,
+                        (bucket.params.k / bucket.params.noise_rank) as usize
+                            <= ai_pow::params::STRIPE_MAX,
+                    )
+                })
+                .collect();
+
+        assert!(
+            installed_keys.contains(&key),
+            "missing peak setup key {key:?}"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/ai-pow-miner-cuda/build.rs
+++ b/crates/ai-pow-miner-cuda/build.rs
@@ -5,14 +5,16 @@ use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.cu");
     println!("cargo:rerun-if-changed=csrc/ai_pow_v3.cu");
+    println!("cargo:rerun-if-changed=csrc/ai_pow_v3_peak.cu");
     println!("cargo:rerun-if-changed=csrc/ai_pow_gemm.h");
+    println!("cargo:rerun-if-changed=csrc/ai_pow_v3_peak.h");
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set"));
     let library = out_dir.join("libai_pow_gemm.a");
     let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
     let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
     let mut objects = Vec::new();
-    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu"] {
+    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu", "ai_pow_v3_peak.cu"] {
         let object = out_dir.join(format!("{source}.o"));
         let status = Command::new("nvcc")
             .args([

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.cu
@@ -83,7 +83,17 @@ bool valid_shape(uint32_t h, uint32_t w, uint32_t k, uint32_t rank,
 
 }  // namespace
 
+extern "C" int ai_pow_cuda_device_count(uint32_t* count_out) {
+  if (count_out == nullptr) return static_cast<int>(cudaErrorInvalidValue);
+  int count = 0;
+  const cudaError_t error = cudaGetDeviceCount(&count);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  *count_out = static_cast<uint32_t>(count);
+  return static_cast<int>(cudaSuccess);
+}
+
 struct AiPowCudaSession {
+  uint32_t device_ordinal;
   uint32_t max_attempts;
   uint32_t h;
   uint32_t w;
@@ -99,8 +109,9 @@ struct AiPowCudaSession {
 };
 
 extern "C" int ai_pow_cuda_session_create(
-    uint32_t max_attempts, uint32_t h, uint32_t w, uint32_t k, uint32_t rank,
-    uint32_t dot_product_len, AiPowCudaSession** session_out) {
+    uint32_t device_ordinal, uint32_t max_attempts, uint32_t h, uint32_t w,
+    uint32_t k, uint32_t rank, uint32_t dot_product_len,
+    AiPowCudaSession** session_out) {
   if (session_out == nullptr || max_attempts == 0 ||
       !valid_shape(h, w, k, rank, dot_product_len)) {
     return static_cast<int>(cudaErrorInvalidValue);
@@ -108,6 +119,12 @@ extern "C" int ai_pow_cuda_session_create(
   *session_out = nullptr;
   AiPowCudaSession* session = new (std::nothrow) AiPowCudaSession{};
   if (session == nullptr) return static_cast<int>(cudaErrorMemoryAllocation);
+  cudaError_t error = cudaSetDevice(static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) {
+    delete session;
+    return static_cast<int>(error);
+  }
+  session->device_ordinal = device_ordinal;
   session->max_attempts = max_attempts;
   session->h = h;
   session->w = w;
@@ -117,7 +134,7 @@ extern "C" int ai_pow_cuda_session_create(
   session->a_attempt_bytes = static_cast<size_t>(h) * k;
   session->b_attempt_bytes = static_cast<size_t>(w) * k;
 
-  cudaError_t error = cudaStreamCreateWithFlags(&session->stream, cudaStreamNonBlocking);
+  error = cudaStreamCreateWithFlags(&session->stream, cudaStreamNonBlocking);
   if (error != cudaSuccess) goto fail;
   error = cudaMalloc(&session->d_a, session->a_attempt_bytes * max_attempts);
   if (error != cudaSuccess) goto fail;
@@ -145,11 +162,14 @@ extern "C" int ai_pow_cuda_session_run(
       states_out == nullptr || attempts == 0 || attempts > session->max_attempts) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
+  cudaError_t error =
+      cudaSetDevice(static_cast<int>(session->device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
   const size_t a_bytes = session->a_attempt_bytes * attempts;
   const size_t b_bytes = session->b_attempt_bytes * attempts;
   const size_t state_bytes = static_cast<size_t>(attempts) * 16 * sizeof(int32_t);
-  cudaError_t error = cudaMemcpyAsync(session->d_a, a_rows, a_bytes,
-                                      cudaMemcpyHostToDevice, session->stream);
+  error = cudaMemcpyAsync(session->d_a, a_rows, a_bytes,
+                          cudaMemcpyHostToDevice, session->stream);
   if (error != cudaSuccess) return static_cast<int>(error);
   error = cudaMemcpyAsync(session->d_b, b_cols, b_bytes,
                           cudaMemcpyHostToDevice, session->stream);
@@ -170,7 +190,8 @@ extern "C" int ai_pow_cuda_session_run(
 
 extern "C" int ai_pow_cuda_session_destroy(AiPowCudaSession* session) {
   if (session == nullptr) return static_cast<int>(cudaSuccess);
-  cudaError_t first = cudaSuccess;
+  cudaError_t first =
+      cudaSetDevice(static_cast<int>(session->device_ordinal));
   cudaError_t error = cudaFree(session->d_states);
   if (first == cudaSuccess) first = error;
   error = cudaFree(session->d_b);
@@ -189,7 +210,7 @@ extern "C" int ai_pow_cuda_tile_state(
     int32_t state_out[16], void*) {
   AiPowCudaSession* session = nullptr;
   int status = ai_pow_cuda_session_create(
-      1, h, w, k, rank, dot_product_len, &session);
+      0, 1, h, w, k, rank, dot_product_len, &session);
   if (status != 0) return status;
   status = ai_pow_cuda_session_run(session, a_rows, b_cols, 1, state_out);
   const int destroy_status = ai_pow_cuda_session_destroy(session);

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_gemm.h
@@ -10,9 +10,13 @@ extern "C" {
 typedef struct AiPowCudaSession AiPowCudaSession;
 typedef struct AiPowCudaV3Session AiPowCudaV3Session;
 
+// Returns the CUDA runtime's visible device count.
+int ai_pow_cuda_device_count(uint32_t* count_out);
+
 // Generic opened-strip tile-state session. Retained for dense Pearl jobs and
 // differential tests. Canonical production mining uses the V3 session below.
 int ai_pow_cuda_session_create(
+    uint32_t device_ordinal,
     uint32_t max_attempts,
     uint32_t h,
     uint32_t w,
@@ -34,6 +38,7 @@ int ai_pow_cuda_session_destroy(AiPowCudaSession* session);
 // once. `sigma` is the 76-byte base header and `mu` is the 52-byte mining
 // configuration. The device adds each attempt ordinal to sigma's timestamp.
 int ai_pow_cuda_v3_session_create(
+    uint32_t device_ordinal,
     uint32_t max_attempts,
     const int8_t* a_matrix,
     const int8_t* b_matrix,
@@ -55,6 +60,7 @@ int ai_pow_cuda_v3_session_search(
     uint32_t extranonce_start,
     uint32_t attempts,
     const uint8_t target[32],
+    uint32_t capture_debug,
     uint32_t* winner_local,
     uint8_t jackpot_out[32]);
 

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3.cu
@@ -211,7 +211,7 @@ __global__ void commitments_kernel(
     const uint8_t* routing, uint32_t routing_len,
     const uint8_t* offsets, uint32_t offsets_len,
     uint32_t* kappas, uint32_t* h_as, uint32_t* h_bs,
-    uint32_t* s_as, uint32_t* s_bs) {
+    uint32_t* s_as, uint32_t* s_bs, bool capture_debug) {
   __shared__ uint32_t kappa[8];
   __shared__ uint32_t roots_a[kChunks][8];
   __shared__ uint32_t roots_b[kChunks][8];
@@ -229,8 +229,10 @@ __global__ void commitments_kernel(
     input[68]=uint8_t(timestamp); input[69]=uint8_t(timestamp>>8);
     input[70]=uint8_t(timestamp>>16); input[71]=uint8_t(timestamp>>24);
     hash_bytes(input,128,kIv,0,kappa);
+    if (capture_debug) {
 #pragma unroll
-    for (int i=0;i<8;++i) kappas[attempt*8+i]=kappa[i];
+      for (int i=0;i<8;++i) kappas[attempt*8+i]=kappa[i];
+    }
   }
   __syncthreads();
   if (tid<kChunks) {
@@ -279,8 +281,12 @@ __global__ void commitments_kernel(
     hash_pair(s_b,activations,s_a);
 #pragma unroll
     for (int i=0;i<8;++i) {
-      h_as[attempt*8+i]=roots_a[0][i]; h_bs[attempt*8+i]=roots_b[0][i];
-      s_as[attempt*8+i]=s_a[i]; s_bs[attempt*8+i]=s_b[i];
+      if (capture_debug) {
+        h_as[attempt*8+i]=roots_a[0][i];
+        h_bs[attempt*8+i]=roots_b[0][i];
+      }
+      s_as[attempt*8+i]=s_a[i];
+      s_bs[attempt*8+i]=s_b[i];
     }
   }
 }
@@ -340,12 +346,13 @@ __global__ void noise_kernel(
 
 __global__ void tile_jackpot_kernel(
     const int8_t* open_a,const int8_t* open_b,const uint32_t* s_as,
-    const uint32_t* target,int32_t* states,uint32_t* jackpots,uint32_t* winner) {
+    const uint32_t* target,int32_t* states,uint32_t* jackpots,uint32_t* winner,
+    bool capture_debug) {
   __shared__ int32_t accum[64]; __shared__ int32_t reduction[64];
+  __shared__ int32_t state[16];
   const uint32_t attempt=blockIdx.x,tid=threadIdx.x;
   const size_t stride=size_t(kOpened)*kK;
   const int8_t* a=open_a+size_t(attempt)*stride; const int8_t* b=open_b+size_t(attempt)*stride;
-  int32_t* state=states+size_t(attempt)*16;
   if(tid<64) accum[tid]=0; if(tid<16) state[tid]=0; __syncthreads();
   for(uint32_t step=0;step<16;++step) {
     if(tid<64) {
@@ -371,6 +378,7 @@ __global__ void tile_jackpot_kernel(
     single_block(block,s_as+size_t(attempt)*8,kKeyed,hash);
 #pragma unroll
     for(int i=0;i<8;++i) jackpots[size_t(attempt)*8+i]=hash[i];
+    if(capture_debug) for(int i=0;i<16;++i) states[size_t(attempt)*16+i]=state[i];
     if(le_target(hash,target)) atomicMin(winner,attempt);
   }
 }
@@ -382,6 +390,7 @@ __global__ void copy_winner_kernel(const uint32_t* winner,const uint32_t* jackpo
 }  // namespace
 
 struct AiPowCudaV3Session {
+  uint32_t device_ordinal;
   uint32_t max_attempts;
   uint32_t routing_len;
   uint32_t offsets_len;
@@ -396,6 +405,7 @@ struct AiPowCudaV3Session {
 namespace {
 void destroy_v3(AiPowCudaV3Session* s) {
   if(!s) return;
+  cudaSetDevice(static_cast<int>(s->device_ordinal));
 #define FREE(field) if(s->field) cudaFree(s->field)
   FREE(winner_hash);FREE(winner);FREE(target);FREE(jackpots);FREE(states);FREE(s_bs);FREE(s_as);
   FREE(h_bs);FREE(h_as);FREE(kappas);FREE(cols);FREE(rows);FREE(offsets);FREE(routing);FREE(mu);FREE(sigma);
@@ -407,7 +417,7 @@ void destroy_v3(AiPowCudaV3Session* s) {
 }
 
 extern "C" int ai_pow_cuda_v3_session_create(
-    uint32_t max_attempts,const int8_t* a_matrix,const int8_t* b_matrix,
+    uint32_t device_ordinal,uint32_t max_attempts,const int8_t* a_matrix,const int8_t* b_matrix,
     const uint8_t sigma[76],const uint8_t mu[52],const uint8_t* routing_data,
     uint32_t routing_data_len,const uint8_t* routing_offsets,uint32_t routing_offsets_len,
     const uint32_t row_indices[8],const uint32_t col_indices[8],AiPowCudaV3Session** out) {
@@ -415,15 +425,17 @@ extern "C" int ai_pow_cuda_v3_session_create(
      routing_data_len>1024||!routing_offsets||!routing_offsets_len||routing_offsets_len>1024||!row_indices||!col_indices)
     return int(cudaErrorInvalidValue);
   *out=nullptr; auto* s=new(std::nothrow) AiPowCudaV3Session{}; if(!s) return int(cudaErrorMemoryAllocation);
+  cudaError_t e=cudaSetDevice(static_cast<int>(device_ordinal));if(e!=cudaSuccess){delete s;return int(e);}
+  s->device_ordinal=device_ordinal;
   const size_t hb=size_t(max_attempts)*32;
   const size_t strips=size_t(max_attempts)*8192;
   s->max_attempts=max_attempts;s->routing_len=routing_data_len;s->offsets_len=routing_offsets_len;
-  cudaError_t e=cudaStreamCreateWithFlags(&s->stream,cudaStreamNonBlocking);if(e!=cudaSuccess)goto fail;
+  e=cudaStreamCreateWithFlags(&s->stream,cudaStreamNonBlocking);if(e!=cudaSuccess)goto fail;
 #define ALLOC(field,bytes) do{e=cudaMalloc(reinterpret_cast<void**>(&s->field),(bytes));if(e!=cudaSuccess)goto fail;}while(0)
   ALLOC(a,65536);ALLOC(b,65536);ALLOC(sigma,76);ALLOC(mu,52);ALLOC(routing,1024);ALLOC(offsets,1024);
   ALLOC(rows,32);ALLOC(cols,32);
-  ALLOC(kappas,hb);ALLOC(h_as,hb);ALLOC(h_bs,hb);ALLOC(s_as,hb);ALLOC(s_bs,hb);ALLOC(open_a,strips);ALLOC(open_b,strips);
-  ALLOC(states,size_t(max_attempts)*64);ALLOC(jackpots,hb);ALLOC(target,32);ALLOC(winner,4);ALLOC(winner_hash,32);
+  ALLOC(kappas,32);ALLOC(h_as,32);ALLOC(h_bs,32);ALLOC(s_as,hb);ALLOC(s_bs,hb);ALLOC(open_a,strips);ALLOC(open_b,strips);
+  ALLOC(states,64);ALLOC(jackpots,hb);ALLOC(target,32);ALLOC(winner,4);ALLOC(winner_hash,32);
 #undef ALLOC
   e=cudaMallocHost(reinterpret_cast<void**>(&s->host_winner),4);if(e!=cudaSuccess)goto fail;e=cudaMallocHost(reinterpret_cast<void**>(&s->host_hash),32);if(e!=cudaSuccess)goto fail;
   e=cudaMemsetAsync(s->routing,0,1024,s->stream);if(e!=cudaSuccess)goto fail;
@@ -438,15 +450,16 @@ fail:destroy_v3(s);return int(e);
 
 extern "C" int ai_pow_cuda_v3_session_search(
     AiPowCudaV3Session* s,uint32_t start,uint32_t attempts,const uint8_t target[32],
-    uint32_t* winner_local,uint8_t jackpot_out[32]) {
-  if(!s||!attempts||attempts>s->max_attempts||!target||!winner_local||!jackpot_out||
+    uint32_t capture_debug,uint32_t* winner_local,uint8_t jackpot_out[32]) {
+  if(!s||!attempts||attempts>s->max_attempts||!target||capture_debug>1||!winner_local||!jackpot_out||
      uint64_t(start)+attempts>(uint64_t(1)<<32)) return int(cudaErrorInvalidValue);
-  cudaError_t e=cudaMemcpyAsync(s->target,target,32,cudaMemcpyHostToDevice,s->stream);if(e!=cudaSuccess)return int(e);
+  cudaError_t e=cudaSetDevice(static_cast<int>(s->device_ordinal));if(e!=cudaSuccess)return int(e);
+  e=cudaMemcpyAsync(s->target,target,32,cudaMemcpyHostToDevice,s->stream);if(e!=cudaSuccess)return int(e);
   e=cudaMemsetAsync(s->winner,0xff,4,s->stream);if(e!=cudaSuccess)return int(e);e=cudaMemsetAsync(s->winner_hash,0,32,s->stream);if(e!=cudaSuccess)return int(e);
   commitments_kernel<<<attempts,160,0,s->stream>>>(start,s->a,s->b,s->sigma,s->mu,s->routing,s->routing_len,s->offsets,s->offsets_len,
-      s->kappas,s->h_as,s->h_bs,s->s_as,s->s_bs);e=cudaGetLastError();if(e!=cudaSuccess)return int(e);
+      s->kappas,s->h_as,s->h_bs,s->s_as,s->s_bs,capture_debug!=0);e=cudaGetLastError();if(e!=cudaSuccess)return int(e);
   noise_kernel<<<attempts,256,0,s->stream>>>(s->a,s->b,s->rows,s->cols,s->s_as,s->s_bs,s->open_a,s->open_b);e=cudaGetLastError();if(e!=cudaSuccess)return int(e);
-  tile_jackpot_kernel<<<attempts,64,0,s->stream>>>(s->open_a,s->open_b,s->s_as,s->target,s->states,s->jackpots,s->winner);
+  tile_jackpot_kernel<<<attempts,64,0,s->stream>>>(s->open_a,s->open_b,s->s_as,s->target,s->states,s->jackpots,s->winner,capture_debug!=0);
   e=cudaGetLastError();if(e!=cudaSuccess)return int(e);copy_winner_kernel<<<1,1,0,s->stream>>>(s->winner,s->jackpots,s->winner_hash);
   e=cudaGetLastError();if(e!=cudaSuccess)return int(e);e=cudaMemcpyAsync(s->host_winner,s->winner,4,cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);
   e=cudaMemcpyAsync(s->host_hash,s->winner_hash,32,cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);e=cudaStreamSynchronize(s->stream);if(e!=cudaSuccess)return int(e);
@@ -458,7 +471,7 @@ extern "C" int ai_pow_cuda_v3_session_debug(
     int8_t a_rows[8192],int8_t b_cols[8192],int32_t state[16],uint8_t jackpot[32]) {
   if(!s||!kappa||!h_a||!h_b||!s_a||!s_b||!a_rows||!b_cols||!state||!jackpot)return int(cudaErrorInvalidValue);
   uint8_t target[32];std::memset(target,0xff,32);uint32_t winner;
-  int status=ai_pow_cuda_v3_session_search(s,extranonce,1,target,&winner,jackpot);if(status)return status;
+  int status=ai_pow_cuda_v3_session_search(s,extranonce,1,target,1,&winner,jackpot);if(status)return status;
 #define GET(destination,source,bytes) do{cudaError_t e=cudaMemcpyAsync((destination),(source),(bytes),cudaMemcpyDeviceToHost,s->stream);if(e!=cudaSuccess)return int(e);}while(0)
   GET(kappa,s->kappas,32);GET(h_a,s->h_as,32);GET(h_b,s->h_bs,32);GET(s_a,s->s_as,32);GET(s_b,s->s_bs,32);
   GET(a_rows,s->open_a,8192);GET(b_cols,s->open_b,8192);GET(state,s->states,64);

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu
@@ -42,6 +42,29 @@ constexpr int kDynamicSmemBytes = kStages * (kSmemABytes + kSmemBBytes);
 constexpr uint64_t kNoWinner = UINT64_MAX;
 constexpr int kRoutingBits = 4;
 constexpr int kRoutingMask = (1 << kRoutingBits) - 1;
+constexpr uint32_t kB3ChunkStart = 1u << 0;
+constexpr uint32_t kB3ChunkEnd = 1u << 1;
+constexpr uint32_t kB3Parent = 1u << 2;
+constexpr uint32_t kB3Root = 1u << 3;
+constexpr uint32_t kB3Keyed = 1u << 4;
+constexpr uint32_t kChunkBytes = 1024;
+constexpr uint32_t kSigmaBytes = 76;
+constexpr uint32_t kMuBytes = 52;
+constexpr uint32_t kTranscriptBytes = kSigmaBytes + kMuBytes;
+constexpr int kPrepareThreads = 256;
+
+__device__ __constant__ uint32_t kB3Iv[8] = {
+    0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+    0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u,
+};
+__device__ __constant__ uint32_t kSeedSaltA[8] = {
+    0x6c404982u, 0x1615eda0u, 0x92f61696u, 0xf876f0fcu,
+    0x2adbdb92u, 0x52b82370u, 0x1977d4f0u, 0x7b0190c3u,
+};
+__device__ __constant__ uint32_t kSeedSaltB[8] = {
+    0x32063011u, 0xca0163ecu, 0x71afe22bu, 0x4f4d3f8bu,
+    0x39c6e91au, 0x04cce888u, 0x1d304448u, 0xa99ab871u,
+};
 
 static_assert(kThreads == 256);
 static_assert(kHashTilesPerCta == 128);
@@ -136,28 +159,155 @@ __device__ __forceinline__ void b3_round(uint32_t state[16], const uint32_t mess
 #undef MSG
 }
 
-__device__ __forceinline__ void b3_keyed_block(
-    const uint32_t message[16], const uint32_t key[8], uint32_t output[8]) {
-  constexpr uint32_t kIv0 = 0x6A09E667u;
-  constexpr uint32_t kIv1 = 0xBB67AE85u;
-  constexpr uint32_t kIv2 = 0x3C6EF372u;
-  constexpr uint32_t kIv3 = 0xA54FF53Au;
-  constexpr uint32_t kFlags = (1u << 0) | (1u << 1) | (1u << 3) | (1u << 4);
-  uint32_t state[16] = {
-      key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[7],
-      kIv0, kIv1, kIv2, kIv3, 0, 0, 64, kFlags};
-  uint32_t block[16];
+__device__ __forceinline__ void b3_compress(
+    const uint32_t message[16],
+    const uint32_t cv[8],
+    uint64_t counter,
+    uint32_t block_len,
+    uint32_t flags,
+    uint32_t output[8]) {
+  uint32_t state[16];
 #pragma unroll
-  for (int i = 0; i < 16; ++i) block[i] = message[i];
-  b3_round<0>(state, block);
-  b3_round<1>(state, block);
-  b3_round<2>(state, block);
-  b3_round<3>(state, block);
-  b3_round<4>(state, block);
-  b3_round<5>(state, block);
-  b3_round<6>(state, block);
+  for (int i = 0; i < 8; ++i) state[i] = cv[i];
+  state[8] = kB3Iv[0];
+  state[9] = kB3Iv[1];
+  state[10] = kB3Iv[2];
+  state[11] = kB3Iv[3];
+  state[12] = static_cast<uint32_t>(counter);
+  state[13] = static_cast<uint32_t>(counter >> 32);
+  state[14] = block_len;
+  state[15] = flags;
+  b3_round<0>(state, message);
+  b3_round<1>(state, message);
+  b3_round<2>(state, message);
+  b3_round<3>(state, message);
+  b3_round<4>(state, message);
+  b3_round<5>(state, message);
+  b3_round<6>(state, message);
 #pragma unroll
   for (int i = 0; i < 8; ++i) output[i] = state[i] ^ state[i + 8];
+}
+
+__device__ __forceinline__ void b3_hash_bytes(
+    const uint8_t* input,
+    uint32_t length,
+    const uint32_t key[8],
+    uint32_t base_flags,
+    uint32_t output[8]) {
+  uint32_t cv[8];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) cv[i] = key[i];
+  const uint32_t blocks = (length + 63u) / 64u;
+  for (uint32_t block_index = 0; block_index < blocks; ++block_index) {
+    uint32_t message[16];
+#pragma unroll
+    for (int word = 0; word < 16; ++word) {
+      uint32_t value = 0;
+#pragma unroll
+      for (int byte = 0; byte < 4; ++byte) {
+        const uint32_t offset = block_index * 64 + word * 4 + byte;
+        if (offset < length) value |= uint32_t(input[offset]) << (byte * 8);
+      }
+      message[word] = value;
+    }
+    const bool first = block_index == 0;
+    const bool last = block_index + 1 == blocks;
+    const uint32_t block_len = last ? length - block_index * 64u : 64u;
+    uint32_t next[8];
+    b3_compress(message, cv, 0, block_len,
+                base_flags | (first ? kB3ChunkStart : 0) |
+                    (last ? (kB3ChunkEnd | kB3Root) : 0),
+                next);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) cv[i] = next[i];
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) output[i] = cv[i];
+}
+
+__device__ __forceinline__ void b3_single_block(
+    const uint32_t message[16],
+    const uint32_t key[8],
+    uint32_t flags,
+    uint32_t output[8]) {
+  b3_compress(message, key, 0, 64,
+              flags | kB3ChunkStart | kB3ChunkEnd | kB3Root, output);
+}
+
+__device__ __forceinline__ void b3_hash_pair(
+    const uint32_t left[8],
+    const uint32_t right[8],
+    uint32_t output[8]) {
+  uint32_t message[16];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    message[i] = left[i];
+    message[i + 8] = right[i];
+  }
+  b3_single_block(message, kB3Iv, 0, output);
+}
+
+__device__ __forceinline__ void b3_chunk_cv(
+    const uint8_t* bytes,
+    uint64_t counter,
+    const uint32_t key[8],
+    uint32_t output[8]) {
+  uint32_t cv[8];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) cv[i] = key[i];
+  for (uint32_t block_index = 0; block_index < 16; ++block_index) {
+    uint32_t message[16];
+#pragma unroll
+    for (int word = 0; word < 16; ++word) {
+      const uint8_t* source = bytes + block_index * 64 + word * 4;
+      message[word] = uint32_t(source[0]) | (uint32_t(source[1]) << 8) |
+                      (uint32_t(source[2]) << 16) |
+                      (uint32_t(source[3]) << 24);
+    }
+    uint32_t next[8];
+    b3_compress(message, cv, counter, 64,
+                kB3Keyed | (block_index == 0 ? kB3ChunkStart : 0) |
+                    (block_index == 15 ? kB3ChunkEnd : 0),
+                next);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) cv[i] = next[i];
+  }
+#pragma unroll
+  for (int i = 0; i < 8; ++i) output[i] = cv[i];
+}
+
+__device__ __forceinline__ void b3_parent_cv(
+    const uint32_t left[8],
+    const uint32_t right[8],
+    const uint32_t key[8],
+    bool root,
+    uint32_t output[8]) {
+  uint32_t message[16];
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    message[i] = left[i];
+    message[i + 8] = right[i];
+  }
+  b3_compress(message, key, 0, 64,
+              kB3Keyed | kB3Parent | (root ? kB3Root : 0), output);
+}
+
+__device__ __forceinline__ void b3_random_hash(
+    uint32_t index,
+    bool b_side,
+    const uint32_t key[8],
+    uint32_t prepend,
+    uint32_t output[8]) {
+  uint32_t message[16]{};
+  message[prepend] = index + 1;
+  message[8] = b_side ? 0x65745f42u : 0x65745f41u;
+  message[9] = 0x726f736eu;
+  b3_single_block(message, key, kB3Keyed, output);
+}
+
+__device__ __forceinline__ void b3_keyed_block(
+    const uint32_t message[16], const uint32_t key[8], uint32_t output[8]) {
+  b3_single_block(message, key, kB3Keyed, output);
 }
 
 __device__ __forceinline__ bool hash_le_target(
@@ -226,6 +376,154 @@ __device__ __forceinline__ void mma_s8(
     static_cast<uint32_t>(accumulator[row][high_col][1]) ^                      \
     static_cast<uint32_t>(accumulator[row][high_col][2]) ^                      \
     static_cast<uint32_t>(accumulator[row][high_col][3]))
+
+__global__ void peak_kappa_kernel(
+    const uint8_t* transcript,
+    uint32_t* kappa) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  uint32_t output[8];
+  b3_hash_bytes(transcript, kTranscriptBytes, kB3Iv, 0, output);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) kappa[i] = output[i];
+}
+
+__global__ void peak_matrix_chunk_kernel(
+    const uint8_t* matrix,
+    uint32_t chunk_count,
+    const uint32_t* key,
+    uint32_t* output) {
+  for (uint32_t chunk = blockIdx.x * blockDim.x + threadIdx.x;
+       chunk < chunk_count;
+       chunk += blockDim.x * gridDim.x) {
+    uint32_t cv[8];
+    b3_chunk_cv(matrix + size_t(chunk) * kChunkBytes, chunk, key, cv);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) output[size_t(chunk) * 8 + i] = cv[i];
+  }
+}
+
+__global__ void peak_matrix_parent_kernel(
+    const uint32_t* input,
+    uint32_t child_count,
+    const uint32_t* key,
+    uint32_t* output) {
+  const uint32_t parent_count = (child_count + 1) / 2;
+  for (uint32_t parent = blockIdx.x * blockDim.x + threadIdx.x;
+       parent < parent_count;
+       parent += blockDim.x * gridDim.x) {
+    const uint32_t left = parent * 2;
+    if (left + 1 == child_count) {
+#pragma unroll
+      for (int i = 0; i < 8; ++i) {
+        output[size_t(parent) * 8 + i] = input[size_t(left) * 8 + i];
+      }
+      continue;
+    }
+    uint32_t cv[8];
+    b3_parent_cv(input + size_t(left) * 8,
+                 input + size_t(left + 1) * 8,
+                 key, child_count == 2, cv);
+#pragma unroll
+    for (int i = 0; i < 8; ++i) output[size_t(parent) * 8 + i] = cv[i];
+  }
+}
+
+__global__ void peak_seed_kernel(
+    const uint32_t* kappa,
+    const uint32_t* h_a,
+    const uint32_t* h_b,
+    uint32_t m,
+    uint32_t n,
+    uint32_t* s_a,
+    uint32_t* s_b) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  uint32_t message_a[16]{};
+  uint32_t message_b[16]{};
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    message_a[i] = h_a[i];
+    message_b[i] = h_b[i];
+  }
+  message_a[8] = m;
+  message_b[8] = n;
+  uint32_t bound_a[8];
+  uint32_t bound_b[8];
+  uint32_t local_s_b[8];
+  uint32_t local_s_a[8];
+  b3_single_block(message_a, kSeedSaltA, kB3Keyed, bound_a);
+  b3_single_block(message_b, kSeedSaltB, kB3Keyed, bound_b);
+  b3_hash_pair(kappa, bound_b, local_s_b);
+  b3_hash_pair(local_s_b, bound_a, local_s_a);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    s_a[i] = local_s_a[i];
+    s_b[i] = local_s_b[i];
+  }
+}
+
+__global__ void peak_uniform_noise_kernel(
+    uint32_t hash_count,
+    bool b_side,
+    const uint32_t* key,
+    int8_t* factors) {
+  for (uint32_t hash_index = blockIdx.x * blockDim.x + threadIdx.x;
+       hash_index < hash_count;
+       hash_index += blockDim.x * gridDim.x) {
+    uint32_t hash[8];
+    b3_random_hash(hash_index, b_side, key, 0, hash);
+#pragma unroll
+    for (int word = 0; word < 8; ++word) {
+#pragma unroll
+      for (int byte = 0; byte < 4; ++byte) {
+        const uint8_t value = uint8_t(hash[word] >> (byte * 8));
+        factors[size_t(hash_index) * 32 + word * 4 + byte] =
+            static_cast<int8_t>(int(value & 63) - 32);
+      }
+    }
+  }
+}
+
+__global__ void peak_position_kernel(
+    uint32_t hash_count,
+    bool b_side,
+    const uint32_t* key,
+    uint32_t* positions) {
+  for (uint32_t hash_index = blockIdx.x * blockDim.x + threadIdx.x;
+       hash_index < hash_count;
+       hash_index += blockDim.x * gridDim.x) {
+    uint32_t hash[8];
+    b3_random_hash(hash_index, b_side, key, 1, hash);
+#pragma unroll
+    for (int slot = 0; slot < 8; ++slot) {
+      const uint32_t random = hash[slot];
+      const uint32_t plus = random & (kRank - 1);
+      const uint32_t minus = plus ^ (1 + __umulhi(kRank - 1, random));
+      const size_t index = size_t(hash_index) * 8 + slot;
+      positions[index * 2] = plus;
+      positions[index * 2 + 1] = minus;
+    }
+  }
+}
+
+__global__ void peak_apply_noise_kernel(
+    const int8_t* source,
+    uint64_t element_count,
+    const int8_t* factors,
+    const uint32_t* positions,
+    int8_t* output) {
+  for (uint64_t index = uint64_t(blockIdx.x) * blockDim.x + threadIdx.x;
+       index < element_count;
+       index += uint64_t(blockDim.x) * gridDim.x) {
+    const uint32_t outer = static_cast<uint32_t>(index / kK);
+    const uint32_t inner = static_cast<uint32_t>(index % kK);
+    const uint32_t plus = positions[size_t(inner) * 2];
+    const uint32_t minus = positions[size_t(inner) * 2 + 1];
+    const int value = int(source[index]) +
+                      int(factors[size_t(outer) * kRank + plus]) -
+                      int(factors[size_t(outer) * kRank + minus]);
+    output[index] = static_cast<int8_t>(value);
+  }
+}
 
 extern "C" __global__ __launch_bounds__(kThreads, 1)
 void ai_pow_v3_peak_kernel(
@@ -517,6 +815,40 @@ void ai_pow_v3_peak_debug_kernel(
   }
 }
 
+cudaError_t launch_peak_matrix_commitment(
+    const int8_t* matrix,
+    uint32_t chunk_count,
+    const uint32_t* key,
+    uint32_t* ping,
+    uint32_t* pong,
+    uint32_t* root,
+    cudaStream_t stream) {
+  const uint32_t chunk_blocks =
+      (chunk_count + kPrepareThreads - 1) / kPrepareThreads;
+  peak_matrix_chunk_kernel<<<chunk_blocks, kPrepareThreads, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(matrix), chunk_count, key, ping);
+  cudaError_t error = cudaGetLastError();
+  if (error != cudaSuccess) return error;
+
+  uint32_t count = chunk_count;
+  uint32_t* input = ping;
+  uint32_t* output = pong;
+  while (count > 1) {
+    const uint32_t parent_count = (count + 1) / 2;
+    const uint32_t parent_blocks =
+        (parent_count + kPrepareThreads - 1) / kPrepareThreads;
+    peak_matrix_parent_kernel<<<parent_blocks, kPrepareThreads, 0, stream>>>(
+        input, count, key, output);
+    error = cudaGetLastError();
+    if (error != cudaSuccess) return error;
+    uint32_t* temporary = input;
+    input = output;
+    output = temporary;
+    count = parent_count;
+  }
+  return cudaMemcpyAsync(root, input, 32, cudaMemcpyDeviceToDevice, stream);
+}
+
 }  // namespace
 
 struct AiPowCudaPeakSession {
@@ -524,13 +856,31 @@ struct AiPowCudaPeakSession {
   uint32_t m;
   uint32_t n;
   uint64_t total_tickets;
+  size_t a_bytes;
+  size_t b_bytes;
   int grid_size;
+  bool source_mode;
+  bool prepared;
   cudaStream_t stream;
   cudaEvent_t start_event;
+  cudaEvent_t commitment_event;
   cudaEvent_t end_event;
+  int8_t* d_source_a;
+  int8_t* d_source_b;
   int8_t* d_a;
   int8_t* d_b;
+  uint8_t* d_transcript;
+  uint32_t* d_kappa;
+  uint32_t* d_h_a;
+  uint32_t* d_h_b;
   uint32_t* d_key;
+  uint32_t* d_s_b;
+  uint32_t* d_cv_ping;
+  uint32_t* d_cv_pong;
+  int8_t* d_e_l;
+  int8_t* d_f_r;
+  uint32_t* d_e_positions;
+  uint32_t* d_f_positions;
   uint32_t* d_target;
   uint64_t* d_winner;
   int32_t* d_debug_state;
@@ -602,6 +952,10 @@ extern "C" int ai_pow_cuda_peak_session_create(
   session->m = m;
   session->n = n;
   session->total_tickets = row_tiles * col_tiles;
+  session->a_bytes = a_bytes;
+  session->b_bytes = b_bytes;
+  session->source_mode = false;
+  session->prepared = true;
 
   cudaDeviceProp properties{};
   cudaError_t error = cudaSetDevice(static_cast<int>(device_ordinal));
@@ -656,13 +1010,262 @@ fail:
   return static_cast<int>(error);
 }
 
+extern "C" int ai_pow_cuda_peak_source_session_create(
+    uint32_t device_ordinal,
+    uint32_t m,
+    uint32_t n,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t tile,
+    const int8_t* a,
+    const int8_t* b,
+    AiPowCudaPeakSession** session_out) {
+  if (session_out == nullptr || a == nullptr || b == nullptr ||
+      m == 0 || n == 0 || k != kK || rank != kRank ||
+      tile != kHashTile || m % kBm != 0 || n % kBn != 0) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  *session_out = nullptr;
+  size_t a_bytes = 0;
+  size_t b_bytes = 0;
+  size_t e_l_bytes = 0;
+  size_t f_r_bytes = 0;
+  if (!checked_product(m, k, &a_bytes) ||
+      !checked_product(n, k, &b_bytes) ||
+      !checked_product(m, rank, &e_l_bytes) ||
+      !checked_product(n, rank, &f_r_bytes)) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  const uint32_t a_chunks = static_cast<uint32_t>(a_bytes / kChunkBytes);
+  const uint32_t b_chunks = static_cast<uint32_t>(b_bytes / kChunkBytes);
+  if (a_bytes % kChunkBytes != 0 || b_bytes % kChunkBytes != 0 ||
+      a_chunks == 0 || b_chunks == 0) {
+    return static_cast<int>(cudaErrorNotSupported);
+  }
+  const uint32_t max_chunks = a_chunks > b_chunks ? a_chunks : b_chunks;
+  size_t cv_words = 0;
+  size_t cv_bytes = 0;
+  size_t position_words = 0;
+  size_t position_bytes = 0;
+  if (!checked_product(max_chunks, 8, &cv_words) ||
+      !checked_product(cv_words, sizeof(uint32_t), &cv_bytes) ||
+      !checked_product(k, 2, &position_words) ||
+      !checked_product(position_words, sizeof(uint32_t), &position_bytes)) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  const uint64_t row_tiles = m / tile;
+  const uint64_t col_tiles = n / tile;
+  if (row_tiles > UINT64_MAX / col_tiles) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+
+  auto* session = static_cast<AiPowCudaPeakSession*>(
+      std::calloc(1, sizeof(AiPowCudaPeakSession)));
+  if (session == nullptr) return static_cast<int>(cudaErrorMemoryAllocation);
+  session->device_ordinal = device_ordinal;
+  session->m = m;
+  session->n = n;
+  session->total_tickets = row_tiles * col_tiles;
+  session->a_bytes = a_bytes;
+  session->b_bytes = b_bytes;
+  session->source_mode = true;
+  session->prepared = false;
+
+  cudaDeviceProp properties{};
+  cudaError_t error = cudaSetDevice(static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) goto fail;
+  error = cudaGetDeviceProperties(&properties, static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) goto fail;
+  if (properties.major != 12 || properties.minor != 0) {
+    error = cudaErrorNotSupported;
+    goto fail;
+  }
+  session->grid_size = properties.multiProcessorCount * 2;
+  error = cudaStreamCreateWithFlags(&session->stream, cudaStreamNonBlocking);
+  if (error != cudaSuccess) goto fail;
+  error = cudaEventCreate(&session->start_event);
+  if (error != cudaSuccess) goto fail;
+  error = cudaEventCreate(&session->commitment_event);
+  if (error != cudaSuccess) goto fail;
+  error = cudaEventCreate(&session->end_event);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_source_a, a_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_source_b, b_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_a, a_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_b, b_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_transcript, kTranscriptBytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_kappa, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_h_a, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_h_b, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_key, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_s_b, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_cv_ping, cv_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_cv_pong, cv_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_e_l, e_l_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_f_r, f_r_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_e_positions, position_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_f_positions, position_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_target, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_winner, sizeof(uint64_t));
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_debug_state, 16 * sizeof(int32_t));
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_debug_hash, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMemcpyAsync(session->d_source_a, a, a_bytes,
+                          cudaMemcpyHostToDevice, session->stream);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMemcpyAsync(session->d_source_b, b, b_bytes,
+                          cudaMemcpyHostToDevice, session->stream);
+  if (error != cudaSuccess) goto fail;
+  error = cudaFuncSetAttribute(ai_pow_v3_peak_kernel,
+                               cudaFuncAttributeMaxDynamicSharedMemorySize,
+                               kDynamicSmemBytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaStreamSynchronize(session->stream);
+  if (error != cudaSuccess) goto fail;
+  *session_out = session;
+  return static_cast<int>(cudaSuccess);
+
+fail:
+  ai_pow_cuda_peak_session_destroy(session);
+  return static_cast<int>(error);
+}
+
+extern "C" int ai_pow_cuda_peak_session_prepare(
+    AiPowCudaPeakSession* session,
+    const uint8_t sigma[76],
+    const uint8_t mu[52],
+    AiPowCudaPeakPrepareResult* result_out) {
+  if (session == nullptr || sigma == nullptr || mu == nullptr ||
+      result_out == nullptr || !session->source_mode) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  session->prepared = false;
+  uint8_t transcript[kTranscriptBytes];
+  std::memcpy(transcript, sigma, kSigmaBytes);
+  std::memcpy(transcript + kSigmaBytes, mu, kMuBytes);
+  cudaError_t error = cudaSetDevice(static_cast<int>(session->device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(session->d_transcript, transcript, kTranscriptBytes,
+                          cudaMemcpyHostToDevice, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventRecord(session->start_event, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  peak_kappa_kernel<<<1, 1, 0, session->stream>>>(
+      session->d_transcript, session->d_kappa);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+
+  const uint32_t a_chunks =
+      static_cast<uint32_t>(session->a_bytes / kChunkBytes);
+  const uint32_t b_chunks =
+      static_cast<uint32_t>(session->b_bytes / kChunkBytes);
+  error = launch_peak_matrix_commitment(
+      session->d_source_a, a_chunks, session->d_kappa,
+      session->d_cv_ping, session->d_cv_pong, session->d_h_a,
+      session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = launch_peak_matrix_commitment(
+      session->d_source_b, b_chunks, session->d_kappa,
+      session->d_cv_ping, session->d_cv_pong, session->d_h_b,
+      session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  peak_seed_kernel<<<1, 1, 0, session->stream>>>(
+      session->d_kappa, session->d_h_a, session->d_h_b,
+      session->m, session->n, session->d_key, session->d_s_b);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventRecord(session->commitment_event, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+
+  const uint32_t e_hashes =
+      static_cast<uint32_t>((size_t(session->m) * kRank) / 32);
+  const uint32_t f_hashes =
+      static_cast<uint32_t>((size_t(session->n) * kRank) / 32);
+  const uint32_t e_blocks =
+      (e_hashes + kPrepareThreads - 1) / kPrepareThreads;
+  const uint32_t f_blocks =
+      (f_hashes + kPrepareThreads - 1) / kPrepareThreads;
+  peak_uniform_noise_kernel<<<e_blocks, kPrepareThreads, 0, session->stream>>>(
+      e_hashes, false, session->d_key, session->d_e_l);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  peak_uniform_noise_kernel<<<f_blocks, kPrepareThreads, 0, session->stream>>>(
+      f_hashes, true, session->d_s_b, session->d_f_r);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  constexpr uint32_t position_hashes = kK / 8;
+  constexpr uint32_t position_blocks =
+      (position_hashes + kPrepareThreads - 1) / kPrepareThreads;
+  peak_position_kernel<<<position_blocks, kPrepareThreads, 0, session->stream>>>(
+      position_hashes, false, session->d_key, session->d_e_positions);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  peak_position_kernel<<<position_blocks, kPrepareThreads, 0, session->stream>>>(
+      position_hashes, true, session->d_s_b, session->d_f_positions);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  const uint32_t noise_blocks =
+      static_cast<uint32_t>(session->grid_size) * 8;
+  peak_apply_noise_kernel<<<noise_blocks, kPrepareThreads, 0, session->stream>>>(
+      session->d_source_a, session->a_bytes, session->d_e_l,
+      session->d_e_positions, session->d_a);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  peak_apply_noise_kernel<<<noise_blocks, kPrepareThreads, 0, session->stream>>>(
+      session->d_source_b, session->b_bytes, session->d_f_r,
+      session->d_f_positions, session->d_b);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventRecord(session->end_event, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventSynchronize(session->end_event);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventElapsedTime(&result_out->commitment_ms, session->start_event,
+                               session->commitment_event);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventElapsedTime(&result_out->noise_ms,
+                               session->commitment_event, session->end_event);
+  if (error != cudaSuccess) return static_cast<int>(error);
+#define COPY_TRANSCRIPT(field, source) do {                                     \
+  error = cudaMemcpy((field), (source), 32, cudaMemcpyDeviceToHost);             \
+  if (error != cudaSuccess) return static_cast<int>(error);                      \
+} while (0)
+  COPY_TRANSCRIPT(result_out->kappa, session->d_kappa);
+  COPY_TRANSCRIPT(result_out->h_a, session->d_h_a);
+  COPY_TRANSCRIPT(result_out->h_b, session->d_h_b);
+  COPY_TRANSCRIPT(result_out->s_a, session->d_key);
+  COPY_TRANSCRIPT(result_out->s_b, session->d_s_b);
+#undef COPY_TRANSCRIPT
+  session->prepared = true;
+  return static_cast<int>(cudaSuccess);
+}
+
 extern "C" int ai_pow_cuda_peak_session_debug(
     AiPowCudaPeakSession* session,
     uint64_t ordinal,
     int32_t state_out[16],
     uint8_t jackpot_out[32]) {
   if (session == nullptr || state_out == nullptr || jackpot_out == nullptr ||
-      ordinal >= session->total_tickets) {
+      !session->prepared || ordinal >= session->total_tickets) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
   cudaError_t error = cudaSetDevice(static_cast<int>(session->device_ordinal));
@@ -689,7 +1292,8 @@ extern "C" int ai_pow_cuda_peak_session_search(
     const uint8_t target[32],
     AiPowCudaPeakSearchResult* result_out) {
   if (session == nullptr || target == nullptr || result_out == nullptr ||
-      ordinal_count == 0 || ordinal_start >= session->total_tickets ||
+      !session->prepared || ordinal_count == 0 ||
+      ordinal_start >= session->total_tickets ||
       ordinal_count > session->total_tickets - ordinal_start) {
     return static_cast<int>(cudaErrorInvalidValue);
   }
@@ -737,6 +1341,17 @@ extern "C" int ai_pow_cuda_peak_session_destroy(AiPowCudaPeakSession* session) {
     if (first == cudaSuccess) first = current;                                   \
   }                                                                              \
 } while (0)
+  FREE_DEVICE(session->d_f_positions);
+  FREE_DEVICE(session->d_e_positions);
+  FREE_DEVICE(session->d_f_r);
+  FREE_DEVICE(session->d_e_l);
+  FREE_DEVICE(session->d_cv_pong);
+  FREE_DEVICE(session->d_cv_ping);
+  FREE_DEVICE(session->d_s_b);
+  FREE_DEVICE(session->d_h_b);
+  FREE_DEVICE(session->d_h_a);
+  FREE_DEVICE(session->d_kappa);
+  FREE_DEVICE(session->d_transcript);
   FREE_DEVICE(session->d_debug_hash);
   FREE_DEVICE(session->d_debug_state);
   FREE_DEVICE(session->d_winner);
@@ -744,9 +1359,15 @@ extern "C" int ai_pow_cuda_peak_session_destroy(AiPowCudaPeakSession* session) {
   FREE_DEVICE(session->d_key);
   FREE_DEVICE(session->d_b);
   FREE_DEVICE(session->d_a);
+  FREE_DEVICE(session->d_source_b);
+  FREE_DEVICE(session->d_source_a);
 #undef FREE_DEVICE
   if (session->end_event != nullptr) {
     const cudaError_t current = cudaEventDestroy(session->end_event);
+    if (first == cudaSuccess) first = current;
+  }
+  if (session->commitment_event != nullptr) {
+    const cudaError_t current = cudaEventDestroy(session->commitment_event);
     if (first == cudaSuccess) first = current;
   }
   if (session->start_event != nullptr) {

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu
@@ -1,0 +1,762 @@
+#include "ai_pow_v3_peak.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+constexpr int kBm = 256;
+constexpr int kBn = 128;
+constexpr int kBk = 64;
+constexpr int kWm = 64;
+constexpr int kWn = 64;
+constexpr int kMmaM = 16;
+constexpr int kMmaN = 8;
+constexpr int kMmaK = 32;
+constexpr int kStages = 2;
+constexpr int kWarpsM = kBm / kWm;
+constexpr int kWarpsN = kBn / kWn;
+constexpr int kWarpsPerCta = kWarpsM * kWarpsN;
+constexpr int kThreads = kWarpsPerCta * 32;
+constexpr int kMmaPerWarpM = kWm / kMmaM;
+constexpr int kMmaPerWarpN = kWn / kMmaN;
+constexpr int kMmaPerWarpK = kBk / kMmaK;
+constexpr int kHashTile = 16;
+constexpr int kHashTilesMPerWarp = kMmaPerWarpM;
+constexpr int kHashTilesNPerWarp = kMmaPerWarpN / 2;
+constexpr int kHashTilesPerWarp = kHashTilesMPerWarp * kHashTilesNPerWarp;
+constexpr int kHashTilesPerCta = kWarpsPerCta * kHashTilesPerWarp;
+constexpr int kTranscriptSlots = 16;
+constexpr int kRank = 512;
+constexpr int kK = 8192;
+constexpr int kCadenceTiles = kRank / kBk;
+constexpr int kGroups = kK / kRank;
+constexpr int kSmemABytes = kBm * kBk;
+constexpr int kSmemBBytes = kBn * kBk;
+constexpr int kDynamicSmemBytes = kStages * (kSmemABytes + kSmemBBytes);
+constexpr uint64_t kNoWinner = UINT64_MAX;
+constexpr int kRoutingBits = 4;
+constexpr int kRoutingMask = (1 << kRoutingBits) - 1;
+
+static_assert(kThreads == 256);
+static_assert(kHashTilesPerCta == 128);
+static_assert(kGroups == kTranscriptSlots);
+static_assert(kCadenceTiles == 8);
+
+bool checked_product(size_t left, size_t right, size_t* out) {
+  if (left != 0 && right > std::numeric_limits<size_t>::max() / left) return false;
+  *out = left * right;
+  return true;
+}
+
+__device__ __forceinline__ uint32_t rotr32(uint32_t value, int shift) {
+  return (value >> shift) | (value << (32 - shift));
+}
+
+#define B3_G(a, b, c, d, mx, my) do { \
+  (a) = (a) + (b) + (mx);               \
+  (d) = rotr32((d) ^ (a), 16);          \
+  (c) = (c) + (d);                      \
+  (b) = rotr32((b) ^ (c), 12);          \
+  (a) = (a) + (b) + (my);               \
+  (d) = rotr32((d) ^ (a), 8);           \
+  (c) = (c) + (d);                      \
+  (b) = rotr32((b) ^ (c), 7);           \
+} while (0)
+
+template <int Round>
+struct B3Schedule;
+
+template <>
+struct B3Schedule<0> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<1> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<2> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<3> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<4> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<5> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7};
+    return schedule[i];
+  }
+};
+template <>
+struct B3Schedule<6> {
+  static __device__ __forceinline__ constexpr int index(int i) {
+    constexpr uint8_t schedule[16] = {11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13};
+    return schedule[i];
+  }
+};
+
+template <int Round>
+__device__ __forceinline__ void b3_round(uint32_t state[16], const uint32_t message[16]) {
+#define MSG(i) message[B3Schedule<Round>::index(i)]
+  B3_G(state[0], state[4], state[8], state[12], MSG(0), MSG(1));
+  B3_G(state[1], state[5], state[9], state[13], MSG(2), MSG(3));
+  B3_G(state[2], state[6], state[10], state[14], MSG(4), MSG(5));
+  B3_G(state[3], state[7], state[11], state[15], MSG(6), MSG(7));
+  B3_G(state[0], state[5], state[10], state[15], MSG(8), MSG(9));
+  B3_G(state[1], state[6], state[11], state[12], MSG(10), MSG(11));
+  B3_G(state[2], state[7], state[8], state[13], MSG(12), MSG(13));
+  B3_G(state[3], state[4], state[9], state[14], MSG(14), MSG(15));
+#undef MSG
+}
+
+__device__ __forceinline__ void b3_keyed_block(
+    const uint32_t message[16], const uint32_t key[8], uint32_t output[8]) {
+  constexpr uint32_t kIv0 = 0x6A09E667u;
+  constexpr uint32_t kIv1 = 0xBB67AE85u;
+  constexpr uint32_t kIv2 = 0x3C6EF372u;
+  constexpr uint32_t kIv3 = 0xA54FF53Au;
+  constexpr uint32_t kFlags = (1u << 0) | (1u << 1) | (1u << 3) | (1u << 4);
+  uint32_t state[16] = {
+      key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[7],
+      kIv0, kIv1, kIv2, kIv3, 0, 0, 64, kFlags};
+  uint32_t block[16];
+#pragma unroll
+  for (int i = 0; i < 16; ++i) block[i] = message[i];
+  b3_round<0>(state, block);
+  b3_round<1>(state, block);
+  b3_round<2>(state, block);
+  b3_round<3>(state, block);
+  b3_round<4>(state, block);
+  b3_round<5>(state, block);
+  b3_round<6>(state, block);
+#pragma unroll
+  for (int i = 0; i < 8; ++i) output[i] = state[i] ^ state[i + 8];
+}
+
+__device__ __forceinline__ bool hash_le_target(
+    const uint32_t hash[8], const uint32_t target[8]) {
+#pragma unroll
+  for (int i = 7; i >= 0; --i) {
+    if (hash[i] < target[i]) return true;
+    if (hash[i] > target[i]) return false;
+  }
+  return true;
+}
+
+__device__ __forceinline__ int swizzled_offset(int row, int col) {
+  const int vector_col = col >> 4;
+  const int vector_row = row >> 1;
+  const int tile_col = (vector_col & 3) + (row & 1) * 4;
+  const int tile_row = vector_row & 3;
+  const int partition = tile_col >> 2;
+  const int permuted = (tile_col & 3) ^ tile_row;
+  return ((partition << 2) + permuted) * 16 + (col & 15) + vector_row * 128;
+}
+
+__device__ __forceinline__ void cp_async_16(void* destination, const void* source) {
+  const uint32_t shared = static_cast<uint32_t>(__cvta_generic_to_shared(destination));
+  asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], 16;\n" ::
+                   "r"(shared), "l"(source));
+}
+
+__device__ __forceinline__ void cp_async_commit() {
+  asm volatile("cp.async.commit_group;\n");
+}
+
+template <int Groups>
+__device__ __forceinline__ void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" :: "n"(Groups));
+}
+
+__device__ __forceinline__ void cp_async_wait_all() {
+  asm volatile("cp.async.wait_all;\n");
+}
+
+__device__ __forceinline__ void ldmatrix_x4(uint32_t (&destination)[4], const void* source) {
+  const uint32_t shared = static_cast<uint32_t>(__cvta_generic_to_shared(source));
+  asm volatile(
+      "ldmatrix.sync.aligned.x4.m8n8.shared.b16 {%0,%1,%2,%3}, [%4];\n" :
+      "=r"(destination[0]), "=r"(destination[1]), "=r"(destination[2]),
+      "=r"(destination[3]) : "r"(shared));
+}
+
+__device__ __forceinline__ void mma_s8(
+    int32_t (&accumulator)[4], const uint32_t (&a)[4], const uint32_t (&b)[2]) {
+  asm volatile(
+      "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite "
+      "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n" :
+      "+r"(accumulator[0]), "+r"(accumulator[1]), "+r"(accumulator[2]),
+      "+r"(accumulator[3]) : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
+      "r"(b[0]), "r"(b[1]));
+}
+
+#define ACCUMULATOR_XOR(row, low_col, high_col) (                              \
+    static_cast<uint32_t>(accumulator[row][low_col][0]) ^                       \
+    static_cast<uint32_t>(accumulator[row][low_col][1]) ^                       \
+    static_cast<uint32_t>(accumulator[row][low_col][2]) ^                       \
+    static_cast<uint32_t>(accumulator[row][low_col][3]) ^                       \
+    static_cast<uint32_t>(accumulator[row][high_col][0]) ^                      \
+    static_cast<uint32_t>(accumulator[row][high_col][1]) ^                      \
+    static_cast<uint32_t>(accumulator[row][high_col][2]) ^                      \
+    static_cast<uint32_t>(accumulator[row][high_col][3]))
+
+extern "C" __global__ __launch_bounds__(kThreads, 1)
+void ai_pow_v3_peak_kernel(
+    const int8_t* __restrict__ a,
+    const int8_t* __restrict__ b,
+    int m,
+    int n,
+    const uint32_t* __restrict__ target,
+    const uint32_t* __restrict__ key,
+    uint64_t ordinal_start,
+    uint64_t ordinal_end,
+    uint64_t* __restrict__ winner) {
+  const int tid = threadIdx.x;
+  const int warp = tid >> 5;
+  const int lane = tid & 31;
+  const int warp_m = (warp / kWarpsN) * kWm;
+  const int warp_n = (warp % kWarpsN) * kWn;
+  const int m_blocks = m / kBm;
+  const int n_blocks = n / kBn;
+  const int routing_x_extent = (1 << kRoutingBits) * m_blocks;
+  const int routing_y_extent =
+      (n_blocks + (1 << kRoutingBits) - 1) >> kRoutingBits;
+  const int total_cta_tiles = routing_x_extent * routing_y_extent;
+  const int grid_stride = gridDim.x;
+
+  extern __shared__ int8_t smem[];
+  __shared__ uint32_t transcript[kTranscriptSlots][kHashTilesPerCta];
+#define SA(stage) (smem + (stage) * kSmemABytes)
+#define SB(stage) (smem + kStages * kSmemABytes + (stage) * kSmemBBytes)
+
+  const int subgroup = lane >> 3;
+  const int row_in_subgroup = lane & 7;
+  const int a_m_offset = (subgroup & 1) * 8;
+  const int a_k_offset = (subgroup >> 1) * 16;
+  const int b_k_offset = subgroup * 16;
+  constexpr int kVectorsA = kSmemABytes / 16 / kThreads;
+  constexpr int kVectorsB = kSmemBBytes / 16 / kThreads;
+  int load_row_a[kVectorsA];
+  int load_col_a[kVectorsA];
+  int load_row_b[kVectorsB];
+  int load_col_b[kVectorsB];
+#pragma unroll
+  for (int vector = 0; vector < kVectorsA; ++vector) {
+    const int index = tid + vector * kThreads;
+    load_row_a[vector] = index / (kBk / 16);
+    load_col_a[vector] = (index % (kBk / 16)) * 16;
+  }
+#pragma unroll
+  for (int vector = 0; vector < kVectorsB; ++vector) {
+    const int index = tid + vector * kThreads;
+    load_row_b[vector] = index / (kBk / 16);
+    load_col_b[vector] = (index % (kBk / 16)) * 16;
+  }
+
+  for (int logical_tile = blockIdx.x; logical_tile < total_cta_tiles;
+       logical_tile += grid_stride) {
+    const int routed_x = logical_tile % routing_x_extent;
+    const int routed_y = logical_tile / routing_x_extent;
+    const int m_block = routed_x >> kRoutingBits;
+    const int n_block = (routed_x & kRoutingMask) + (routed_y << kRoutingBits);
+    if (n_block >= n_blocks) continue;
+    const int cta_m = m_block * kBm;
+    const int cta_n = n_block * kBn;
+
+    for (int index = tid; index < kTranscriptSlots * kHashTilesPerCta;
+         index += kThreads) {
+      transcript[index / kHashTilesPerCta][index % kHashTilesPerCta] = 0;
+    }
+
+    int32_t accumulator[kMmaPerWarpM][kMmaPerWarpN][4];
+#pragma unroll
+    for (int mm = 0; mm < kMmaPerWarpM; ++mm) {
+#pragma unroll
+      for (int nn = 0; nn < kMmaPerWarpN; ++nn) {
+#pragma unroll
+        for (int word = 0; word < 4; ++word) accumulator[mm][nn][word] = 0;
+      }
+    }
+
+#define ISSUE_STAGE(stage, k_tile) do {                                         \
+  if ((k_tile) < kK / kBk) {                                                    \
+    const int8_t* global_a = a + static_cast<size_t>(cta_m) * kK + (k_tile) * kBk; \
+    const int8_t* global_b = b + static_cast<size_t>(cta_n) * kK + (k_tile) * kBk; \
+    _Pragma("unroll")                                                           \
+    for (int vector = 0; vector < kVectorsA; ++vector) {                         \
+      const int row = load_row_a[vector];                                       \
+      const int col = load_col_a[vector];                                       \
+      cp_async_16(SA(stage) + swizzled_offset(row, col),                         \
+                  global_a + static_cast<size_t>(row) * kK + col);               \
+    }                                                                            \
+    _Pragma("unroll")                                                           \
+    for (int vector = 0; vector < kVectorsB; ++vector) {                         \
+      const int row = load_row_b[vector];                                       \
+      const int col = load_col_b[vector];                                       \
+      cp_async_16(SB(stage) + swizzled_offset(row, col),                         \
+                  global_b + static_cast<size_t>(row) * kK + col);               \
+    }                                                                            \
+  }                                                                              \
+  cp_async_commit();                                                             \
+} while (0)
+
+    uint32_t a_fragment[2][kMmaPerWarpM][4];
+    uint32_t b_fragment[kMmaPerWarpK][kMmaPerWarpN][2];
+
+#define LOAD_A(buffer, stage, kk) do {                                           \
+  _Pragma("unroll")                                                             \
+  for (int mm = 0; mm < kMmaPerWarpM; ++mm) {                                   \
+    ldmatrix_x4(a_fragment[buffer][mm],                                          \
+      SA(stage) + swizzled_offset(                                               \
+        warp_m + mm * kMmaM + a_m_offset + row_in_subgroup,                     \
+        (kk) * kMmaK + a_k_offset));                                             \
+  }                                                                              \
+} while (0)
+
+#define LOAD_B(stage) do {                                                       \
+  _Pragma("unroll")                                                             \
+  for (int nn = 0; nn < kMmaPerWarpN; ++nn) {                                   \
+    uint32_t fragment[4];                                                        \
+    ldmatrix_x4(fragment, SB(stage) + swizzled_offset(                           \
+      warp_n + nn * kMmaN + row_in_subgroup, b_k_offset));                      \
+    b_fragment[0][nn][0] = fragment[0];                                         \
+    b_fragment[0][nn][1] = fragment[1];                                         \
+    b_fragment[1][nn][0] = fragment[2];                                         \
+    b_fragment[1][nn][1] = fragment[3];                                         \
+  }                                                                              \
+} while (0)
+
+#define MMA_SUBSTEP(buffer, kk) do {                                             \
+  _Pragma("unroll")                                                             \
+  for (int nn = 0; nn < kMmaPerWarpN; ++nn) {                                   \
+    const bool forward = (((kk) * kMmaPerWarpN + nn) & 1) == 0;                 \
+    _Pragma("unroll")                                                           \
+    for (int iteration = 0; iteration < kMmaPerWarpM; ++iteration) {             \
+      const int mm = forward ? iteration : (kMmaPerWarpM - 1 - iteration);      \
+      mma_s8(accumulator[mm][nn], a_fragment[buffer][mm],                        \
+             b_fragment[kk][nn]);                                                \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define TILE_BODY(current, prefetch, next, tile_number) do {                    \
+  ISSUE_STAGE(prefetch, (tile_number) + kStages - 1);                            \
+  LOAD_A(1, current, 1);                                                        \
+  MMA_SUBSTEP(0, 0);                                                            \
+  cp_async_wait<kStages - 2>();                                                 \
+  __syncthreads();                                                              \
+  LOAD_A(0, next, 0);                                                           \
+  MMA_SUBSTEP(1, 1);                                                            \
+  LOAD_B(next);                                                                 \
+} while (0)
+
+#define WRITE_TRANSCRIPT(slot) do {                                              \
+  uint32_t owned = 0;                                                           \
+  _Pragma("unroll")                                                             \
+  for (int hi = 0; hi < kHashTilesMPerWarp; ++hi) {                             \
+    _Pragma("unroll")                                                           \
+    for (int wi = 0; wi < kHashTilesNPerWarp; ++wi) {                           \
+      uint32_t value = ACCUMULATOR_XOR(hi, 2 * wi, 2 * wi + 1);                 \
+      value = __reduce_xor_sync(0xffffffffu, value);                            \
+      if (lane == hi * kHashTilesNPerWarp + wi) owned = value;                  \
+    }                                                                            \
+  }                                                                              \
+  if (lane < kHashTilesPerWarp) {                                               \
+    transcript[slot][warp * kHashTilesPerWarp + lane] = owned;                  \
+  }                                                                              \
+} while (0)
+
+    ISSUE_STAGE(0, 0);
+    cp_async_wait<0>();
+    __syncthreads();
+    LOAD_B(0);
+    LOAD_A(0, 0, 0);
+
+    int tile_number = 0;
+#pragma unroll 1
+    for (int group = 0; group < kGroups; ++group) {
+#pragma unroll
+      for (int tile = 0; tile < kCadenceTiles; ++tile) {
+        TILE_BODY(tile & 1, (tile + 1) & 1, (tile + 1) & 1, tile_number);
+        ++tile_number;
+      }
+      WRITE_TRANSCRIPT(group);
+    }
+
+    cp_async_wait_all();
+    __syncthreads();
+
+    // Complete warps finalize the CTA's hash tiles. The branch is warp-uniform.
+    if (warp < kHashTilesPerCta / 32) {
+      const int job = tid;
+      uint32_t message[16];
+#pragma unroll
+      for (int slot = 0; slot < 16; ++slot) message[slot] = transcript[slot][job];
+      uint32_t local_key[8];
+      uint32_t local_target[8];
+#pragma unroll
+      for (int word = 0; word < 8; ++word) {
+        local_key[word] = key[word];
+        local_target[word] = target[word];
+      }
+      uint32_t hash[8];
+      b3_keyed_block(message, local_key, hash);
+      if (hash_le_target(hash, local_target)) {
+        const int owner_warp = job / kHashTilesPerWarp;
+        const int owner_tile = job % kHashTilesPerWarp;
+        const int owner_warp_m = owner_warp / kWarpsN;
+        const int owner_warp_n = owner_warp % kWarpsN;
+        const int local_tile_m =
+            owner_warp_m * kHashTilesMPerWarp + owner_tile / kHashTilesNPerWarp;
+        const int local_tile_n =
+            owner_warp_n * kHashTilesNPerWarp + owner_tile % kHashTilesNPerWarp;
+        const uint64_t row_tile = static_cast<uint64_t>(cta_m / kHashTile + local_tile_m);
+        const uint64_t col_tile = static_cast<uint64_t>(cta_n / kHashTile + local_tile_n);
+        const uint64_t ordinal = row_tile * static_cast<uint64_t>(n / kHashTile) + col_tile;
+        if (ordinal >= ordinal_start && ordinal < ordinal_end) {
+          atomicMin(reinterpret_cast<unsigned long long*>(winner),
+                    static_cast<unsigned long long>(ordinal));
+        }
+      }
+    }
+    __syncthreads();
+
+#undef WRITE_TRANSCRIPT
+#undef TILE_BODY
+#undef MMA_SUBSTEP
+#undef LOAD_B
+#undef LOAD_A
+#undef ISSUE_STAGE
+  }
+
+#undef SB
+#undef SA
+}
+
+extern "C" __global__
+void ai_pow_v3_peak_debug_kernel(
+    const int8_t* __restrict__ a,
+    const int8_t* __restrict__ b,
+    int n,
+    uint64_t ordinal,
+    const uint32_t* __restrict__ key,
+    int32_t* __restrict__ state_out,
+    uint32_t* __restrict__ hash_out) {
+  __shared__ int32_t accumulator[256];
+  __shared__ uint32_t reduction[256];
+  __shared__ uint32_t state[16];
+  const int tid = threadIdx.x;
+  const uint64_t col_tiles = static_cast<uint64_t>(n / kHashTile);
+  const uint64_t row_tile = ordinal / col_tiles;
+  const uint64_t col_tile = ordinal - row_tile * col_tiles;
+  const int row = tid / kHashTile;
+  const int col = tid % kHashTile;
+  const int8_t* a_row = a + (row_tile * kHashTile + row) * static_cast<uint64_t>(kK);
+  const int8_t* b_col = b + (col_tile * kHashTile + col) * static_cast<uint64_t>(kK);
+  accumulator[tid] = 0;
+  if (tid < 16) state[tid] = 0;
+  __syncthreads();
+
+#pragma unroll
+  for (int step = 0; step < kGroups; ++step) {
+    int32_t delta = 0;
+    const int offset = step * kRank;
+#pragma unroll 8
+    for (int index = 0; index < kRank; ++index) {
+      delta += static_cast<int32_t>(a_row[offset + index]) *
+               static_cast<int32_t>(b_col[offset + index]);
+    }
+    accumulator[tid] += delta;
+    reduction[tid] = static_cast<uint32_t>(accumulator[tid]);
+    __syncthreads();
+#pragma unroll
+    for (int stride = 128; stride != 0; stride >>= 1) {
+      if (tid < stride) reduction[tid] ^= reduction[tid + stride];
+      __syncthreads();
+    }
+    if (tid == 0) state[step] = reduction[0];
+    __syncthreads();
+  }
+
+  if (tid < 16) state_out[tid] = static_cast<int32_t>(state[tid]);
+  if (tid == 0) {
+    uint32_t local_key[8];
+#pragma unroll
+    for (int word = 0; word < 8; ++word) local_key[word] = key[word];
+    uint32_t hash[8];
+    b3_keyed_block(state, local_key, hash);
+#pragma unroll
+    for (int word = 0; word < 8; ++word) hash_out[word] = hash[word];
+  }
+}
+
+}  // namespace
+
+struct AiPowCudaPeakSession {
+  uint32_t device_ordinal;
+  uint32_t m;
+  uint32_t n;
+  uint64_t total_tickets;
+  int grid_size;
+  cudaStream_t stream;
+  cudaEvent_t start_event;
+  cudaEvent_t end_event;
+  int8_t* d_a;
+  int8_t* d_b;
+  uint32_t* d_key;
+  uint32_t* d_target;
+  uint64_t* d_winner;
+  int32_t* d_debug_state;
+  uint32_t* d_debug_hash;
+};
+
+extern "C" int ai_pow_cuda_peak_kernel_info(
+    uint32_t device_ordinal,
+    AiPowCudaPeakKernelInfo* info_out) {
+  if (info_out == nullptr) return static_cast<int>(cudaErrorInvalidValue);
+  cudaError_t error = cudaSetDevice(static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
+
+  cudaDeviceProp properties{};
+  error = cudaGetDeviceProperties(&properties, static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
+  cudaFuncAttributes attributes{};
+  error = cudaFuncGetAttributes(&attributes, ai_pow_v3_peak_kernel);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  int active_ctas = 0;
+  error = cudaFuncSetAttribute(ai_pow_v3_peak_kernel,
+                               cudaFuncAttributeMaxDynamicSharedMemorySize,
+                               kDynamicSmemBytes);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &active_ctas, ai_pow_v3_peak_kernel, kThreads, kDynamicSmemBytes);
+  if (error != cudaSuccess) return static_cast<int>(error);
+
+  info_out->sm_count = static_cast<uint32_t>(properties.multiProcessorCount);
+  info_out->threads_per_cta = kThreads;
+  info_out->active_ctas_per_sm = static_cast<uint32_t>(active_ctas);
+  info_out->registers_per_thread = static_cast<uint32_t>(attributes.numRegs);
+  info_out->static_shared_bytes =
+      static_cast<uint64_t>(attributes.sharedSizeBytes);
+  info_out->dynamic_shared_bytes = kDynamicSmemBytes;
+  return static_cast<int>(cudaSuccess);
+}
+
+extern "C" int ai_pow_cuda_peak_session_create(
+    uint32_t device_ordinal,
+    uint32_t m,
+    uint32_t n,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t tile,
+    const int8_t* a_prime,
+    const int8_t* b_prime,
+    const uint8_t pow_key[32],
+    AiPowCudaPeakSession** session_out) {
+  if (session_out == nullptr || a_prime == nullptr || b_prime == nullptr ||
+      pow_key == nullptr || m == 0 || n == 0 || k != kK || rank != kRank ||
+      tile != kHashTile || m % kBm != 0 || n % kBn != 0) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  *session_out = nullptr;
+  size_t a_bytes = 0;
+  size_t b_bytes = 0;
+  if (!checked_product(m, k, &a_bytes) || !checked_product(n, k, &b_bytes)) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  const uint64_t row_tiles = m / tile;
+  const uint64_t col_tiles = n / tile;
+  if (row_tiles > UINT64_MAX / col_tiles) return static_cast<int>(cudaErrorInvalidValue);
+
+  auto* session = static_cast<AiPowCudaPeakSession*>(
+      std::calloc(1, sizeof(AiPowCudaPeakSession)));
+  if (session == nullptr) return static_cast<int>(cudaErrorMemoryAllocation);
+  session->device_ordinal = device_ordinal;
+  session->m = m;
+  session->n = n;
+  session->total_tickets = row_tiles * col_tiles;
+
+  cudaDeviceProp properties{};
+  cudaError_t error = cudaSetDevice(static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) goto fail;
+  error = cudaGetDeviceProperties(&properties, static_cast<int>(device_ordinal));
+  if (error != cudaSuccess) goto fail;
+  if (properties.major != 12 || properties.minor != 0) {
+    error = cudaErrorNotSupported;
+    goto fail;
+  }
+  session->grid_size = properties.multiProcessorCount * 2;
+  error = cudaStreamCreateWithFlags(&session->stream, cudaStreamNonBlocking);
+  if (error != cudaSuccess) goto fail;
+  error = cudaEventCreate(&session->start_event);
+  if (error != cudaSuccess) goto fail;
+  error = cudaEventCreate(&session->end_event);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_a, a_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_b, b_bytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_key, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_target, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_winner, sizeof(uint64_t));
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_debug_state, 16 * sizeof(int32_t));
+  if (error != cudaSuccess) goto fail;
+  error = cudaMalloc(&session->d_debug_hash, 32);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMemcpyAsync(session->d_a, a_prime, a_bytes, cudaMemcpyHostToDevice,
+                          session->stream);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMemcpyAsync(session->d_b, b_prime, b_bytes, cudaMemcpyHostToDevice,
+                          session->stream);
+  if (error != cudaSuccess) goto fail;
+  error = cudaMemcpyAsync(session->d_key, pow_key, 32, cudaMemcpyHostToDevice,
+                          session->stream);
+  if (error != cudaSuccess) goto fail;
+  error = cudaFuncSetAttribute(ai_pow_v3_peak_kernel,
+                               cudaFuncAttributeMaxDynamicSharedMemorySize,
+                               kDynamicSmemBytes);
+  if (error != cudaSuccess) goto fail;
+  error = cudaStreamSynchronize(session->stream);
+  if (error != cudaSuccess) goto fail;
+  *session_out = session;
+  return static_cast<int>(cudaSuccess);
+
+fail:
+  ai_pow_cuda_peak_session_destroy(session);
+  return static_cast<int>(error);
+}
+
+extern "C" int ai_pow_cuda_peak_session_debug(
+    AiPowCudaPeakSession* session,
+    uint64_t ordinal,
+    int32_t state_out[16],
+    uint8_t jackpot_out[32]) {
+  if (session == nullptr || state_out == nullptr || jackpot_out == nullptr ||
+      ordinal >= session->total_tickets) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  cudaError_t error = cudaSetDevice(static_cast<int>(session->device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
+  ai_pow_v3_peak_debug_kernel<<<1, 256, 0, session->stream>>>(
+      session->d_a, session->d_b, static_cast<int>(session->n), ordinal,
+      session->d_key, session->d_debug_state, session->d_debug_hash);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(state_out, session->d_debug_state,
+                          16 * sizeof(int32_t), cudaMemcpyDeviceToHost,
+                          session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(jackpot_out, session->d_debug_hash, 32,
+                          cudaMemcpyDeviceToHost, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  return static_cast<int>(cudaStreamSynchronize(session->stream));
+}
+
+extern "C" int ai_pow_cuda_peak_session_search(
+    AiPowCudaPeakSession* session,
+    uint64_t ordinal_start,
+    uint64_t ordinal_count,
+    const uint8_t target[32],
+    AiPowCudaPeakSearchResult* result_out) {
+  if (session == nullptr || target == nullptr || result_out == nullptr ||
+      ordinal_count == 0 || ordinal_start >= session->total_tickets ||
+      ordinal_count > session->total_tickets - ordinal_start) {
+    return static_cast<int>(cudaErrorInvalidValue);
+  }
+  cudaError_t error = cudaSetDevice(static_cast<int>(session->device_ordinal));
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemsetAsync(session->d_winner, 0xff, sizeof(uint64_t), session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpyAsync(session->d_target, target, 32, cudaMemcpyHostToDevice,
+                          session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventRecord(session->start_event, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  ai_pow_v3_peak_kernel<<<session->grid_size, kThreads, kDynamicSmemBytes,
+                          session->stream>>>(
+      session->d_a, session->d_b, static_cast<int>(session->m),
+      static_cast<int>(session->n), session->d_target, session->d_key,
+      ordinal_start, ordinal_start + ordinal_count, session->d_winner);
+  error = cudaGetLastError();
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventRecord(session->end_event, session->stream);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventSynchronize(session->end_event);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaEventElapsedTime(&result_out->kernel_ms, session->start_event,
+                               session->end_event);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  error = cudaMemcpy(&result_out->winner_ordinal, session->d_winner,
+                     sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  if (error != cudaSuccess) return static_cast<int>(error);
+  std::memset(result_out->jackpot, 0, sizeof(result_out->jackpot));
+  if (result_out->winner_ordinal != kNoWinner) {
+    int32_t state[16];
+    return ai_pow_cuda_peak_session_debug(session, result_out->winner_ordinal,
+                                          state, result_out->jackpot);
+  }
+  return static_cast<int>(cudaSuccess);
+}
+
+extern "C" int ai_pow_cuda_peak_session_destroy(AiPowCudaPeakSession* session) {
+  if (session == nullptr) return static_cast<int>(cudaSuccess);
+  cudaError_t first = cudaSetDevice(static_cast<int>(session->device_ordinal));
+#define FREE_DEVICE(pointer) do {                                                \
+  if ((pointer) != nullptr) {                                                    \
+    const cudaError_t current = cudaFree(pointer);                               \
+    if (first == cudaSuccess) first = current;                                   \
+  }                                                                              \
+} while (0)
+  FREE_DEVICE(session->d_debug_hash);
+  FREE_DEVICE(session->d_debug_state);
+  FREE_DEVICE(session->d_winner);
+  FREE_DEVICE(session->d_target);
+  FREE_DEVICE(session->d_key);
+  FREE_DEVICE(session->d_b);
+  FREE_DEVICE(session->d_a);
+#undef FREE_DEVICE
+  if (session->end_event != nullptr) {
+    const cudaError_t current = cudaEventDestroy(session->end_event);
+    if (first == cudaSuccess) first = current;
+  }
+  if (session->start_event != nullptr) {
+    const cudaError_t current = cudaEventDestroy(session->start_event);
+    if (first == cudaSuccess) first = current;
+  }
+  if (session->stream != nullptr) {
+    const cudaError_t current = cudaStreamDestroy(session->stream);
+    if (first == cudaSuccess) first = current;
+  }
+  std::free(session);
+  return static_cast<int>(first);
+}

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h
@@ -14,6 +14,16 @@ typedef struct AiPowCudaPeakSearchResult {
   float kernel_ms;
 } AiPowCudaPeakSearchResult;
 
+typedef struct AiPowCudaPeakPrepareResult {
+  uint8_t kappa[32];
+  uint8_t h_a[32];
+  uint8_t h_b[32];
+  uint8_t s_a[32];
+  uint8_t s_b[32];
+  float commitment_ms;
+  float noise_ms;
+} AiPowCudaPeakPrepareResult;
+
 typedef struct AiPowCudaPeakKernelInfo {
   uint32_t sm_count;
   uint32_t threads_per_cta;
@@ -41,6 +51,28 @@ int ai_pow_cuda_peak_session_create(
     const int8_t* b_prime,
     const uint8_t pow_key[32],
     AiPowCudaPeakSession** session_out);
+
+// Creates a persistent source-matrix session. The source matrices remain
+// resident while prepare replaces every attempt-bound device buffer.
+int ai_pow_cuda_peak_source_session_create(
+    uint32_t device_ordinal,
+    uint32_t m,
+    uint32_t n,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t tile,
+    const int8_t* a,
+    const int8_t* b,
+    AiPowCudaPeakSession** session_out);
+
+// Derives the complete dense Pearl V3 transcript for one 76-byte header and
+// 52-byte mining configuration. The returned values are required for scalar
+// winner validation and proof construction.
+int ai_pow_cuda_peak_session_prepare(
+    AiPowCudaPeakSession* session,
+    const uint8_t sigma[76],
+    const uint8_t mu[52],
+    AiPowCudaPeakPrepareResult* result_out);
 
 // Searches [ordinal_start, ordinal_start + ordinal_count). The lowest matching
 // ordinal is returned. UINT64_MAX means no winner.

--- a/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h
+++ b/crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AiPowCudaPeakSession AiPowCudaPeakSession;
+
+typedef struct AiPowCudaPeakSearchResult {
+  uint64_t winner_ordinal;
+  uint8_t jackpot[32];
+  float kernel_ms;
+} AiPowCudaPeakSearchResult;
+
+typedef struct AiPowCudaPeakKernelInfo {
+  uint32_t sm_count;
+  uint32_t threads_per_cta;
+  uint32_t active_ctas_per_sm;
+  uint32_t registers_per_thread;
+  uint64_t static_shared_bytes;
+  uint64_t dynamic_shared_bytes;
+} AiPowCudaPeakKernelInfo;
+
+int ai_pow_cuda_peak_kernel_info(
+    uint32_t device_ordinal,
+    AiPowCudaPeakKernelInfo* info_out);
+
+// Creates one immutable dense Pearl V3 template session. A is row-major and B
+// is column-major. The first kernel family accepts tile=16, k=8192, rank=512,
+// m divisible by 256, and n divisible by 128.
+int ai_pow_cuda_peak_session_create(
+    uint32_t device_ordinal,
+    uint32_t m,
+    uint32_t n,
+    uint32_t k,
+    uint32_t rank,
+    uint32_t tile,
+    const int8_t* a_prime,
+    const int8_t* b_prime,
+    const uint8_t pow_key[32],
+    AiPowCudaPeakSession** session_out);
+
+// Searches [ordinal_start, ordinal_start + ordinal_count). The lowest matching
+// ordinal is returned. UINT64_MAX means no winner.
+int ai_pow_cuda_peak_session_search(
+    AiPowCudaPeakSession* session,
+    uint64_t ordinal_start,
+    uint64_t ordinal_count,
+    const uint8_t target[32],
+    AiPowCudaPeakSearchResult* result_out);
+
+// Recomputes one ticket on the device. This path is for differential tests and
+// winner readback, not for the no-hit loop.
+int ai_pow_cuda_peak_session_debug(
+    AiPowCudaPeakSession* session,
+    uint64_t ordinal,
+    int32_t state_out[16],
+    uint8_t jackpot_out[32]);
+
+int ai_pow_cuda_peak_session_destroy(AiPowCudaPeakSession* session);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/ai-pow-miner/Cargo.toml
+++ b/crates/ai-pow-miner/Cargo.toml
@@ -19,6 +19,11 @@ name = "ai-pow-mine"
 path = "src/bin/ai_pow_mine.rs"
 required-features = ["node"]
 
+[[bin]]
+name = "ai-pow-peak-bench"
+path = "src/bin/ai_pow_peak_bench.rs"
+required-features = ["gpu"]
+
 [[bench]]
 name = "search"
 harness = false

--- a/crates/ai-pow-miner/README.md
+++ b/crates/ai-pow-miner/README.md
@@ -66,7 +66,7 @@ docker run --rm --gpus all \
   ai-pow-miner-gpu
 ```
 
-The image uses CUDA device `0`, canonical mode, and batches of 32,768 attempts by default. Set `CUDA_DEVICE`, `CANONICAL`, or `GPU_BATCH_ATTEMPTS` to override these values. Non-canonical mode also requires `PEARL_GATEWAY`.
+The image uses up to eight visible CUDA devices, canonical mode, and batches of 32,768 attempts per device by default. Set `CUDA_DEVICES` to `all` or a comma-separated ordinal list such as `0,1,2,3`; set `CANONICAL` or `GPU_BATCH_ATTEMPTS` to override the other values. Non-canonical mode also requires `PEARL_GATEWAY`.
 
 ## Validation
 

--- a/crates/ai-pow-miner/benches/search.rs
+++ b/crates/ai-pow-miner/benches/search.rs
@@ -20,7 +20,7 @@ use ai_pow::pearl_compat::{
 use ai_pow::synth::{synth_matrices, AI_POW_PROD_SYNTH_SEED};
 use ai_pow_miner::canonical::PreparedCanonicalMoeTemplate;
 #[cfg(feature = "gpu")]
-use ai_pow_miner::gpu::GpuSearchBackend;
+use ai_pow_miner::gpu::{GpuSearchBackend, MultiGpuSearchBackend};
 use ai_pow_miner::search::{CpuSearchBackend, SearchBackend, SearchBatch};
 use ai_pow_miner::DENSE_PRODUCTION_PARAMS;
 
@@ -238,6 +238,40 @@ fn main() {
             1,
             canonical_gpu_measurement,
         );
+
+        let device_count = GpuSearchBackend::available_device_count()
+            .expect("visible CUDA devices")
+            .min(8);
+        if device_count > 1 {
+            let attempts_per_device = u64::from(canonical_attempts).div_ceil(device_count as u64);
+            let multi_gpu_backend = MultiGpuSearchBackend::all_visible(attempts_per_device)
+                .expect("multi-GPU search backend");
+            multi_gpu_backend
+                .search_canonical(
+                    Arc::clone(&canonical_template),
+                    SearchBatch::new(0, device_count as u64, [0; 32])
+                        .expect("multi-GPU warmup batch"),
+                )
+                .expect("multi-GPU warmup");
+            let canonical_multi_gpu_measurement = measure(|| {
+                std::hint::black_box(
+                    multi_gpu_backend
+                        .search_canonical(
+                            Arc::clone(&canonical_template),
+                            SearchBatch::new(0, u64::from(canonical_attempts), [0; 32])
+                                .expect("multi-GPU canonical batch"),
+                        )
+                        .expect("multi-GPU canonical search"),
+                );
+            });
+            print_measurement(
+                "canonical_prepared_multi_cuda",
+                u64::from(canonical_attempts),
+                canonical_shape_work_factor,
+                device_count,
+                canonical_multi_gpu_measurement,
+            );
+        }
     }
 
     let header = dense_header();

--- a/crates/ai-pow-miner/build.rs
+++ b/crates/ai-pow-miner/build.rs
@@ -5,7 +5,9 @@ use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.cu");
     println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_v3.cu");
+    println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu");
     println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_gemm.h");
+    println!("cargo:rerun-if-changed=../ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h");
     println!("cargo:rerun-if-env-changed=AI_POW_CUDA_ARCH");
     println!("cargo:rerun-if-env-changed=AI_POW_CUDA_CODE");
     println!("cargo:rerun-if-env-changed=CUDA_HOME");
@@ -18,7 +20,7 @@ fn main() {
     let arch = env::var("AI_POW_CUDA_ARCH").unwrap_or_else(|_| "compute_89".to_owned());
     let code = env::var("AI_POW_CUDA_CODE").unwrap_or_else(|_| "compute_89".to_owned());
     let mut objects = Vec::new();
-    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu"] {
+    for source in ["ai_pow_gemm.cu", "ai_pow_v3.cu", "ai_pow_v3_peak.cu"] {
         let object = out_dir.join(format!("{source}.o"));
         let status = Command::new("nvcc")
             .args([

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -69,10 +69,10 @@ struct AcceleratorArgs {
     #[arg(long)]
     gpu: bool,
 
-    /// CUDA device ordinal. The current backend supports device 0.
+    /// CUDA device ordinals as a comma-separated list, or `all` for up to eight visible devices.
     #[cfg(feature = "gpu")]
-    #[arg(long, default_value_t = 0)]
-    cuda_device: usize,
+    #[arg(long, default_value = "all")]
+    cuda_devices: String,
 
     /// Attempts dispatched through CUDA before the scheduler checks cancellation.
     #[cfg(feature = "gpu")]
@@ -80,16 +80,34 @@ struct AcceleratorArgs {
     gpu_batch_attempts: u64,
 }
 
+#[cfg(feature = "gpu")]
+fn gpu_backend(args: &AcceleratorArgs) -> Result<ai_pow_miner::gpu::MultiGpuSearchBackend, String> {
+    let selection = args.cuda_devices.trim();
+    if selection.eq_ignore_ascii_case("all") {
+        return ai_pow_miner::gpu::MultiGpuSearchBackend::all_visible(args.gpu_batch_attempts)
+            .map_err(|error| error.to_string());
+    }
+    let ordinals = selection
+        .split(',')
+        .map(|value| {
+            let value = value.trim();
+            value
+                .parse::<usize>()
+                .map_err(|_| format!("invalid CUDA device ordinal `{value}`"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    ai_pow_miner::gpu::MultiGpuSearchBackend::new(ordinals, args.gpu_batch_attempts)
+        .map_err(|error| error.to_string())
+}
+
 fn search_backend(args: &Args) -> Result<Arc<dyn SearchBackend>, String> {
     #[cfg(feature = "gpu")]
     if args.accelerator.gpu {
-        let backend = ai_pow_miner::gpu::GpuSearchBackend::new(
-            args.accelerator.cuda_device, args.accelerator.gpu_batch_attempts,
-        )
-        .map_err(|error| error.to_string())?;
+        let backend = gpu_backend(&args.accelerator)?;
         info!(
-            cuda_device = backend.device_ordinal(),
-            gpu_batch_attempts = backend.batch_attempts(),
+            cuda_devices = ?backend.device_ordinals(),
+            gpu_batch_attempts_per_device = backend.batch_attempts_per_device(),
+            gpu_batch_attempts_total = backend.batch_attempts(),
             "ai-pow-mine: CUDA search enabled"
         );
         return Ok(MeteredSearchBackend::new("cuda", Arc::new(backend)));

--- a/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_mine.rs
@@ -5,27 +5,21 @@
 //! effects, searches Pearl-compatible tickets, builds the recursive
 //! certificate only after a Nockchain target hit, and submits
 //! `[%command %pow %ai-pow nonce cert]` on the `AiPowMinerWire::Mined` wire
-//! (`SOURCE = "ai-pow-miner"`, `VERSION = 1`). The production submission path
-//! fails closed for multi-tile configurations until the recursive statement
-//! binds a full-matrix aggregate.
+//! (`SOURCE = "ai-pow-miner"`, `VERSION = 1`).
 //!
-//! Quick start (assuming a fakenet node on `127.0.0.1:5555` and Pearl Gateway
-//! on `/tmp/pearlgw.sock`):
+//! The production CUDA route is `--gpu --canonical`. It searches the fixed
+//! dense Pearl V3 profile across all visible GPUs unless `--cuda-devices`
+//! selects a subset. Scalar Rust recomputes every reported winner before the
+//! host builds the existing compact recursive certificate.
 //!
-//!   ai-pow-mine \
+//!   ai-pow-mine --gpu --canonical \
 //!       --mining-pkh 9yPePjfWAdUnzaQKyxcRXKRa5PpUzKKEwtpECBZsUYt9Jd7egSDEWoV
 //!
-//! The CLI defaults to Pearl-compatible submission with single-tile,
-//! production-envelope smoke parameters for local Layer-0 development. The
-//! Pearl work source is Pearl Gateway miner RPC; the endpoint defaults to the
-//! Unix socket `/tmp/pearlgw.sock`. Use `--pearl-gateway tcp://host:port` for a
-//! TCP gateway or `--pearl-gateway /path/to.sock` for a different Unix socket.
-//! Rewards must be configured with v1 pubkey-hash configs via `--mining-pkh`
-//! or `--mining-pkh-adv`.
-//! The production profile
-//! derives canonical seeds from the nonce-keyed chunk commitments bound by the
-//! recursive proof as `HASH_A` / `HASH_B`; larger production shapes remain
-//! closed until full-matrix aggregation is implemented.
+//! `--canonical` without `--gpu` retains the gateway-free CPU MoE route. Without
+//! `--canonical`, the miner uses the Pearl Gateway route configured by
+//! `--pearl-gateway`.
+//! Rewards use v1 pubkey-hash configs from `--mining-pkh` or
+//! `--mining-pkh-adv`.
 //!
 //! ## AI puzzle inputs (local config)
 //! The chain's `%mine-ai` effect carries the candidate block commitment,
@@ -81,11 +75,10 @@ struct AcceleratorArgs {
 }
 
 #[cfg(feature = "gpu")]
-fn gpu_backend(args: &AcceleratorArgs) -> Result<ai_pow_miner::gpu::MultiGpuSearchBackend, String> {
+fn cuda_device_ordinals(args: &AcceleratorArgs) -> Result<Option<Vec<usize>>, String> {
     let selection = args.cuda_devices.trim();
     if selection.eq_ignore_ascii_case("all") {
-        return ai_pow_miner::gpu::MultiGpuSearchBackend::all_visible(args.gpu_batch_attempts)
-            .map_err(|error| error.to_string());
+        return Ok(None);
     }
     let ordinals = selection
         .split(',')
@@ -96,8 +89,18 @@ fn gpu_backend(args: &AcceleratorArgs) -> Result<ai_pow_miner::gpu::MultiGpuSear
                 .map_err(|_| format!("invalid CUDA device ordinal `{value}`"))
         })
         .collect::<Result<Vec<_>, _>>()?;
-    ai_pow_miner::gpu::MultiGpuSearchBackend::new(ordinals, args.gpu_batch_attempts)
-        .map_err(|error| error.to_string())
+    Ok(Some(ordinals))
+}
+
+#[cfg(feature = "gpu")]
+fn gpu_backend(args: &AcceleratorArgs) -> Result<ai_pow_miner::gpu::MultiGpuSearchBackend, String> {
+    match cuda_device_ordinals(args)? {
+        Some(ordinals) => {
+            ai_pow_miner::gpu::MultiGpuSearchBackend::new(ordinals, args.gpu_batch_attempts)
+        }
+        None => ai_pow_miner::gpu::MultiGpuSearchBackend::all_visible(args.gpu_batch_attempts),
+    }
+    .map_err(|error| error.to_string())
 }
 
 fn search_backend(args: &Args) -> Result<Arc<dyn SearchBackend>, String> {
@@ -123,6 +126,42 @@ fn search_backend(args: &Args) -> Result<Arc<dyn SearchBackend>, String> {
         .map_err(|error| error.to_string())
 }
 
+#[cfg(feature = "gpu")]
+fn run_peak_if_selected(
+    args: &Args,
+    rt: &tokio::runtime::Runtime,
+) -> Result<Option<Result<(), MinerError>>, String> {
+    if !(args.common.canonical && args.accelerator.gpu) {
+        return Ok(None);
+    }
+    let pkh_configs = args
+        .common
+        .mining_pkh_configs()
+        .map_err(|error| format!("{error:#}"))?;
+    let node_addr = args.common.node_addr.clone();
+    let device_ordinals = cuda_device_ordinals(&args.accelerator)?;
+    Ok(Some(rt.block_on(async move {
+        info!(node = %node_addr, "ai-pow-mine: starting peak production miner");
+        let shutdown = CancellationToken::new();
+        let shutdown_clone = shutdown.clone();
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                info!("ai-pow-mine: SIGINT received; shutting down");
+                shutdown_clone.cancel();
+            }
+        });
+        ai_pow_miner::run::run_peak(node_addr, pkh_configs, shutdown, device_ordinals).await
+    })))
+}
+
+#[cfg(not(feature = "gpu"))]
+fn run_peak_if_selected(
+    _: &Args,
+    _: &tokio::runtime::Runtime,
+) -> Result<Option<Result<(), MinerError>>, String> {
+    Ok(None)
+}
+
 fn main() -> ExitCode {
     let args = Args::parse();
     init_tracing(&args.common.log);
@@ -138,7 +177,17 @@ fn main() -> ExitCode {
         }
     };
 
-    let result = if args.common.canonical {
+    let peak_result = match run_peak_if_selected(&args, &rt) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("ai-pow-mine: cannot initialize peak miner: {error}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let result = if let Some(result) = peak_result {
+        result
+    } else if args.common.canonical {
         let backend = match search_backend(&args) {
             Ok(backend) => backend,
             Err(error) => {

--- a/crates/ai-pow-miner/src/bin/ai_pow_peak_bench.rs
+++ b/crates/ai-pow-miner/src/bin/ai_pow_peak_bench.rs
@@ -1,0 +1,181 @@
+use std::time::Instant;
+
+use ai_pow::matmul::TileState;
+use ai_pow::pearl_compat::pearl_jackpot_hash;
+use ai_pow_miner::peak::{PeakCudaSession, PEAK_K, PEAK_RANK, PEAK_TILE};
+use anyhow::{bail, Context, Result};
+
+#[derive(Clone, Copy)]
+struct Options {
+    device: usize,
+    m: usize,
+    n: usize,
+    iterations: usize,
+    warmup_iterations: usize,
+}
+
+fn main() -> Result<()> {
+    let options = parse_options()?;
+    let kernel_info = PeakCudaSession::kernel_info(options.device)?;
+    let total_tickets = (options.m / PEAK_TILE)
+        .checked_mul(options.n / PEAK_TILE)
+        .context("ticket count overflow")?;
+    eprintln!(
+        "preparing m={} n={} k={} rank={} tickets={}",
+        options.m, options.n, PEAK_K, PEAK_RANK, total_tickets
+    );
+
+    let mut random_state = 0x0123_4567_89ab_cdefu64;
+    let mut next_value = || {
+        random_state ^= random_state << 13;
+        random_state ^= random_state >> 7;
+        random_state ^= random_state << 17;
+        ((random_state >> 32) as u8 & 0x7f) as i8 - 64
+    };
+    let mut a = Vec::with_capacity(options.m * PEAK_K);
+    a.resize_with(options.m * PEAK_K, &mut next_value);
+    let mut b = Vec::with_capacity(options.n * PEAK_K);
+    b.resize_with(options.n * PEAK_K, &mut next_value);
+    let key = std::array::from_fn(|index| (index as u8).wrapping_mul(17).wrapping_add(3));
+
+    let prepare_started = Instant::now();
+    let mut session = PeakCudaSession::new(options.device, options.m, options.n, &a, &b, &key)?;
+    let prepare_ms = prepare_started.elapsed().as_secs_f64() * 1_000.0;
+
+    let check_ordinals = [0, (total_tickets / 2) as u64, total_tickets as u64 - 1];
+    for ordinal in check_ordinals {
+        let device = session.debug_ticket(ordinal)?;
+        let scalar = scalar_ticket(&a, &b, options.n, ordinal);
+        if device.state != scalar {
+            bail!("device transcript differs from scalar oracle at ordinal {ordinal}");
+        }
+        if device.jackpot != pearl_jackpot_hash(&scalar, &key) {
+            bail!("device jackpot differs from scalar oracle at ordinal {ordinal}");
+        }
+    }
+
+    let target = [0u8; 32];
+    for _ in 0..options.warmup_iterations {
+        let warmup = session.search(0, session.total_tickets(), &target)?;
+        if warmup.winner.is_some() {
+            bail!("zero-target warmup returned a winner");
+        }
+    }
+
+    let mut kernel_ms = Vec::with_capacity(options.iterations);
+    let mut wall_ms = Vec::with_capacity(options.iterations);
+    for _ in 0..options.iterations {
+        let started = Instant::now();
+        let result = session.search(0, session.total_tickets(), &target)?;
+        let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
+        if result.winner.is_some() {
+            bail!("zero-target benchmark returned a winner");
+        }
+        kernel_ms.push(f64::from(result.kernel_ms));
+        wall_ms.push(elapsed_ms);
+    }
+    kernel_ms.sort_by(f64::total_cmp);
+    wall_ms.sort_by(f64::total_cmp);
+    let median_kernel_ms = median(&kernel_ms);
+    let median_wall_ms = median(&wall_ms);
+    let tickets_per_second = total_tickets as f64 * 1_000.0 / median_kernel_ms;
+    println!("device\tsms\tthreads_per_cta\tactive_ctas_per_sm\tregisters_per_thread\tstatic_shared_bytes\tdynamic_shared_bytes\tm\tn\tk\trank\ttickets\tprepare_ms\tkernel_min_ms\tkernel_median_ms\tkernel_max_ms\twall_median_ms\ttickets_per_s\ttmac_per_s");
+    let tmac_per_second = tickets_per_second * (PEAK_TILE * PEAK_TILE * PEAK_K) as f64 / 1.0e12;
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.6}",
+        options.device,
+        kernel_info.sm_count,
+        kernel_info.threads_per_cta,
+        kernel_info.active_ctas_per_sm,
+        kernel_info.registers_per_thread,
+        kernel_info.static_shared_bytes,
+        kernel_info.dynamic_shared_bytes,
+        options.m,
+        options.n,
+        PEAK_K,
+        PEAK_RANK,
+        total_tickets,
+        prepare_ms,
+        kernel_ms[0],
+        median_kernel_ms,
+        kernel_ms[kernel_ms.len() - 1],
+        median_wall_ms,
+        tickets_per_second,
+        tmac_per_second,
+    );
+    Ok(())
+}
+
+fn parse_options() -> Result<Options> {
+    let mut options = Options {
+        device: 0,
+        m: 4096,
+        n: 32768,
+        iterations: 7,
+        warmup_iterations: 100,
+    };
+    let mut args = std::env::args().skip(1);
+    while let Some(argument) = args.next() {
+        let value = match argument.as_str() {
+            "--help" | "-h" => {
+                println!("Usage: ai_pow_peak_bench [--device N] [--m N] [--n N] [--warmup-iterations N] [--iterations N]");
+                return Ok(options);
+            }
+            "--device" | "--m" | "--n" | "--warmup-iterations" | "--iterations" => args
+                .next()
+                .with_context(|| format!("{argument} requires a value"))?,
+            _ => bail!("unknown argument {argument}"),
+        };
+        match argument.as_str() {
+            "--device" => options.device = value.parse().context("invalid --device")?,
+            "--m" => options.m = value.parse().context("invalid --m")?,
+            "--n" => options.n = value.parse().context("invalid --n")?,
+            "--warmup-iterations" => {
+                options.warmup_iterations = value.parse().context("invalid --warmup-iterations")?
+            }
+            "--iterations" => options.iterations = value.parse().context("invalid --iterations")?,
+            _ => unreachable!(),
+        }
+    }
+    if options.iterations == 0 {
+        bail!("--iterations must be nonzero");
+    }
+    if options.m == 0 || options.m % 256 != 0 || options.n == 0 || options.n % 128 != 0 {
+        bail!("shape requires nonzero m%256==0 and n%128==0");
+    }
+    Ok(options)
+}
+
+fn scalar_ticket(a: &[i8], b: &[i8], n: usize, ordinal: u64) -> TileState {
+    let col_tiles = n / PEAK_TILE;
+    let row_tile = ordinal as usize / col_tiles;
+    let col_tile = ordinal as usize % col_tiles;
+    let mut cells = [0i32; PEAK_TILE * PEAK_TILE];
+    let mut state = [0i32; 16];
+    for step in 0..PEAK_K / PEAK_RANK {
+        for row in 0..PEAK_TILE {
+            let a_base = (row_tile * PEAK_TILE + row) * PEAK_K + step * PEAK_RANK;
+            for col in 0..PEAK_TILE {
+                let b_base = (col_tile * PEAK_TILE + col) * PEAK_K + step * PEAK_RANK;
+                let mut delta = 0i32;
+                for index in 0..PEAK_RANK {
+                    delta += i32::from(a[a_base + index]) * i32::from(b[b_base + index]);
+                }
+                let cell = row * PEAK_TILE + col;
+                cells[cell] = cells[cell].saturating_add(delta);
+            }
+        }
+        state[step] = cells
+            .iter()
+            .fold(0u32, |value, cell| value ^ (*cell as u32)) as i32;
+    }
+    TileState(state)
+}
+
+fn median(values: &[f64]) -> f64 {
+    if values.len() % 2 == 0 {
+        (values[values.len() / 2 - 1] + values[values.len() / 2]) * 0.5
+    } else {
+        values[values.len() / 2]
+    }
+}

--- a/crates/ai-pow-miner/src/canonical.rs
+++ b/crates/ai-pow-miner/src/canonical.rs
@@ -14,21 +14,30 @@
 //! depend back on it. Keep them in sync with the jets copy (the node's setup
 //! builder must prove the same shape it later verifies).
 
+use std::sync::Arc;
+
 use ai_pow::fiat_shamir::canonical_noise_seeds_moe;
 use ai_pow::matmul::{
     compute_pattern_tile_state_from_slices, BlockNoise, PatternTileScratch, TileState,
 };
 use ai_pow::params::MatmulParams;
 use ai_pow::pearl_compat::{
-    compute_pearl_moe_ticket, derive_pearl_moe_work_commitments, moe_expert_b_cols_from_local,
+    compute_pearl_moe_ticket, derive_pearl_moe_work_commitments,
+    evaluate_pearl_merge_checked_ticket_attempt, moe_expert_b_cols_from_local,
     pearl_bitcoin_double_sha256_raw, pearl_jackpot_hash, pearl_kappa, pearl_matrix_commitments,
-    PearlAuxInclusionProof, PearlIncompleteBlockHeader, PearlMiningConfig, PearlMoeParams,
-    PearlNockchainAux, PearlPeriodicPattern, PearlPublicProofParams, PearlWorkCommitments,
-    PEARL_MMA_INT7XINT7_TO_INT32, PEARL_NOCKCHAIN_AUX_COMMITMENT_TAG,
+    prepare_pearl_pattern_job, PearlAuxInclusionProof, PearlIncompleteBlockHeader,
+    PearlMergeCheckedTicketAttempt, PearlMiningConfig, PearlMoeParams, PearlNockchainAux,
+    PearlPeriodicPattern, PearlPublicProofParams, PearlWorkCommitments, PreparedPearlPatternJob,
+    PEARL_MINING_CONFIG_RESERVED_SIZE, PEARL_MMA_INT7XINT7_TO_INT32,
+    PEARL_NOCKCHAIN_AUX_COMMITMENT_TAG,
 };
 use ai_pow::pearl_moe_routing::build_routing_data;
 use ai_pow::synth::{synth_matrices, AI_POW_PROD_SYNTH_SEED};
-use ai_pow::zk_bridge::{prove_pearl_moe_compact_recursive_certificate, PearlMoeCompactProveRun};
+use ai_pow::zk_bridge::{
+    prove_pearl_merge_compact_recursive_certificate_checked,
+    prove_pearl_moe_compact_recursive_certificate, AiPowCompactRecursiveCertificateRun,
+    PearlMoeCompactProveRun,
+};
 
 use crate::certificate_noun::{
     AiPowCertificateShape, AiProofNode, PearlMergeMoeArtifact, PearlMergePublicStatementShape,
@@ -56,6 +65,17 @@ pub struct CanonicalBlock {
     pub aux_inclusion: PearlAuxInclusionProof,
     pub moe_art: PearlMergeMoeArtifact,
     pub certificate: AiPowCertificateShape,
+    pub commit: [u8; 32],
+    pub jackpot_hash: [u8; 32],
+}
+
+/// A proved dense canonical block that is ready for `AIP1` artifact encoding.
+pub struct CanonicalDenseBlock {
+    pub attempt: PearlMergeCheckedTicketAttempt,
+    pub aux_inclusion: PearlAuxInclusionProof,
+    pub a: Arc<Vec<i8>>,
+    pub b: Arc<Vec<i8>>,
+    pub run: AiPowCompactRecursiveCertificateRun,
     pub commit: [u8; 32],
     pub jackpot_hash: [u8; 32],
 }
@@ -193,6 +213,32 @@ pub struct PreparedCanonicalMoeTemplate {
     aux_commitment: [u8; 32],
     aux_inclusion: PearlAuxInclusionProof,
     mu: [u8; ai_pow::pearl_compat::PEARL_MINING_CONFIG_SIZE],
+}
+
+/// Immutable dense canonical inputs for one Nockchain block commitment.
+///
+/// Source matrices and auxiliary inclusion remain immutable across
+/// attempt-bound search transcripts.
+pub struct PreparedCanonicalDenseTemplate {
+    params: MatmulParams,
+    config: PearlMiningConfig,
+    a: Arc<Vec<i8>>,
+    b: Arc<Vec<i8>>,
+    header: PearlIncompleteBlockHeader,
+    aux: PearlNockchainAux,
+    aux_inclusion: PearlAuxInclusionProof,
+}
+
+/// Host metadata for one dense search transcript prepared on the GPU.
+pub struct PreparedCanonicalDenseSearch {
+    extranonce: u32,
+    header: PearlIncompleteBlockHeader,
+    config: PearlMiningConfig,
+    params: MatmulParams,
+    sigma: [u8; ai_pow::pearl_compat::PEARL_INCOMPLETE_BLOCK_HEADER_SIZE],
+    mu: [u8; ai_pow::pearl_compat::PEARL_MINING_CONFIG_SIZE],
+    row_tickets: u64,
+    col_tickets: u64,
 }
 
 /// Reusable mutable storage for one canonical template worker.
@@ -439,6 +485,243 @@ impl PreparedCanonicalMoeTemplate {
         usize,
     ) {
         (&self.routing, &self.inner, &self.local_b, self.n_e, self.m)
+    }
+}
+
+impl PreparedCanonicalDenseTemplate {
+    pub fn new(
+        params: &MatmulParams,
+        nock_commit: [u8; 32],
+        a: Arc<Vec<i8>>,
+        b: Arc<Vec<i8>>,
+    ) -> Result<Self, CanonicalProveError> {
+        params
+            .validate_prod_envelope()
+            .map_err(err("dense canonical parameter envelope"))?;
+        if params.spot_checks != 1 || params.difficulty_bits != 0 {
+            return Err(CanonicalProveError(
+                "dense canonical proof requires spot_checks=1 and difficulty_bits=0".to_string(),
+            ));
+        }
+        let expected_a = usize::try_from(params.m)
+            .ok()
+            .and_then(|m| m.checked_mul(params.k as usize))
+            .ok_or_else(|| CanonicalProveError("dense A length overflow".to_string()))?;
+        let expected_b = usize::try_from(params.n)
+            .ok()
+            .and_then(|n| n.checked_mul(params.k as usize))
+            .ok_or_else(|| CanonicalProveError("dense B length overflow".to_string()))?;
+        if a.len() != expected_a || b.len() != expected_b {
+            return Err(CanonicalProveError(format!(
+                "dense matrix lengths must be {expected_a} and {expected_b}, got {} and {}",
+                a.len(),
+                b.len()
+            )));
+        }
+        let config = PearlMiningConfig {
+            common_dim: params.k,
+            rank: u16::try_from(params.noise_rank)
+                .map_err(|_| CanonicalProveError("dense rank does not fit u16".to_string()))?,
+            mma_type: PEARL_MMA_INT7XINT7_TO_INT32,
+            rows_pattern: setup_pattern(params.tile),
+            cols_pattern: setup_pattern(params.tile),
+            reserved: [0; PEARL_MINING_CONFIG_RESERVED_SIZE],
+        };
+        config.to_bytes().map_err(err("dense mining config"))?;
+        let aux = setup_aux(nock_commit);
+        let aux_commitment = aux.commitment().map_err(err("dense aux commitment"))?;
+        let (header, aux_inclusion) = setup_aux_inclusion(&aux_commitment, 0);
+        Ok(Self {
+            params: *params,
+            config,
+            a,
+            b,
+            header,
+            aux,
+            aux_inclusion,
+        })
+    }
+
+    pub const fn params(&self) -> MatmulParams {
+        self.params
+    }
+
+    pub const fn config(&self) -> PearlMiningConfig {
+        self.config
+    }
+
+    pub fn header_for(&self, extranonce: u32) -> PearlIncompleteBlockHeader {
+        PearlIncompleteBlockHeader {
+            timestamp: self.header.timestamp.wrapping_add(extranonce),
+            ..self.header
+        }
+    }
+
+    pub fn prepare_search(
+        &self,
+        extranonce: u32,
+    ) -> Result<PreparedCanonicalDenseSearch, CanonicalProveError> {
+        let header = self.header_for(extranonce);
+        let row_tickets = u64::from(self.params.m / self.params.tile);
+        let col_tickets = u64::from(self.params.n / self.params.tile);
+        if row_tickets == 0 || col_tickets == 0 {
+            return Err(CanonicalProveError(
+                "dense search requires at least one complete tile".to_string(),
+            ));
+        }
+        row_tickets
+            .checked_mul(col_tickets)
+            .ok_or_else(|| CanonicalProveError("dense ticket count overflow".to_string()))?;
+        Ok(PreparedCanonicalDenseSearch {
+            extranonce,
+            header,
+            config: self.config,
+            params: self.params,
+            sigma: header.to_bytes(),
+            mu: self
+                .config
+                .to_bytes()
+                .map_err(err("dense search mining config"))?,
+            row_tickets,
+            col_tickets,
+        })
+    }
+
+    pub fn prepare(&self, extranonce: u32) -> Result<PreparedPearlPatternJob, CanonicalProveError> {
+        prepare_pearl_pattern_job(
+            &self.header_for(extranonce),
+            &self.config,
+            &self.params,
+            &self.a,
+            &self.b,
+            self.params.tile as usize,
+        )
+        .map_err(err("prepare dense canonical template"))
+    }
+
+    pub fn checked_winner(
+        &self,
+        prepared: &PreparedPearlPatternJob,
+        ordinal: u64,
+        nockchain_target: &[u8; 32],
+    ) -> Result<PearlMergeCheckedTicketAttempt, CanonicalProveError> {
+        if prepared.params() != self.params || prepared.config() != self.config {
+            return Err(CanonicalProveError(
+                "dense winner belongs to a different prepared template".to_string(),
+            ));
+        }
+        let (t_rows, t_cols) = prepared.offsets_at_ordinal(ordinal).ok_or_else(|| {
+            CanonicalProveError("dense winner ordinal is out of range".to_string())
+        })?;
+        let attempt = evaluate_pearl_merge_checked_ticket_attempt(
+            &prepared.header(),
+            &self.config,
+            &self.params,
+            t_rows,
+            t_cols,
+            &self.a,
+            &self.b,
+            nockchain_target,
+            self.params.tile as usize,
+            self.aux.clone(),
+        )
+        .map_err(err("validate dense canonical winner"))?;
+        attempt
+            .public_params
+            .check_nockchain_jackpot_target(nockchain_target)
+            .map_err(err("dense canonical winner target"))?;
+        Ok(attempt)
+    }
+
+    pub fn checked_search_winner(
+        &self,
+        prepared: &PreparedCanonicalDenseSearch,
+        ordinal: u64,
+        nockchain_target: &[u8; 32],
+    ) -> Result<PearlMergeCheckedTicketAttempt, CanonicalProveError> {
+        if prepared.params != self.params
+            || prepared.config != self.config
+            || prepared.header != self.header_for(prepared.extranonce)
+        {
+            return Err(CanonicalProveError(
+                "dense winner belongs to a different search transcript".to_string(),
+            ));
+        }
+        let (t_rows, t_cols) = prepared.offsets_at_ordinal(ordinal).ok_or_else(|| {
+            CanonicalProveError("dense winner ordinal is out of range".to_string())
+        })?;
+        let attempt = evaluate_pearl_merge_checked_ticket_attempt(
+            &prepared.header,
+            &self.config,
+            &self.params,
+            t_rows,
+            t_cols,
+            &self.a,
+            &self.b,
+            nockchain_target,
+            self.params.tile as usize,
+            self.aux.clone(),
+        )
+        .map_err(err("validate dense canonical search winner"))?;
+        attempt
+            .public_params
+            .check_nockchain_jackpot_target(nockchain_target)
+            .map_err(err("dense canonical search winner target"))?;
+        Ok(attempt)
+    }
+
+    pub fn prove(
+        &self,
+        attempt: PearlMergeCheckedTicketAttempt,
+    ) -> Result<CanonicalDenseBlock, CanonicalProveError> {
+        let run = prove_pearl_merge_compact_recursive_certificate_checked(
+            &attempt, &self.params, &self.a, &self.b,
+        )
+        .map_err(err("prove dense canonical winner"))?;
+        let jackpot_hash = attempt.ticket.jackpot_hash;
+        Ok(CanonicalDenseBlock {
+            attempt,
+            aux_inclusion: self.aux_inclusion.clone(),
+            a: Arc::clone(&self.a),
+            b: Arc::clone(&self.b),
+            run,
+            commit: self.aux.nock_block_commitment,
+            jackpot_hash,
+        })
+    }
+}
+
+impl PreparedCanonicalDenseSearch {
+    pub const fn config(&self) -> PearlMiningConfig {
+        self.config
+    }
+
+    pub const fn params(&self) -> MatmulParams {
+        self.params
+    }
+
+    pub fn sigma(&self) -> &[u8] {
+        &self.sigma
+    }
+
+    pub fn mu(&self) -> &[u8] {
+        &self.mu
+    }
+
+    pub fn total_tickets(&self) -> u64 {
+        self.row_tickets * self.col_tickets
+    }
+
+    pub fn offsets_at_ordinal(&self, ordinal: u64) -> Option<(u32, u32)> {
+        if ordinal >= self.total_tickets() {
+            return None;
+        }
+        let row = u32::try_from(ordinal / self.col_tickets).ok()?;
+        let col = u32::try_from(ordinal % self.col_tickets).ok()?;
+        Some((
+            row.checked_mul(self.params.tile)?,
+            col.checked_mul(self.params.tile)?,
+        ))
     }
 }
 
@@ -730,7 +1013,7 @@ pub(crate) fn prove_canonical_moe_block_at_for_miner(
         .map(|(block, _)| block)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gpu"))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn prove_canonical_moe_block_at_with_verifier_context(
     params: &MatmulParams,
@@ -865,6 +1148,46 @@ mod tests {
             spot_checks: 1,
             difficulty_bits: 0,
         }
+    }
+
+    fn dense_params() -> MatmulParams {
+        MatmulParams {
+            m: 16,
+            k: 1024,
+            n: 16,
+            noise_rank: 64,
+            tile: 8,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        }
+    }
+
+    #[test]
+    fn dense_template_rebinds_every_extranonce_and_validates_the_winner() {
+        let params = dense_params();
+        let (a, b) = synth_matrices(AI_POW_PROD_SYNTH_SEED, &params);
+        let template =
+            PreparedCanonicalDenseTemplate::new(&params, [0x5a; 32], Arc::new(a), Arc::new(b))
+                .expect("dense canonical template");
+        let first = template.prepare(0).expect("first dense template");
+        let second = template.prepare(1).expect("second dense template");
+
+        assert_ne!(first.header(), second.header());
+        assert_ne!(first.commitments(), second.commitments());
+        assert_eq!(first.row_offsets(), &[0, 8]);
+        assert_eq!(first.col_offsets(), &[0, 8]);
+
+        let mut target = [0xff; 32];
+        target[30] = 0;
+        target[31] = 0;
+        let checked = template
+            .checked_winner(&first, 0, &target)
+            .expect("scalar-checked dense winner");
+        let scalar = first
+            .evaluate(0, 0, &mut first.scratch())
+            .expect("scalar ticket");
+        assert_eq!(checked.ticket.jackpot_hash, scalar.jackpot_hash);
+        assert_eq!(checked.aux.nock_block_commitment, [0x5a; 32]);
     }
 
     /// The cheap grind evaluator must be byte-identical to the jackpot the full

--- a/crates/ai-pow-miner/src/certificate_noun.rs
+++ b/crates/ai-pow-miner/src/certificate_noun.rs
@@ -5966,7 +5966,11 @@ mod tests {
             .validate_prod_envelope()
             .expect("tile=16,k=4096,r=64 must be in the prod envelope");
         let aux = pearl_test_aux();
-        let (header, aux_inclusion) = pearl_test_aux_inclusion(&aux.commitment().unwrap());
+        let (mut header, aux_inclusion) = pearl_test_aux_inclusion(&aux.commitment().unwrap());
+        // This proof-size fixture needs an easy target that still fits after
+        // the 2^20 max-envelope shape-work adjustment.
+        header.nbits = 0x1e0f_ffff;
+        let easy_shape_target = ai_pow::pearl_compat::pearl_nbits_to_target_le(header.nbits);
         let config = PearlMiningConfig {
             common_dim: 4096,
             rank: 64,
@@ -5977,16 +5981,7 @@ mod tests {
         };
         let (a, b) = synth_matrices(b"pearl-max-envelope-t16-k4096", &params);
         let attempt = evaluate_pearl_merge_ticket_attempt(
-            &header,
-            &config,
-            &params,
-            0,
-            0,
-            &a,
-            &b,
-            &easy_nock_target(),
-            16,
-            aux,
+            &header, &config, &params, 0, 0, &a, &b, &easy_shape_target, 16, aux,
         )
         .expect("evaluate max-envelope Pearl merge ticket attempt");
 
@@ -8567,5 +8562,73 @@ mod tests {
             ),
             "expected a fail-closed threshold overflow, got {err:?}"
         );
+    }
+
+    #[test]
+    #[ignore = "builds and verifies the full peak production certificate"]
+    fn peak_production_certificate_verifies_through_consensus_entrypoint() {
+        let params = crate::PEAK_PRODUCTION_PARAMS;
+        let commit = [0x5a; 32];
+        let target = ai_pow::difficulty::AI_POW_MAX_CONSENSUS_TARGET;
+        let (a, b) = synth_matrices(ai_pow::synth::AI_POW_PROD_SYNTH_SEED, &params);
+        let template = crate::canonical::PreparedCanonicalDenseTemplate::new(
+            &params,
+            commit,
+            std::sync::Arc::new(a),
+            std::sync::Arc::new(b),
+        )
+        .expect("peak template");
+        let prepared = template.prepare(0).expect("peak transcript");
+        let factor = prepared
+            .config()
+            .shape_work_factor()
+            .expect("peak work factor");
+        let mut scratch = prepared.scratch();
+        let total_tickets =
+            prepared.row_offsets().len() as u64 * prepared.col_offsets().len() as u64;
+        let winner = (0..total_tickets)
+            .find(|&ordinal| {
+                let (rows, cols) = prepared
+                    .offsets_at_ordinal(ordinal)
+                    .expect("peak ticket offsets");
+                let ticket = prepared
+                    .evaluate(rows, cols, &mut scratch)
+                    .expect("peak ticket");
+                ai_pow::difficulty::attempt_wins(&ticket.jackpot_hash, &target, factor)
+                    .expect("peak target")
+            })
+            .expect("the deterministic fixture must contain a winning ticket");
+        let attempt = template
+            .checked_winner(&prepared, winner, &target)
+            .expect("checked peak winner");
+        let block = template.prove(attempt).expect("peak compact proof");
+        let artifact = build_ai_pow_pearl_merge_artifact_noun_from_ticket_compact_recursive_run(
+            block.attempt.attempt(),
+            &block.aux_inclusion,
+            &block.a,
+            &block.b,
+            params.tile as usize,
+            &block.run,
+        )
+        .expect("peak artifact noun");
+        let digest = ai_pow_zk::recursion::compact_batch_verifier_key_digest_to_bytes(
+            block.run.verifier_key_digest(),
+        );
+        let outcome = verify_ai_pow_block_artifact_jam(
+            &artifact.jam(),
+            CertificateNounLimits::default(),
+            &commit,
+            &target,
+            params.tile as usize,
+            block.run.verifier_context(),
+            &digest,
+        )
+        .expect("peak artifact verifies through consensus");
+        match outcome {
+            AiPowBlockVerifyOutcome::Dense(verified) => {
+                assert_eq!(verified.work.ticket.jackpot_hash, block.jackpot_hash);
+            }
+            AiPowBlockVerifyOutcome::Moe(_) => panic!("peak artifact routed to the MoE verifier"),
+        }
     }
 }

--- a/crates/ai-pow-miner/src/cli.rs
+++ b/crates/ai-pow-miner/src/cli.rs
@@ -64,9 +64,9 @@ pub struct CommonArgs {
     #[arg(long, value_name = "ENDPOINT", default_value = DEFAULT_PEARL_GATEWAY_ENDPOINT)]
     pub pearl_gateway: String,
 
-    /// Gateway-free mode: prove a CANONICAL AI-PoW block bound to each %mine-ai candidate,
-    /// with no Pearl Gateway. Intended for fakenet; the candidate refresh interval must
-    /// exceed the recursive proof time.
+    /// Gateway-free mode: prove a CANONICAL AI-PoW block bound to each
+    /// %mine-ai candidate. CUDA mode selects the dense production backend;
+    /// CPU mode retains the small diagnostic profile.
     #[arg(long)]
     pub canonical: bool,
 

--- a/crates/ai-pow-miner/src/gpu.rs
+++ b/crates/ai-pow-miner/src/gpu.rs
@@ -17,9 +17,12 @@ use crate::canonical::PreparedCanonicalMoeTemplate;
 use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
 
 const NO_WINNER: u32 = u32::MAX;
+const MAX_GPU_DEVICES: usize = 8;
 
 unsafe extern "C" {
+    fn ai_pow_cuda_device_count(count_out: *mut u32) -> c_int;
     fn ai_pow_cuda_session_create(
+        device_ordinal: u32,
         max_attempts: u32,
         h: u32,
         w: u32,
@@ -37,6 +40,7 @@ unsafe extern "C" {
     ) -> c_int;
     fn ai_pow_cuda_session_destroy(session: *mut c_void) -> c_int;
     fn ai_pow_cuda_v3_session_create(
+        device_ordinal: u32,
         max_attempts: u32,
         a_matrix: *const i8,
         b_matrix: *const i8,
@@ -55,6 +59,7 @@ unsafe extern "C" {
         extranonce_start: u32,
         attempts: u32,
         target: *const u8,
+        capture_debug: u32,
         winner_local: *mut u32,
         jackpot_out: *mut u8,
     ) -> c_int;
@@ -81,6 +86,13 @@ pub struct GpuSearchBackend {
     dispatch: Mutex<CanonicalDispatch>,
 }
 
+/// One ordered CUDA search spread across independent devices.
+pub struct MultiGpuSearchBackend {
+    backends: Vec<GpuSearchBackend>,
+    batch_attempts_per_device: u64,
+    batch_attempts: u64,
+}
+
 #[derive(Default)]
 struct CanonicalDispatch {
     template: Option<Arc<PreparedCanonicalMoeTemplate>>,
@@ -98,6 +110,7 @@ unsafe impl Send for CudaSession {}
 
 impl CudaSession {
     fn generic(
+        device_ordinal: usize,
         attempts: usize,
         h: usize,
         w: usize,
@@ -109,6 +122,7 @@ impl CudaSession {
         // SAFETY: `raw` is writable. Dimensions are checked before crossing the ABI.
         let status = unsafe {
             ai_pow_cuda_session_create(
+                u32::try_from(device_ordinal).map_err(unavailable)?,
                 u32::try_from(attempts).map_err(unavailable)?,
                 u32::try_from(h).map_err(unavailable)?,
                 u32::try_from(w).map_err(unavailable)?,
@@ -130,6 +144,7 @@ impl CudaSession {
     fn canonical(
         template: &PreparedCanonicalMoeTemplate,
         max_attempts: u32,
+        device_ordinal: usize,
     ) -> Result<Self, SearchBackendError> {
         let (a, b, routing, offsets, rows, cols, sigma, mu) = template.gpu_inputs();
         let rows: &[u32; 8] = rows
@@ -142,6 +157,7 @@ impl CudaSession {
         // SAFETY: CUDA copies all fixed template inputs before returning.
         let status = unsafe {
             ai_pow_cuda_v3_session_create(
+                u32::try_from(device_ordinal).map_err(unavailable)?,
                 max_attempts,
                 a.as_ptr(),
                 b.as_ptr(),
@@ -210,6 +226,7 @@ impl CudaSession {
                 start,
                 attempts,
                 threshold.as_ptr(),
+                0,
                 &mut local,
                 jackpot.as_mut_ptr(),
             )
@@ -260,15 +277,32 @@ impl Drop for CudaSession {
 }
 
 impl GpuSearchBackend {
+    pub fn available_device_count() -> Result<usize> {
+        let mut count = 0u32;
+        // SAFETY: `count` is a valid writable output.
+        let status = unsafe { ai_pow_cuda_device_count(&mut count) };
+        if status != 0 {
+            bail!("CUDA device enumeration failed with error {status}");
+        }
+        if count == 0 {
+            bail!("no CUDA devices are visible");
+        }
+        Ok(count as usize)
+    }
+
     pub fn new(device_ordinal: usize, batch_attempts: u64) -> Result<Self> {
         if batch_attempts == 0 {
             bail!("--gpu-batch-attempts must be nonzero");
         }
-        if device_ordinal != 0 {
-            bail!("the GPU backend currently supports CUDA device 0 only");
-        }
         if batch_attempts > u64::from(u32::MAX) {
             bail!("--gpu-batch-attempts must fit in u32");
+        }
+        let device_count = Self::available_device_count()?;
+        if device_ordinal >= device_count {
+            bail!(
+                "CUDA device {device_ordinal} is not visible; visible ordinals are 0..{}",
+                device_count - 1
+            );
         }
         Ok(Self {
             device_ordinal,
@@ -283,6 +317,78 @@ impl GpuSearchBackend {
 
     pub const fn batch_attempts(&self) -> u64 {
         self.batch_attempts
+    }
+}
+
+impl MultiGpuSearchBackend {
+    pub fn all_visible(batch_attempts_per_device: u64) -> Result<Self> {
+        let count = GpuSearchBackend::available_device_count()?.min(MAX_GPU_DEVICES);
+        Self::new((0..count).collect(), batch_attempts_per_device)
+    }
+
+    pub fn new(device_ordinals: Vec<usize>, batch_attempts_per_device: u64) -> Result<Self> {
+        if device_ordinals.is_empty() {
+            bail!("--cuda-devices must select at least one CUDA device");
+        }
+        if device_ordinals.len() > MAX_GPU_DEVICES {
+            bail!("--cuda-devices supports at most {MAX_GPU_DEVICES} devices");
+        }
+        for (index, &ordinal) in device_ordinals.iter().enumerate() {
+            if device_ordinals[..index].contains(&ordinal) {
+                bail!("--cuda-devices contains duplicate device {ordinal}");
+            }
+        }
+        let batch_attempts = batch_attempts_per_device
+            .checked_mul(device_ordinals.len() as u64)
+            .ok_or_else(|| anyhow::anyhow!("combined GPU batch size overflows u64"))?;
+        let backends = device_ordinals
+            .into_iter()
+            .map(|ordinal| GpuSearchBackend::new(ordinal, batch_attempts_per_device))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            backends,
+            batch_attempts_per_device,
+            batch_attempts,
+        })
+    }
+
+    pub fn device_ordinals(&self) -> Vec<usize> {
+        self.backends
+            .iter()
+            .map(GpuSearchBackend::device_ordinal)
+            .collect()
+    }
+
+    pub const fn batch_attempts_per_device(&self) -> u64 {
+        self.batch_attempts_per_device
+    }
+}
+
+fn active_device_count(batch: SearchBatch, device_count: usize) -> usize {
+    device_count.min(usize::try_from(batch.len).unwrap_or(usize::MAX))
+}
+
+fn partition_for_device(batch: SearchBatch, active: usize, index: usize) -> SearchBatch {
+    let active = active as u64;
+    let index = index as u64;
+    let base = batch.len / active;
+    let remainder = batch.len % active;
+    SearchBatch {
+        start: batch.start + base * index + index.min(remainder),
+        len: base + u64::from(index < remainder),
+        threshold: batch.threshold,
+    }
+}
+
+fn lower_winner(left: Option<SearchWinner>, right: Option<SearchWinner>) -> Option<SearchWinner> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(if left.ordinal <= right.ordinal {
+            left
+        } else {
+            right
+        }),
+        (Some(winner), None) | (None, Some(winner)) => Some(winner),
+        (None, None) => None,
     }
 }
 
@@ -327,7 +433,7 @@ impl SearchBackend for GpuSearchBackend {
                 destination_b.copy_from_slice(b);
                 Ok::<_, SearchBackendError>(())
             })?;
-        let session = CudaSession::generic(attempts, h, w, k, rank, dot)?;
+        let session = CudaSession::generic(self.device_ordinal, attempts, h, w, k, rank, dot)?;
         let states = session.run_generic(&all_a, &all_b, attempts)?;
         for (offset, state) in states.iter().enumerate() {
             let jackpot = pearl_jackpot_hash(state, &template.commitments().s_a);
@@ -366,6 +472,7 @@ impl SearchBackend for GpuSearchBackend {
             dispatch.session = Some(CudaSession::canonical(
                 &template,
                 u32::try_from(self.batch_attempts).map_err(unavailable)?,
+                self.device_ordinal,
             )?);
             dispatch.template = Some(Arc::clone(&template));
         }
@@ -400,6 +507,48 @@ impl SearchBackend for GpuSearchBackend {
             ordinal,
             jackpot_hash: scalar.jackpot_hash,
         }))
+    }
+
+    fn batch_attempts(&self) -> u64 {
+        self.batch_attempts
+    }
+}
+
+impl SearchBackend for MultiGpuSearchBackend {
+    fn search_dense(
+        &self,
+        template: Arc<ai_pow::pearl_compat::PreparedPearlPatternJob>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let active = active_device_count(batch, self.backends.len());
+        self.backends[..active]
+            .par_iter()
+            .enumerate()
+            .map(|(index, backend)| {
+                backend.search_dense(
+                    Arc::clone(&template),
+                    partition_for_device(batch, active, index),
+                )
+            })
+            .try_reduce(|| None, |left, right| Ok(lower_winner(left, right)))
+    }
+
+    fn search_canonical(
+        &self,
+        template: Arc<PreparedCanonicalMoeTemplate>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let active = active_device_count(batch, self.backends.len());
+        self.backends[..active]
+            .par_iter()
+            .enumerate()
+            .map(|(index, backend)| {
+                backend.search_canonical(
+                    Arc::clone(&template),
+                    partition_for_device(batch, active, index),
+                )
+            })
+            .try_reduce(|| None, |left, right| Ok(lower_winner(left, right)))
     }
 
     fn batch_attempts(&self) -> u64 {
@@ -462,15 +611,94 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_device() {
-        assert!(GpuSearchBackend::new(1, 1).is_err());
+    fn rejects_non_visible_device() {
+        let count = GpuSearchBackend::available_device_count().expect("visible CUDA devices");
+        assert!(GpuSearchBackend::new(count, 1).is_err());
+    }
+
+    #[test]
+    fn multi_gpu_partitions_preserve_the_ordered_batch() {
+        let batch = SearchBatch::new(41, 19, [0x5a; 32]).expect("search batch");
+        let active = active_device_count(batch, 8);
+        let partitions = (0..active)
+            .map(|index| partition_for_device(batch, active, index))
+            .collect::<Vec<_>>();
+        assert_eq!(partitions.len(), 8);
+        assert_eq!(partitions.first().expect("first").start, batch.start);
+        assert_eq!(
+            partitions.last().expect("last").end_exclusive(),
+            batch.end_exclusive()
+        );
+        assert_eq!(
+            partitions
+                .iter()
+                .map(|partition| partition.len)
+                .sum::<u64>(),
+            batch.len
+        );
+        assert!(partitions
+            .windows(2)
+            .all(|pair| pair[0].end_exclusive() == pair[1].start));
+    }
+
+    #[test]
+    fn multi_gpu_reduction_returns_the_global_lowest_winner() {
+        let lowest = [
+            Some(SearchWinner {
+                ordinal: 900,
+                jackpot_hash: [9; 32],
+            }),
+            None,
+            Some(SearchWinner {
+                ordinal: 100,
+                jackpot_hash: [1; 32],
+            }),
+        ]
+        .into_iter()
+        .fold(None, lower_winner)
+        .expect("winner");
+        assert_eq!(lowest.ordinal, 100);
+        assert_eq!(lowest.jackpot_hash, [1; 32]);
+    }
+    #[test]
+    fn multi_gpu_canonical_search_returns_global_lowest_winner() {
+        let device_count =
+            GpuSearchBackend::available_device_count().expect("visible CUDA devices");
+        if device_count < 2 {
+            return;
+        }
+        let template = Arc::new(
+            PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x4d; 32])
+                .expect("canonical template"),
+        );
+        let backend = MultiGpuSearchBackend::all_visible(4).expect("multi-GPU backend");
+        let batch_len = u64::try_from(device_count.min(8)).expect("device count") * 2;
+        let winner = backend
+            .search_canonical(
+                Arc::clone(&template),
+                SearchBatch::new(41, batch_len, [u8::MAX; 32]).expect("maximum target batch"),
+            )
+            .expect("maximum target search")
+            .expect("first ordinal is a winner");
+        assert_eq!(winner.ordinal, 41);
+        assert_eq!(
+            winner.jackpot_hash,
+            template.evaluate(41, &mut template.scratch()).jackpot_hash
+        );
+        assert!(backend
+            .search_canonical(
+                template,
+                SearchBatch::new(57, batch_len, [0; 32]).expect("zero target batch"),
+            )
+            .expect("zero target search")
+            .is_none());
     }
 
     #[test]
     fn canonical_v3_device_pipeline_matches_scalar() {
         let template = PreparedCanonicalMoeTemplate::new(&canonical_params(), 8, 2, 1, [0x42; 32])
             .expect("canonical template");
-        let session = CudaSession::canonical(&template, 4).expect("CUDA V3 session");
+        let session = CudaSession::canonical(&template, 4, 0).expect("CUDA V3 session");
         for extranonce in [0, 1, 7, u32::MAX - 1, u32::MAX] {
             let debug = session
                 .debug_canonical(extranonce)

--- a/crates/ai-pow-miner/src/lib.rs
+++ b/crates/ai-pow-miner/src/lib.rs
@@ -86,6 +86,10 @@ pub mod pearl_mining;
 /// Bounded CPU and accelerator ticket-search backend contract.
 pub mod search;
 
+/// RTX 5090 dense ticket-search session and benchmark contract.
+#[cfg(feature = "gpu")]
+pub mod peak;
+
 /// Pearl Gateway `submitPlainProof` artifact construction.
 ///
 /// Internal by design: Hoon and external Nockchain callers submit only the

--- a/crates/ai-pow-miner/src/lib.rs
+++ b/crates/ai-pow-miner/src/lib.rs
@@ -38,6 +38,22 @@ pub const DENSE_PRODUCTION_PARAMS: ai_pow::params::MatmulParams = ai_pow::params
     difficulty_bits: 0,
 };
 
+/// Dense Pearl V3 profile for the RTX 5090 production search kernel.
+pub const PEAK_PRODUCTION_PARAMS: ai_pow::params::MatmulParams = ai_pow::params::MatmulParams {
+    m: 4096,
+    k: 8192,
+    n: 32768,
+    noise_rank: 512,
+    tile: 16,
+    spot_checks: 1,
+    difficulty_bits: 0,
+};
+
+/// Return the dense RTX 5090 production profile.
+pub const fn peak_production_params() -> ai_pow::params::MatmulParams {
+    PEAK_PRODUCTION_PARAMS
+}
+
 /// Return the exact dense production fixture parameters.
 pub const fn dense_production_params() -> ai_pow::params::MatmulParams {
     DENSE_PRODUCTION_PARAMS

--- a/crates/ai-pow-miner/src/lib.rs
+++ b/crates/ai-pow-miner/src/lib.rs
@@ -144,7 +144,8 @@ pub mod run;
 /// the same work arguments and choose their search implementation explicitly.
 #[cfg(feature = "node")]
 pub mod cli;
-/// CUDA search implementation selected by `ai-pow-mine --gpu`.
+/// CUDA search implementations. `--gpu --canonical` selects the production
+/// dense route. Gateway mode retains the generic CUDA backend.
 #[cfg(all(feature = "node", feature = "gpu"))]
 pub mod gpu;
 

--- a/crates/ai-pow-miner/src/peak.rs
+++ b/crates/ai-pow-miner/src/peak.rs
@@ -8,24 +8,39 @@ use std::ffi::{c_int, c_void};
 use std::sync::{Arc, Mutex};
 
 use ai_pow::matmul::TileState;
-use ai_pow::pearl_compat::PreparedPearlPatternJob;
+use ai_pow::pearl_compat::{PearlWorkCommitments, PreparedPearlPatternJob};
 use ai_pow::tile_hash::hash_le_target;
 use anyhow::{bail, Result};
+use rayon::prelude::*;
 
 #[cfg(feature = "node")]
-use crate::canonical::PreparedCanonicalMoeTemplate;
+use crate::canonical::{PreparedCanonicalDenseSearch, PreparedCanonicalMoeTemplate};
+#[cfg(feature = "node")]
+use crate::search::PeakSearchOutcome;
 use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
+use crate::PEAK_PRODUCTION_PARAMS;
 
 pub const PEAK_K: usize = 8192;
 pub const PEAK_RANK: usize = 512;
 pub const PEAK_TILE: usize = 16;
 const NO_WINNER: u64 = u64::MAX;
+const MAX_PEAK_GPU_DEVICES: usize = 8;
 
 #[repr(C)]
 struct FfiSearchResult {
     winner_ordinal: u64,
     jackpot: [u8; 32],
     kernel_ms: f32,
+}
+#[repr(C)]
+struct FfiPrepareResult {
+    kappa: [u8; 32],
+    h_a: [u8; 32],
+    h_b: [u8; 32],
+    s_a: [u8; 32],
+    s_b: [u8; 32],
+    commitment_ms: f32,
+    noise_ms: f32,
 }
 #[repr(C)]
 struct FfiKernelInfo {
@@ -50,6 +65,23 @@ unsafe extern "C" {
         b_prime: *const i8,
         pow_key: *const u8,
         session_out: *mut *mut c_void,
+    ) -> c_int;
+    fn ai_pow_cuda_peak_source_session_create(
+        device_ordinal: u32,
+        m: u32,
+        n: u32,
+        k: u32,
+        rank: u32,
+        tile: u32,
+        a: *const i8,
+        b: *const i8,
+        session_out: *mut *mut c_void,
+    ) -> c_int;
+    fn ai_pow_cuda_peak_session_prepare(
+        session: *mut c_void,
+        sigma: *const u8,
+        mu: *const u8,
+        result_out: *mut FfiPrepareResult,
     ) -> c_int;
     fn ai_pow_cuda_peak_session_search(
         session: *mut c_void,
@@ -78,6 +110,13 @@ pub struct PeakSearchResult {
 pub struct PeakDebugResult {
     pub state: TileState,
     pub jackpot: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PeakPreparation {
+    pub commitments: PearlWorkCommitments,
+    pub commitment_ms: f32,
+    pub noise_ms: f32,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PeakKernelInfo {
@@ -181,6 +220,98 @@ impl PeakCudaSession {
         })
     }
 
+    pub fn new_source(
+        device_ordinal: usize,
+        m: usize,
+        n: usize,
+        a: &[i8],
+        b: &[i8],
+    ) -> Result<Self> {
+        if m == 0 || n == 0 || m % 256 != 0 || n % 128 != 0 {
+            bail!("peak shape requires nonzero m%256==0 and n%128==0");
+        }
+        let a_len = m
+            .checked_mul(PEAK_K)
+            .ok_or_else(|| anyhow::anyhow!("peak source A length overflow"))?;
+        let b_len = n
+            .checked_mul(PEAK_K)
+            .ok_or_else(|| anyhow::anyhow!("peak source B length overflow"))?;
+        if a.len() != a_len || b.len() != b_len {
+            bail!(
+                "peak source matrix lengths must be m*k={} and n*k={}, got {} and {}",
+                a_len,
+                b_len,
+                a.len(),
+                b.len()
+            );
+        }
+        let total_tickets = u64::try_from(m / PEAK_TILE)?
+            .checked_mul(u64::try_from(n / PEAK_TILE)?)
+            .ok_or_else(|| anyhow::anyhow!("peak ticket count overflow"))?;
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: the source slices have the validated fixed lengths. CUDA
+        // copies them before this synchronous call returns.
+        let status = unsafe {
+            ai_pow_cuda_peak_source_session_create(
+                u32::try_from(device_ordinal)?,
+                u32::try_from(m)?,
+                u32::try_from(n)?,
+                PEAK_K as u32,
+                PEAK_RANK as u32,
+                PEAK_TILE as u32,
+                a.as_ptr(),
+                b.as_ptr(),
+                &mut raw,
+            )
+        };
+        check_cuda("peak source session creation", status)?;
+        if raw.is_null() {
+            bail!("peak source session creation returned a null session");
+        }
+        Ok(Self {
+            raw,
+            m,
+            n,
+            total_tickets,
+        })
+    }
+
+    pub fn prepare(&mut self, sigma: &[u8], mu: &[u8]) -> Result<PeakPreparation> {
+        if sigma.len() != 76 || mu.len() != 52 {
+            bail!(
+                "peak transcript lengths must be sigma=76 and mu=52, got {} and {}",
+                sigma.len(),
+                mu.len()
+            );
+        }
+        let mut result = FfiPrepareResult {
+            kappa: [0; 32],
+            h_a: [0; 32],
+            h_b: [0; 32],
+            s_a: [0; 32],
+            s_b: [0; 32],
+            commitment_ms: 0.0,
+            noise_ms: 0.0,
+        };
+        // SAFETY: both transcript slices have their ABI-required fixed lengths.
+        // The session is exclusively borrowed for the synchronous preparation.
+        let status = unsafe {
+            ai_pow_cuda_peak_session_prepare(self.raw, sigma.as_ptr(), mu.as_ptr(), &mut result)
+        };
+        check_cuda("peak transcript preparation", status)?;
+        Ok(PeakPreparation {
+            commitments: PearlWorkCommitments {
+                kappa: result.kappa,
+                h_a: result.h_a,
+                h_b: result.h_b,
+                s_a: result.s_a,
+                s_b: result.s_b,
+            },
+            commitment_ms: result.commitment_ms,
+            noise_ms: result.noise_ms,
+        })
+    }
+
     pub const fn m(&self) -> usize {
         self.m
     }
@@ -259,10 +390,18 @@ pub struct PeakSearchBackend {
     dispatch: Mutex<PeakDispatch>,
 }
 
+/// One ordered dense peak search distributed across independent devices.
+pub struct MultiGpuPeakSearchBackend {
+    backends: Vec<PeakSearchBackend>,
+}
+
 #[derive(Default)]
 struct PeakDispatch {
     template: Option<Arc<PreparedPearlPatternJob>>,
     session: Option<PeakCudaSession>,
+    peak_template: Option<Arc<PreparedCanonicalDenseSearch>>,
+    peak_session: Option<PeakCudaSession>,
+    peak_preparation: Option<PeakPreparation>,
 }
 
 impl PeakSearchBackend {
@@ -318,6 +457,101 @@ impl PeakSearchBackend {
             ));
         }
         Ok(())
+    }
+
+    #[cfg(feature = "node")]
+    fn validate_peak_template(
+        template: &PreparedCanonicalDenseSearch,
+    ) -> Result<(), SearchBackendError> {
+        let params = template.params();
+        if params.k as usize != PEAK_K
+            || params.noise_rank as usize != PEAK_RANK
+            || params.tile as usize != PEAK_TILE
+            || params.m == 0
+            || params.n == 0
+            || params.m % 256 != 0
+            || params.n % 128 != 0
+        {
+            return Err(unavailable(format!(
+                "peak backend requires k={PEAK_K}, rank={PEAK_RANK}, tile={PEAK_TILE}, m%256=0, and n%128=0"
+            )));
+        }
+        let rows = template.config().rows_pattern.to_list_bounded(PEAK_TILE)?;
+        let cols = template.config().cols_pattern.to_list_bounded(PEAK_TILE)?;
+        if rows.len() != PEAK_TILE
+            || cols.len() != PEAK_TILE
+            || !rows.iter().copied().eq(0..PEAK_TILE as u32)
+            || !cols.iter().copied().eq(0..PEAK_TILE as u32)
+        {
+            return Err(unavailable(
+                "peak backend requires contiguous 16-element row and column patterns",
+            ));
+        }
+        let expected = u64::from(params.m / params.tile)
+            .checked_mul(u64::from(params.n / params.tile))
+            .ok_or_else(|| unavailable("peak ticket count overflow"))?;
+        if template.total_tickets() != expected {
+            return Err(unavailable(
+                "peak backend requires complete non-overlapping tile offsets",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl MultiGpuPeakSearchBackend {
+    pub fn all_visible() -> Result<Self> {
+        let count =
+            crate::gpu::GpuSearchBackend::available_device_count()?.min(MAX_PEAK_GPU_DEVICES);
+        Self::new((0..count).collect())
+    }
+
+    pub fn new(device_ordinals: Vec<usize>) -> Result<Self> {
+        if device_ordinals.is_empty() {
+            bail!("--cuda-devices must select at least one CUDA device");
+        }
+        if device_ordinals.len() > MAX_PEAK_GPU_DEVICES {
+            bail!("--cuda-devices supports at most {MAX_PEAK_GPU_DEVICES} devices");
+        }
+        let visible = crate::gpu::GpuSearchBackend::available_device_count()?;
+        for (index, &ordinal) in device_ordinals.iter().enumerate() {
+            if ordinal >= visible {
+                bail!("CUDA device {ordinal} is not visible; visible device count is {visible}");
+            }
+            if device_ordinals[..index].contains(&ordinal) {
+                bail!("--cuda-devices contains duplicate device {ordinal}");
+            }
+        }
+        Ok(Self {
+            backends: device_ordinals
+                .into_iter()
+                .map(PeakSearchBackend::new)
+                .collect(),
+        })
+    }
+
+    pub fn device_ordinals(&self) -> Vec<usize> {
+        self.backends
+            .iter()
+            .map(PeakSearchBackend::device_ordinal)
+            .collect()
+    }
+
+    pub fn preflight(&self, a: &[i8], b: &[i8]) -> Result<()> {
+        self.backends.par_iter().try_for_each(|backend| {
+            let session = PeakCudaSession::new_source(
+                backend.device_ordinal, PEAK_PRODUCTION_PARAMS.m as usize,
+                PEAK_PRODUCTION_PARAMS.n as usize, a, b,
+            )?;
+            let mut dispatch = backend
+                .dispatch
+                .lock()
+                .map_err(|_| anyhow::anyhow!("peak CUDA dispatch lock was poisoned"))?;
+            dispatch.peak_template = None;
+            dispatch.peak_preparation = None;
+            dispatch.peak_session = Some(session);
+            Ok(())
+        })
     }
 }
 
@@ -387,6 +621,69 @@ impl SearchBackend for PeakSearchBackend {
     }
 
     #[cfg(feature = "node")]
+    fn search_peak(
+        &self,
+        template: Arc<PreparedCanonicalDenseSearch>,
+        batch: SearchBatch,
+    ) -> Result<PeakSearchOutcome, SearchBackendError> {
+        let mut dispatch = self
+            .dispatch
+            .lock()
+            .map_err(|_| unavailable("peak CUDA dispatch lock was poisoned"))?;
+        let replace = dispatch
+            .peak_template
+            .as_ref()
+            .is_none_or(|current| !Arc::ptr_eq(current, &template));
+        if replace {
+            Self::validate_peak_template(&template)?;
+            let preparation = dispatch
+                .peak_session
+                .as_mut()
+                .ok_or_else(|| unavailable("peak source session is unavailable"))?
+                .prepare(template.sigma(), template.mu())
+                .map_err(unavailable)?;
+            dispatch.peak_template = Some(Arc::clone(&template));
+            dispatch.peak_preparation = Some(preparation);
+        }
+        let preparation = dispatch
+            .peak_preparation
+            .ok_or_else(|| unavailable("peak transcript preparation is unavailable"))?;
+        let result = dispatch
+            .peak_session
+            .as_mut()
+            .ok_or_else(|| unavailable("peak source session is unavailable"))?
+            .search(batch.start, batch.len, &batch.threshold)
+            .map_err(unavailable)?;
+        let winner = match result.winner {
+            Some(ordinal) => {
+                if ordinal < batch.start || ordinal >= batch.end_exclusive() {
+                    return Err(SearchBackendError::WinnerOutsideBatch {
+                        winner: ordinal,
+                        batch_start: batch.start,
+                        batch_end_exclusive: batch.end_exclusive(),
+                    });
+                }
+                if !hash_le_target(&result.jackpot, &batch.threshold) {
+                    return Err(unavailable(format!(
+                        "peak CUDA winner {ordinal} is above the dispatched threshold"
+                    )));
+                }
+                Some(SearchWinner {
+                    ordinal,
+                    jackpot_hash: result.jackpot,
+                })
+            }
+            None => None,
+        };
+        Ok(PeakSearchOutcome {
+            winner,
+            commitments: preparation.commitments,
+            commitment_ms: preparation.commitment_ms,
+            noise_ms: preparation.noise_ms,
+        })
+    }
+
+    #[cfg(feature = "node")]
     fn search_canonical(
         &self,
         _: Arc<PreparedCanonicalMoeTemplate>,
@@ -399,6 +696,108 @@ impl SearchBackend for PeakSearchBackend {
 
     fn batch_attempts(&self) -> u64 {
         u64::MAX
+    }
+}
+
+impl SearchBackend for MultiGpuPeakSearchBackend {
+    fn search_dense(
+        &self,
+        template: Arc<PreparedPearlPatternJob>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let active = self
+            .backends
+            .len()
+            .min(usize::try_from(batch.len).unwrap_or(usize::MAX));
+        self.backends[..active]
+            .par_iter()
+            .enumerate()
+            .map(|(index, backend)| {
+                backend.search_dense(
+                    Arc::clone(&template),
+                    peak_partition_for_device(batch, active, index),
+                )
+            })
+            .try_reduce(|| None, |left, right| Ok(lower_peak_winner(left, right)))
+    }
+
+    #[cfg(feature = "node")]
+    fn search_peak(
+        &self,
+        template: Arc<PreparedCanonicalDenseSearch>,
+        batch: SearchBatch,
+    ) -> Result<PeakSearchOutcome, SearchBackendError> {
+        let active = self
+            .backends
+            .len()
+            .min(usize::try_from(batch.len).unwrap_or(usize::MAX));
+        let outcomes = self.backends[..active]
+            .par_iter()
+            .enumerate()
+            .map(|(index, backend)| {
+                backend.search_peak(
+                    Arc::clone(&template),
+                    peak_partition_for_device(batch, active, index),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut outcomes = outcomes.into_iter();
+        let mut merged = outcomes
+            .next()
+            .ok_or_else(|| unavailable("peak multi-GPU search has no active device"))?;
+        for outcome in outcomes {
+            if outcome.commitments != merged.commitments {
+                return Err(unavailable(
+                    "peak devices derived different attempt transcripts",
+                ));
+            }
+            merged.winner = lower_peak_winner(merged.winner, outcome.winner);
+            merged.commitment_ms = merged.commitment_ms.max(outcome.commitment_ms);
+            merged.noise_ms = merged.noise_ms.max(outcome.noise_ms);
+        }
+        Ok(merged)
+    }
+
+    #[cfg(feature = "node")]
+    fn search_canonical(
+        &self,
+        _: Arc<PreparedCanonicalMoeTemplate>,
+        _: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        Err(unavailable(
+            "peak dense backend does not accept canonical MoE jobs",
+        ))
+    }
+
+    fn batch_attempts(&self) -> u64 {
+        u64::MAX
+    }
+}
+
+fn peak_partition_for_device(batch: SearchBatch, active: usize, index: usize) -> SearchBatch {
+    let active = active as u64;
+    let index = index as u64;
+    let base = batch.len / active;
+    let remainder = batch.len % active;
+    SearchBatch {
+        start: batch.start + base * index + index.min(remainder),
+        len: base + u64::from(index < remainder),
+        threshold: batch.threshold,
+    }
+}
+
+fn lower_peak_winner(
+    left: Option<SearchWinner>,
+    right: Option<SearchWinner>,
+) -> Option<SearchWinner> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(if left.ordinal <= right.ordinal {
+            left
+        } else {
+            right
+        }),
+        (Some(winner), None) | (None, Some(winner)) => Some(winner),
+        (None, None) => None,
     }
 }
 
@@ -428,6 +827,84 @@ mod tests {
     use ai_pow::pearl_compat::pearl_jackpot_hash;
 
     use super::*;
+
+    #[test]
+    fn multi_gpu_partitions_are_adjacent_and_cover_the_batch() {
+        let batch = SearchBatch::new(100, 10, [0; 32]).expect("batch");
+        let partitions: Vec<_> = (0..3)
+            .map(|index| peak_partition_for_device(batch, 3, index))
+            .collect();
+        assert_eq!(
+            partitions
+                .iter()
+                .map(|part| (part.start, part.len))
+                .collect::<Vec<_>>(),
+            vec![(100, 4), (104, 3), (107, 3)]
+        );
+        assert_eq!(partitions[0].start, batch.start);
+        assert_eq!(
+            partitions.last().expect("last").end_exclusive(),
+            batch.end_exclusive()
+        );
+    }
+
+    #[test]
+    fn multi_gpu_winner_reduction_uses_the_global_lowest_ordinal() {
+        let higher = SearchWinner {
+            ordinal: 29,
+            jackpot_hash: [0x29; 32],
+        };
+        let lower = SearchWinner {
+            ordinal: 17,
+            jackpot_hash: [0x17; 32],
+        };
+        assert_eq!(lower_peak_winner(Some(higher), Some(lower)), Some(lower));
+        assert_eq!(lower_peak_winner(None, Some(lower)), Some(lower));
+        assert_eq!(lower_peak_winner(None, None), None);
+    }
+
+    #[cfg(feature = "node")]
+    #[test]
+    #[ignore = "requires two compatible CUDA devices"]
+    fn multi_gpu_search_returns_global_lowest_winner() {
+        let params = ai_pow::params::MatmulParams {
+            m: 256,
+            k: PEAK_K as u32,
+            n: 128,
+            noise_rank: PEAK_RANK as u32,
+            tile: PEAK_TILE as u32,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        };
+        let (a, b) = ai_pow::synth::synth_matrices(ai_pow::synth::AI_POW_PROD_SYNTH_SEED, &params);
+        let template = crate::canonical::PreparedCanonicalDenseTemplate::new(
+            &params,
+            [0x5a; 32],
+            Arc::new(a),
+            Arc::new(b),
+        )
+        .expect("dense template");
+        let prepared = Arc::new(template.prepare(0).expect("prepared template"));
+        let backend = MultiGpuPeakSearchBackend::new(vec![0, 1]).expect("two CUDA devices");
+
+        for start in [0, 17, 64] {
+            let winner = backend
+                .search_dense(
+                    Arc::clone(&prepared),
+                    SearchBatch::new(start, 128 - start, [0xff; 32]).expect("maximum-target batch"),
+                )
+                .expect("multi-GPU search")
+                .expect("maximum target always wins");
+            assert_eq!(winner.ordinal, start);
+        }
+        assert!(backend
+            .search_dense(
+                prepared,
+                SearchBatch::new(0, 128, [0; 32]).expect("zero-target batch"),
+            )
+            .expect("zero-target search")
+            .is_none());
+    }
 
     fn fixture(m: usize, n: usize) -> (Vec<i8>, Vec<i8>, [u8; 32]) {
         let mut state = 0x0123_4567_89ab_cdefu64;
@@ -490,6 +967,62 @@ mod tests {
             let scalar = scalar_ticket(&a, &b, 128, ordinal);
             assert_eq!(device.state, scalar, "ordinal {ordinal}");
             assert_eq!(device.jackpot, pearl_jackpot_hash(&scalar, &key));
+        }
+    }
+
+    #[cfg(feature = "node")]
+    #[test]
+    #[ignore = "requires a compatible CUDA device"]
+    fn peak_source_session_matches_complete_scalar_transcript() {
+        let params = ai_pow::params::MatmulParams {
+            m: 256,
+            k: PEAK_K as u32,
+            n: 128,
+            noise_rank: PEAK_RANK as u32,
+            tile: PEAK_TILE as u32,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        };
+        let (a, b) = ai_pow::synth::synth_matrices(ai_pow::synth::AI_POW_PROD_SYNTH_SEED, &params);
+        let a = Arc::new(a);
+        let b = Arc::new(b);
+        let template = crate::canonical::PreparedCanonicalDenseTemplate::new(
+            &params,
+            [0x5a; 32],
+            Arc::clone(&a),
+            Arc::clone(&b),
+        )
+        .expect("dense template");
+        let mut session =
+            PeakCudaSession::new_source(0, params.m as usize, params.n as usize, &a, &b)
+                .expect("peak source session");
+        for extranonce in [0, 1, u32::MAX - 1, u32::MAX] {
+            let scalar = template.prepare(extranonce).expect("scalar preparation");
+            let device = session
+                .prepare(scalar.sigma(), scalar.mu())
+                .expect("device preparation");
+            assert_eq!(
+                device.commitments,
+                *scalar.commitments(),
+                "extranonce {extranonce}"
+            );
+            for ordinal in [0, scalar.row_offsets().len() as u64 - 1, 127] {
+                let (t_rows, t_cols) = scalar
+                    .offsets_at_ordinal(ordinal)
+                    .expect("scalar ticket offsets");
+                let expected = scalar
+                    .evaluate(t_rows, t_cols, &mut scalar.scratch())
+                    .expect("scalar ticket");
+                let actual = session.debug_ticket(ordinal).expect("device ticket");
+                assert_eq!(
+                    actual.state, expected.tile_state,
+                    "extranonce {extranonce}, ordinal {ordinal}"
+                );
+                assert_eq!(
+                    actual.jackpot, expected.jackpot_hash,
+                    "extranonce {extranonce}, ordinal {ordinal}"
+                );
+            }
         }
     }
 

--- a/crates/ai-pow-miner/src/peak.rs
+++ b/crates/ai-pow-miner/src/peak.rs
@@ -1,0 +1,576 @@
+//! Isolated RTX 5090 dense Pearl ticket-search session.
+//!
+//! The peak path accepts precomputed noised matrices in row-major `A` and
+//! transposed row-major `B` form. One ticket is one 16-by-16 output tile. The
+//! session owns all device allocations until drop.
+
+use std::ffi::{c_int, c_void};
+use std::sync::{Arc, Mutex};
+
+use ai_pow::matmul::TileState;
+use ai_pow::pearl_compat::PreparedPearlPatternJob;
+use ai_pow::tile_hash::hash_le_target;
+use anyhow::{bail, Result};
+
+#[cfg(feature = "node")]
+use crate::canonical::PreparedCanonicalMoeTemplate;
+use crate::search::{SearchBackend, SearchBackendError, SearchBatch, SearchWinner};
+
+pub const PEAK_K: usize = 8192;
+pub const PEAK_RANK: usize = 512;
+pub const PEAK_TILE: usize = 16;
+const NO_WINNER: u64 = u64::MAX;
+
+#[repr(C)]
+struct FfiSearchResult {
+    winner_ordinal: u64,
+    jackpot: [u8; 32],
+    kernel_ms: f32,
+}
+#[repr(C)]
+struct FfiKernelInfo {
+    sm_count: u32,
+    threads_per_cta: u32,
+    active_ctas_per_sm: u32,
+    registers_per_thread: u32,
+    static_shared_bytes: u64,
+    dynamic_shared_bytes: u64,
+}
+
+unsafe extern "C" {
+    fn ai_pow_cuda_peak_kernel_info(device_ordinal: u32, info_out: *mut FfiKernelInfo) -> c_int;
+    fn ai_pow_cuda_peak_session_create(
+        device_ordinal: u32,
+        m: u32,
+        n: u32,
+        k: u32,
+        rank: u32,
+        tile: u32,
+        a_prime: *const i8,
+        b_prime: *const i8,
+        pow_key: *const u8,
+        session_out: *mut *mut c_void,
+    ) -> c_int;
+    fn ai_pow_cuda_peak_session_search(
+        session: *mut c_void,
+        ordinal_start: u64,
+        ordinal_count: u64,
+        target: *const u8,
+        result_out: *mut FfiSearchResult,
+    ) -> c_int;
+    fn ai_pow_cuda_peak_session_debug(
+        session: *mut c_void,
+        ordinal: u64,
+        state_out: *mut i32,
+        jackpot_out: *mut u8,
+    ) -> c_int;
+    fn ai_pow_cuda_peak_session_destroy(session: *mut c_void) -> c_int;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PeakSearchResult {
+    pub winner: Option<u64>,
+    pub jackpot: [u8; 32],
+    pub kernel_ms: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeakDebugResult {
+    pub state: TileState,
+    pub jackpot: [u8; 32],
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PeakKernelInfo {
+    pub sm_count: u32,
+    pub threads_per_cta: u32,
+    pub active_ctas_per_sm: u32,
+    pub registers_per_thread: u32,
+    pub static_shared_bytes: u64,
+    pub dynamic_shared_bytes: u64,
+}
+
+pub struct PeakCudaSession {
+    raw: *mut c_void,
+    m: usize,
+    n: usize,
+    total_tickets: u64,
+}
+
+// A session is owned by one worker. The CUDA stream and allocations move with it.
+unsafe impl Send for PeakCudaSession {}
+
+impl PeakCudaSession {
+    pub fn kernel_info(device_ordinal: usize) -> Result<PeakKernelInfo> {
+        let device_ordinal = u32::try_from(device_ordinal)?;
+        let mut info = FfiKernelInfo {
+            sm_count: 0,
+            threads_per_cta: 0,
+            active_ctas_per_sm: 0,
+            registers_per_thread: 0,
+            static_shared_bytes: 0,
+            dynamic_shared_bytes: 0,
+        };
+        // SAFETY: `info` remains valid for the synchronous query.
+        let status = unsafe { ai_pow_cuda_peak_kernel_info(device_ordinal, &mut info) };
+        check_cuda("query peak CUDA kernel", status)?;
+        Ok(PeakKernelInfo {
+            sm_count: info.sm_count,
+            threads_per_cta: info.threads_per_cta,
+            active_ctas_per_sm: info.active_ctas_per_sm,
+            registers_per_thread: info.registers_per_thread,
+            static_shared_bytes: info.static_shared_bytes,
+            dynamic_shared_bytes: info.dynamic_shared_bytes,
+        })
+    }
+
+    pub fn new(
+        device_ordinal: usize,
+        m: usize,
+        n: usize,
+        a_prime: &[i8],
+        b_prime: &[i8],
+        pow_key: &[u8; 32],
+    ) -> Result<Self> {
+        if m == 0 || n == 0 || m % 256 != 0 || n % 128 != 0 {
+            bail!("peak shape requires nonzero m%256==0 and n%128==0");
+        }
+        let a_len = m
+            .checked_mul(PEAK_K)
+            .ok_or_else(|| anyhow::anyhow!("peak A length overflow"))?;
+        let b_len = n
+            .checked_mul(PEAK_K)
+            .ok_or_else(|| anyhow::anyhow!("peak B length overflow"))?;
+        if a_prime.len() != a_len || b_prime.len() != b_len {
+            bail!(
+                "peak matrix lengths must be m*k={} and n*k={}, got {} and {}",
+                a_len,
+                b_len,
+                a_prime.len(),
+                b_prime.len()
+            );
+        }
+        let total_tickets = u64::try_from(m / PEAK_TILE)?
+            .checked_mul(u64::try_from(n / PEAK_TILE)?)
+            .ok_or_else(|| anyhow::anyhow!("peak ticket count overflow"))?;
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: all slices have the validated fixed lengths. CUDA copies them
+        // before this synchronous call returns and initializes `raw` on success.
+        let status = unsafe {
+            ai_pow_cuda_peak_session_create(
+                u32::try_from(device_ordinal)?,
+                u32::try_from(m)?,
+                u32::try_from(n)?,
+                PEAK_K as u32,
+                PEAK_RANK as u32,
+                PEAK_TILE as u32,
+                a_prime.as_ptr(),
+                b_prime.as_ptr(),
+                pow_key.as_ptr(),
+                &mut raw,
+            )
+        };
+        check_cuda("peak session creation", status)?;
+        if raw.is_null() {
+            bail!("peak session creation returned a null session");
+        }
+        Ok(Self {
+            raw,
+            m,
+            n,
+            total_tickets,
+        })
+    }
+
+    pub const fn m(&self) -> usize {
+        self.m
+    }
+
+    pub const fn n(&self) -> usize {
+        self.n
+    }
+
+    pub const fn total_tickets(&self) -> u64 {
+        self.total_tickets
+    }
+
+    pub fn search(
+        &mut self,
+        ordinal_start: u64,
+        ordinal_count: u64,
+        target: &[u8; 32],
+    ) -> Result<PeakSearchResult> {
+        if ordinal_count == 0
+            || ordinal_start >= self.total_tickets
+            || ordinal_count > self.total_tickets - ordinal_start
+        {
+            bail!("peak search range is outside the prepared ticket space");
+        }
+        let mut raw_result = FfiSearchResult {
+            winner_ordinal: NO_WINNER,
+            jackpot: [0; 32],
+            kernel_ms: 0.0,
+        };
+        // SAFETY: the session is exclusively borrowed. The fixed buffers remain
+        // valid for the synchronous ABI call.
+        let status = unsafe {
+            ai_pow_cuda_peak_session_search(
+                self.raw,
+                ordinal_start,
+                ordinal_count,
+                target.as_ptr(),
+                &mut raw_result,
+            )
+        };
+        check_cuda("peak search", status)?;
+        Ok(PeakSearchResult {
+            winner: (raw_result.winner_ordinal != NO_WINNER).then_some(raw_result.winner_ordinal),
+            jackpot: raw_result.jackpot,
+            kernel_ms: raw_result.kernel_ms,
+        })
+    }
+
+    pub fn debug_ticket(&mut self, ordinal: u64) -> Result<PeakDebugResult> {
+        if ordinal >= self.total_tickets {
+            bail!("peak debug ordinal is outside the prepared ticket space");
+        }
+        let mut state = [0i32; 16];
+        let mut jackpot = [0u8; 32];
+        // SAFETY: the session is exclusively borrowed and both output buffers
+        // have their ABI-required fixed lengths.
+        let status = unsafe {
+            ai_pow_cuda_peak_session_debug(
+                self.raw,
+                ordinal,
+                state.as_mut_ptr(),
+                jackpot.as_mut_ptr(),
+            )
+        };
+        check_cuda("peak ticket debug", status)?;
+        Ok(PeakDebugResult {
+            state: TileState(state),
+            jackpot,
+        })
+    }
+}
+
+/// Opt-in dense search backend for the fixed peak geometry.
+pub struct PeakSearchBackend {
+    device_ordinal: usize,
+    dispatch: Mutex<PeakDispatch>,
+}
+
+#[derive(Default)]
+struct PeakDispatch {
+    template: Option<Arc<PreparedPearlPatternJob>>,
+    session: Option<PeakCudaSession>,
+}
+
+impl PeakSearchBackend {
+    pub fn new(device_ordinal: usize) -> Self {
+        Self {
+            device_ordinal,
+            dispatch: Mutex::new(PeakDispatch::default()),
+        }
+    }
+
+    pub const fn device_ordinal(&self) -> usize {
+        self.device_ordinal
+    }
+
+    fn validate_template(template: &PreparedPearlPatternJob) -> Result<(), SearchBackendError> {
+        let params = template.params();
+        if params.k as usize != PEAK_K
+            || params.noise_rank as usize != PEAK_RANK
+            || params.tile as usize != PEAK_TILE
+            || params.m == 0
+            || params.n == 0
+            || params.m % 256 != 0
+            || params.n % 128 != 0
+        {
+            return Err(unavailable(format!(
+                "peak backend requires k={PEAK_K}, rank={PEAK_RANK}, tile={PEAK_TILE}, m%256=0, and n%128=0"
+            )));
+        }
+        let rows = template.config().rows_pattern.to_list_bounded(PEAK_TILE)?;
+        let cols = template.config().cols_pattern.to_list_bounded(PEAK_TILE)?;
+        if rows.len() != PEAK_TILE
+            || cols.len() != PEAK_TILE
+            || !rows.iter().copied().eq(0..PEAK_TILE as u32)
+            || !cols.iter().copied().eq(0..PEAK_TILE as u32)
+        {
+            return Err(unavailable(
+                "peak backend requires contiguous 16-element row and column patterns",
+            ));
+        }
+        if !template
+            .row_offsets()
+            .iter()
+            .copied()
+            .eq((0..params.m).step_by(PEAK_TILE))
+            || !template
+                .col_offsets()
+                .iter()
+                .copied()
+                .eq((0..params.n).step_by(PEAK_TILE))
+        {
+            return Err(unavailable(
+                "peak backend requires complete non-overlapping tile offsets",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl SearchBackend for PeakSearchBackend {
+    fn search_dense(
+        &self,
+        template: Arc<PreparedPearlPatternJob>,
+        batch: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        let mut dispatch = self
+            .dispatch
+            .lock()
+            .map_err(|_| unavailable("peak CUDA dispatch lock was poisoned"))?;
+        let replace = dispatch
+            .template
+            .as_ref()
+            .is_none_or(|current| !Arc::ptr_eq(current, &template));
+        if replace {
+            dispatch.session = None;
+            dispatch.template = None;
+            Self::validate_template(&template)?;
+            let params = template.params();
+            let (a_prime, b_prime) = template.prepared_matrices();
+            let session = PeakCudaSession::new(
+                self.device_ordinal,
+                params.m as usize,
+                params.n as usize,
+                a_prime,
+                b_prime,
+                &template.commitments().s_a,
+            )
+            .map_err(unavailable)?;
+            dispatch.template = Some(Arc::clone(&template));
+            dispatch.session = Some(session);
+        }
+        let result = dispatch
+            .session
+            .as_mut()
+            .ok_or_else(|| unavailable("peak CUDA session is unavailable"))?
+            .search(batch.start, batch.len, &batch.threshold)
+            .map_err(unavailable)?;
+        let Some(ordinal) = result.winner else {
+            return Ok(None);
+        };
+        if ordinal < batch.start || ordinal >= batch.end_exclusive() {
+            return Err(SearchBackendError::WinnerOutsideBatch {
+                winner: ordinal,
+                batch_start: batch.start,
+                batch_end_exclusive: batch.end_exclusive(),
+            });
+        }
+        let (t_rows, t_cols) = template
+            .offsets_at_ordinal(ordinal)
+            .ok_or(SearchBackendError::DenseOrdinalOutOfRange(ordinal))?;
+        let scalar = template.evaluate(t_rows, t_cols, &mut template.scratch())?;
+        if scalar.jackpot_hash != result.jackpot
+            || !hash_le_target(&scalar.jackpot_hash, &batch.threshold)
+        {
+            return Err(unavailable(format!(
+                "peak CUDA winner {ordinal} failed scalar validation"
+            )));
+        }
+        Ok(Some(SearchWinner {
+            ordinal,
+            jackpot_hash: scalar.jackpot_hash,
+        }))
+    }
+
+    #[cfg(feature = "node")]
+    fn search_canonical(
+        &self,
+        _: Arc<PreparedCanonicalMoeTemplate>,
+        _: SearchBatch,
+    ) -> Result<Option<SearchWinner>, SearchBackendError> {
+        Err(unavailable(
+            "peak dense backend does not accept canonical MoE jobs",
+        ))
+    }
+
+    fn batch_attempts(&self) -> u64 {
+        u64::MAX
+    }
+}
+
+fn unavailable(error: impl std::fmt::Display) -> SearchBackendError {
+    SearchBackendError::BackendUnavailable(error.to_string())
+}
+
+impl Drop for PeakCudaSession {
+    fn drop(&mut self) {
+        if !self.raw.is_null() {
+            // SAFETY: this object uniquely owns the opaque session.
+            let _ = unsafe { ai_pow_cuda_peak_session_destroy(self.raw) };
+            self.raw = std::ptr::null_mut();
+        }
+    }
+}
+
+fn check_cuda(operation: &str, status: c_int) -> Result<()> {
+    if status != 0 {
+        bail!("{operation} failed with CUDA status {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use ai_pow::pearl_compat::pearl_jackpot_hash;
+
+    use super::*;
+
+    fn fixture(m: usize, n: usize) -> (Vec<i8>, Vec<i8>, [u8; 32]) {
+        let mut state = 0x0123_4567_89ab_cdefu64;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            ((state >> 32) as u8 & 0x7f) as i8 - 64
+        };
+        let a = (0..m * PEAK_K).map(|_| next()).collect();
+        let b = (0..n * PEAK_K).map(|_| next()).collect();
+        let key = std::array::from_fn(|index| (index as u8).wrapping_mul(17).wrapping_add(3));
+        (a, b, key)
+    }
+
+    fn scalar_ticket(a: &[i8], b: &[i8], n: usize, ordinal: u64) -> TileState {
+        let col_tiles = n / PEAK_TILE;
+        let row_tile = ordinal as usize / col_tiles;
+        let col_tile = ordinal as usize % col_tiles;
+        let mut cells = [0i32; PEAK_TILE * PEAK_TILE];
+        let mut state = [0i32; 16];
+        for step in 0..PEAK_K / PEAK_RANK {
+            for row in 0..PEAK_TILE {
+                let a_base = (row_tile * PEAK_TILE + row) * PEAK_K + step * PEAK_RANK;
+                for col in 0..PEAK_TILE {
+                    let b_base = (col_tile * PEAK_TILE + col) * PEAK_K + step * PEAK_RANK;
+                    let mut delta = 0i32;
+                    for index in 0..PEAK_RANK {
+                        delta += i32::from(a[a_base + index]) * i32::from(b[b_base + index]);
+                    }
+                    let cell = row * PEAK_TILE + col;
+                    cells[cell] = cells[cell].saturating_add(delta);
+                }
+            }
+            state[step] = cells
+                .iter()
+                .fold(0u32, |value, cell| value ^ (*cell as u32)) as i32;
+        }
+        TileState(state)
+    }
+
+    fn little_endian_predecessor(mut value: [u8; 32]) -> [u8; 32] {
+        for byte in &mut value {
+            if *byte != 0 {
+                *byte -= 1;
+                return value;
+            }
+            *byte = 0xff;
+        }
+        panic!("zero has no unsigned predecessor");
+    }
+
+    #[test]
+    fn peak_device_transcript_matches_scalar() {
+        let (a, b, key) = fixture(256, 128);
+        let mut session =
+            PeakCudaSession::new(0, 256, 128, &a, &b, &key).expect("peak CUDA session");
+        for ordinal in [0, 1, 63, 127] {
+            let device = session.debug_ticket(ordinal).expect("device ticket");
+            let scalar = scalar_ticket(&a, &b, 128, ordinal);
+            assert_eq!(device.state, scalar, "ordinal {ordinal}");
+            assert_eq!(device.jackpot, pearl_jackpot_hash(&scalar, &key));
+        }
+    }
+
+    #[test]
+    fn peak_device_matches_one_thousand_deterministic_tickets() {
+        const TICKET_COUNT: usize = 1_000;
+        let (a, b, key) = fixture(2_048, 256);
+        let mut session =
+            PeakCudaSession::new(0, 2_048, 256, &a, &b, &key).expect("peak CUDA session");
+        let total_tickets = session.total_tickets();
+        let mut ordinals = Vec::with_capacity(TICKET_COUNT);
+        ordinals.extend([0, 1, 127, 128, 129, 1_023, 1_024, total_tickets - 1]);
+        let mut state = 0xd1b5_4a32_d192_ed03u64;
+        while ordinals.len() < TICKET_COUNT {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            ordinals.push(state % total_tickets);
+        }
+
+        for ordinal in ordinals {
+            let scalar = scalar_ticket(&a, &b, 256, ordinal);
+            let jackpot = pearl_jackpot_hash(&scalar, &key);
+            let device = session.debug_ticket(ordinal).expect("device ticket");
+            assert_eq!(device.state, scalar, "ordinal {ordinal}");
+            assert_eq!(device.jackpot, jackpot, "ordinal {ordinal}");
+            let lower_target = little_endian_predecessor(jackpot);
+            for repetition in 0..3 {
+                let hit = session
+                    .search(ordinal, 1, &jackpot)
+                    .expect("exact-target search");
+                assert_eq!(
+                    hit.winner,
+                    Some(ordinal),
+                    "ordinal {ordinal}, repetition {repetition}"
+                );
+                assert_eq!(
+                    hit.jackpot, jackpot,
+                    "ordinal {ordinal}, repetition {repetition}"
+                );
+                let miss = session
+                    .search(ordinal, 1, &lower_target)
+                    .expect("predecessor-target search");
+                assert_eq!(
+                    miss.winner, None,
+                    "ordinal {ordinal}, repetition {repetition}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn peak_search_returns_lowest_winner_and_no_hit() {
+        let (a, b, key) = fixture(256, 128);
+        let mut session =
+            PeakCudaSession::new(0, 256, 128, &a, &b, &key).expect("peak CUDA session");
+        let maximum = session
+            .search(0, session.total_tickets(), &[0xff; 32])
+            .expect("maximum-target search");
+        assert_eq!(maximum.winner, Some(0));
+        assert_eq!(
+            maximum.jackpot,
+            session.debug_ticket(0).expect("winner debug").jackpot
+        );
+        let zero = session
+            .search(0, session.total_tickets(), &[0; 32])
+            .expect("zero-target search");
+        assert_eq!(zero.winner, None);
+    }
+
+    #[test]
+    fn peak_search_honors_adjacent_ranges_across_persistent_tiles() {
+        let (a, b, key) = fixture(4_096, 4_096);
+        let mut session =
+            PeakCudaSession::new(0, 4_096, 4_096, &a, &b, &key).expect("peak CUDA session");
+        let midpoint = session.total_tickets() / 2;
+        for (start, len) in [(0, midpoint), (midpoint, session.total_tickets() - midpoint)] {
+            let result = session
+                .search(start, len, &[0xff; 32])
+                .expect("maximum-target range search");
+            assert_eq!(result.winner, Some(start));
+        }
+    }
+}

--- a/crates/ai-pow-miner/src/run.rs
+++ b/crates/ai-pow-miner/src/run.rs
@@ -44,6 +44,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use ai_pow::params::MatmulParams;
+#[cfg(feature = "gpu")]
+use ai_pow::pearl_compat::PearlWorkCommitments;
 use ai_pow::pearl_compat::{
     pearl_nbits_to_target_le, validate_pearl_merge_config_for_recursive_prover,
     verify_pearl_aux_inclusion, PearlAuxInclusionProof, PearlCompatError,
@@ -78,6 +80,10 @@ use crate::canonical::{
     evaluate_canonical_moe_jackpot, prove_canonical_moe_block_at_for_miner, CanonicalBlock,
     CanonicalProveError, PreparedCanonicalMoeTemplate,
 };
+#[cfg(feature = "gpu")]
+use crate::canonical::{
+    CanonicalDenseBlock, PreparedCanonicalDenseSearch, PreparedCanonicalDenseTemplate,
+};
 use crate::certificate_noun::{
     build_ai_pow_pearl_merge_artifact_noun_from_ticket_compact_recursive_run,
     build_ai_pow_pearl_merge_artifact_noun_from_ticket_public_inputs_node,
@@ -86,12 +92,20 @@ use crate::certificate_noun::{
     decode_ai_pow_pearl_merge_artifact_metadata_slab, AiProofNode, CertificateNounError,
     CertificateNounLimits,
 };
+#[cfg(feature = "gpu")]
+use crate::peak::MultiGpuPeakSearchBackend;
 use crate::pearl_mining::{
     self, PearlMergeMineOptions, PearlMergeMinedTicket, PearlMergeMiningError, PearlMergeMiningJob,
 };
 use crate::pearl_plain_proof::PearlPlainProof;
+#[cfg(feature = "gpu")]
+use crate::search::MeteredSearchBackend;
+#[cfg(feature = "gpu")]
+use crate::search::SearchBatch;
 use crate::search::{CpuSearchBackend, OrderedBatchScheduler, SearchBackend, SearchScheduleEnd};
 use crate::wire::AiPowMinerWire;
+#[cfg(feature = "gpu")]
+use crate::PEAK_PRODUCTION_PARAMS;
 use crate::{DifficultyTarget, MiningCancel};
 
 // Covers a base64-encoded max-size coinbase inclusion plus the Pearl header,
@@ -405,6 +419,8 @@ pub enum MinerError {
     CertificateBuild(String),
     #[error("{0}")]
     CanonicalCertificateUnavailable(String),
+    #[error("production AI-PoW worker failed: {0}")]
+    ProductionWorker(String),
 }
 
 /// Production entry point using a physical-core CPU search backend.
@@ -884,10 +900,105 @@ fn build_canonical_poke(block: &CanonicalBlock) -> Result<NounSlab, MinerError> 
     Ok(slab)
 }
 
-/// A grind worker returns `Ok(Some(block))` when a nonce cleared the target and
-/// its certificate was proved, `Ok(None)` when the grind was cancelled (a new
-/// candidate arrived) or exhausted the nonce space, and `Err` on a prove failure.
-type GrindResult = Result<Option<CanonicalBlock>, CanonicalProveError>;
+#[cfg(feature = "gpu")]
+fn build_peak_poke(block: &CanonicalDenseBlock) -> Result<NounSlab, MinerError> {
+    let artifact = build_ai_pow_pearl_merge_artifact_noun_from_ticket_compact_recursive_run(
+        block.attempt.attempt(),
+        &block.aux_inclusion,
+        &block.a,
+        &block.b,
+        PEAK_PRODUCTION_PARAMS.tile as usize,
+        &block.run,
+    )
+    .map_err(|e| MinerError::CertificateBuild(format!("peak dense artifact: {e}")))?;
+    let artifact_space = artifact.noun_space();
+    let mut slab = NounSlab::new();
+    let art = slab.copy_into(unsafe { *artifact.root() }, &artifact_space);
+    let payload = T(&mut slab, &[D(tas!(b"command")), D(tas!(b"pow")), art]);
+    slab.set_root(payload);
+    Ok(slab)
+}
+
+enum GatewayFreeBlock {
+    Canonical(CanonicalBlock),
+    #[cfg(feature = "gpu")]
+    Peak(CanonicalDenseBlock),
+}
+
+impl GatewayFreeBlock {
+    fn commit(&self) -> [u8; 32] {
+        match self {
+            Self::Canonical(block) => block.commit,
+            #[cfg(feature = "gpu")]
+            Self::Peak(block) => block.commit,
+        }
+    }
+
+    fn trace_height(&self) -> usize {
+        match self {
+            Self::Canonical(block) => block.certificate.trace_height,
+            #[cfg(feature = "gpu")]
+            Self::Peak(block) => block.run.trace_height(),
+        }
+    }
+
+    fn build_poke(&self) -> Result<NounSlab, MinerError> {
+        match self {
+            Self::Canonical(block) => build_canonical_poke(block),
+            #[cfg(feature = "gpu")]
+            Self::Peak(block) => build_peak_poke(block),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum GatewayFreeProfile {
+    Canonical,
+    #[cfg(feature = "gpu")]
+    Peak {
+        a: Arc<Vec<i8>>,
+        b: Arc<Vec<i8>>,
+    },
+}
+
+impl GatewayFreeProfile {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Canonical => "canonical-moe",
+            #[cfg(feature = "gpu")]
+            Self::Peak { .. } => "peak-dense",
+        }
+    }
+
+    fn worker_errors_are_fatal(&self) -> bool {
+        match self {
+            Self::Canonical => false,
+            #[cfg(feature = "gpu")]
+            Self::Peak { .. } => true,
+        }
+    }
+
+    fn grind(
+        &self,
+        commit: [u8; 32],
+        target: DifficultyTarget,
+        cancel: Arc<AtomicBool>,
+        backend: &dyn SearchBackend,
+    ) -> GrindResult {
+        match self {
+            Self::Canonical => grind_canonical_block_with_backend(commit, target, cancel, backend),
+            #[cfg(feature = "gpu")]
+            Self::Peak { a, b } => {
+                grind_peak_block_with_backend(commit, target, cancel, backend, a, b)
+            }
+        }
+    }
+}
+
+/// A grind worker returns `Ok(Some(block))` when a ticket cleared the target and
+/// its certificate was proved, `Ok(None)` when the grind was cancelled or
+/// exhausted, and `Err` on search, revalidation, or proof failure.
+type GrindResult = Result<Option<GatewayFreeBlock>, CanonicalProveError>;
 
 enum CanonicalOutcome {
     None,
@@ -1041,7 +1152,7 @@ fn grind_canonical_block_with_backend(
             &CANONICAL_MATMUL_PARAMS, CANONICAL_HW, CANONICAL_E, CANONICAL_TOP_K, commit,
             extranonce,
         )?;
-        return Ok(Some(proved));
+        return Ok(Some(GatewayFreeBlock::Canonical(proved)));
     }
     warn!(
         commit = %hex::encode(commit),
@@ -1051,20 +1162,99 @@ fn grind_canonical_block_with_backend(
     Ok(None)
 }
 
-/// Gateway-free miner loop: connect to the node, subscribe to `%mine-ai`
-/// candidates, and for each candidate GRIND a CANONICAL AI-PoW block bound to the
-/// candidate's block commitment — sweeping the extranonce, computing each attempt's
-/// MoE tile jackpot, until one clears the candidate's difficulty target; then pay
-/// the one-time recursive-certificate cost (~25-30s) and poke it as `%pow`. This is
-/// real proof-of-work: expected attempts ~= 2^256 / (target · F), where F is the
-/// canonical shape work factor — the consensus target prices one MAC-equivalent,
-/// not one attempt, so expected MAC-equivalents per block is 2^256 / target
-/// regardless of tile shape (`ai_pow::difficulty`). No Pearl Gateway. One
-/// grind runs at a time; candidates that arrive mid-grind are ignored until it
-/// finishes. Because a block takes grind + prove time, run the node with
-/// `--fakenet-update-candidate-interval-secs` LARGER than that (and tune the AI
-/// ASERT target so the grind fits inside the window) so the winning certificate
-/// still binds the current candidate when it lands.
+#[cfg(feature = "gpu")]
+fn grind_peak_block_with_backend(
+    commit: [u8; 32],
+    target: DifficultyTarget,
+    cancel: Arc<AtomicBool>,
+    backend: &dyn SearchBackend,
+    a: &Arc<Vec<i8>>,
+    b: &Arc<Vec<i8>>,
+) -> GrindResult {
+    if cancel.load(Ordering::Relaxed) {
+        return Ok(None);
+    }
+    let template = PreparedCanonicalDenseTemplate::new(
+        &PEAK_PRODUCTION_PARAMS,
+        commit,
+        Arc::clone(a),
+        Arc::clone(b),
+    )?;
+
+    for extranonce in 0..=u32::MAX {
+        if cancel.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let prepared = Arc::new(template.prepare_search(extranonce)?);
+        let factor = prepared
+            .config()
+            .shape_work_factor()
+            .map_err(|e| CanonicalProveError(format!("peak shape work factor: {e}")))?;
+        let threshold =
+            ai_pow::difficulty::effective_jackpot_threshold(&target, factor).map_err(|e| {
+                CanonicalProveError(format!(
+                    "candidate target {} is outside the representable AI-PoW domain for the peak \
+                     shape (factor {factor}): {e:?}",
+                    hex::encode(target)
+                ))
+            })?;
+        let total_tickets = prepared.total_tickets();
+        let batch = SearchBatch::new(0, total_tickets, threshold)
+            .map_err(|e| CanonicalProveError(format!("peak search batch: {e}")))?;
+        let outcome = backend
+            .search_peak(Arc::clone(&prepared), batch)
+            .map_err(|e| CanonicalProveError(format!("peak search backend: {e}")))?;
+        if cancel.load(Ordering::Relaxed) {
+            return Ok(None);
+        }
+        let Some(winner) = outcome.winner else {
+            continue;
+        };
+        let attempt =
+            revalidate_peak_winner(&template, &prepared, winner, &outcome.commitments, &target)?;
+        info!(
+            extranonce,
+            ordinal = winner.ordinal,
+            commit = %hex::encode(commit),
+            "peak dense AI-PoW jackpot hit; proving recursive certificate"
+        );
+        let block = template.prove(attempt)?;
+        return Ok(Some(GatewayFreeBlock::Peak(block)));
+    }
+
+    warn!(
+        commit = %hex::encode(commit),
+        "peak AI-PoW grind exhausted the u32 extranonce space with no jackpot"
+    );
+    Ok(None)
+}
+
+#[cfg(feature = "gpu")]
+fn revalidate_peak_winner(
+    template: &PreparedCanonicalDenseTemplate,
+    prepared: &PreparedCanonicalDenseSearch,
+    winner: crate::search::SearchWinner,
+    device_commitments: &PearlWorkCommitments,
+    target: &DifficultyTarget,
+) -> Result<PearlMergeCheckedTicketAttempt, CanonicalProveError> {
+    let attempt = template.checked_search_winner(prepared, winner.ordinal, target)?;
+    if attempt.commitments != *device_commitments {
+        return Err(CanonicalProveError(
+            "peak backend transcript disagrees with scalar winner recheck".to_string(),
+        ));
+    }
+    if attempt.ticket.jackpot_hash != winner.jackpot_hash {
+        return Err(CanonicalProveError(
+            "peak backend jackpot disagrees with scalar winner recheck".to_string(),
+        ));
+    }
+    Ok(attempt)
+}
+
+/// Gateway-free canonical CPU miner. It binds each MoE search to the current
+/// `%mine-ai` block commitment, applies the consensus shape-work adjustment, and
+/// builds the recursive certificate only after a scalar-validated hit. A new
+/// candidate cancels and drains the old search before its replacement starts.
 pub async fn run_canonical(
     node_addr: String,
     mining_pkh_configs: Vec<MiningPkhConfig>,
@@ -1073,7 +1263,14 @@ pub async fn run_canonical(
     let backend: Arc<dyn SearchBackend> = Arc::new(CpuSearchBackend::new(
         CpuSearchBackend::default_worker_count(),
     )?);
-    run_canonical_with_backend(node_addr, mining_pkh_configs, shutdown, backend).await
+    run_gateway_free_with_backend(
+        node_addr,
+        mining_pkh_configs,
+        shutdown,
+        backend,
+        GatewayFreeProfile::Canonical,
+    )
+    .await
 }
 
 /// Gateway-free canonical miner with an owned ticket-search backend.
@@ -1083,11 +1280,66 @@ pub async fn run_canonical_with_backend(
     shutdown: CancellationToken,
     backend: Arc<dyn SearchBackend>,
 ) -> Result<(), MinerError> {
+    run_gateway_free_with_backend(
+        node_addr,
+        mining_pkh_configs,
+        shutdown,
+        backend,
+        GatewayFreeProfile::Canonical,
+    )
+    .await
+}
+
+#[cfg(feature = "gpu")]
+pub async fn run_peak(
+    node_addr: String,
+    mining_pkh_configs: Vec<MiningPkhConfig>,
+    shutdown: CancellationToken,
+    device_ordinals: Option<Vec<usize>>,
+) -> Result<(), MinerError> {
+    let backend = match device_ordinals {
+        Some(ordinals) => MultiGpuPeakSearchBackend::new(ordinals),
+        None => MultiGpuPeakSearchBackend::all_visible(),
+    }
+    .map_err(|e| MinerError::Configure(format!("peak CUDA backend: {e}")))?;
+    let (a, b) = ai_pow::synth::synth_matrices(
+        ai_pow::synth::AI_POW_PROD_SYNTH_SEED,
+        &PEAK_PRODUCTION_PARAMS,
+    );
+    backend
+        .preflight(&a, &b)
+        .map_err(|e| MinerError::Configure(format!("peak CUDA preflight: {e}")))?;
+    info!(
+        cuda_devices = ?backend.device_ordinals(),
+        "ai-pow-miner: peak CUDA search initialized"
+    );
+    let backend: Arc<dyn SearchBackend> = MeteredSearchBackend::new("peak-cuda", Arc::new(backend));
+    run_gateway_free_with_backend(
+        node_addr,
+        mining_pkh_configs,
+        shutdown,
+        backend,
+        GatewayFreeProfile::Peak {
+            a: Arc::new(a),
+            b: Arc::new(b),
+        },
+    )
+    .await
+}
+
+async fn run_gateway_free_with_backend(
+    node_addr: String,
+    mining_pkh_configs: Vec<MiningPkhConfig>,
+    shutdown: CancellationToken,
+    backend: Arc<dyn SearchBackend>,
+    profile: GatewayFreeProfile,
+) -> Result<(), MinerError> {
     validate_mining_pkh_configs(&mining_pkh_configs)?;
+    let profile_name = profile.name();
     info!(
         node = %node_addr,
-        params = ?CANONICAL_MATMUL_PARAMS,
-        "ai-pow-miner: entering CANONICAL gateway-free loop"
+        profile = profile_name,
+        "ai-pow-miner: entering gateway-free production loop"
     );
     loop {
         if shutdown.is_cancelled() {
@@ -1128,7 +1380,8 @@ pub async fn run_canonical_with_backend(
             return Err(MinerError::Configure(format!("enable_mining(true): {e}")));
         }
         info!(
-            "ai-pow-miner: subscribed + mining enabled (canonical); awaiting %mine-ai candidates"
+            profile = profile_name,
+            "ai-pow-miner: subscribed + mining enabled; awaiting %mine-ai candidates"
         );
 
         let mut worker: Option<JoinHandle<GrindResult>> = None;
@@ -1162,13 +1415,11 @@ pub async fn run_canonical_with_backend(
                         continue;
                     }
                     if worker.is_some() {
-                        // A grind is already in flight; ignore intervening candidates
-                        // to keep exactly one CPU grind running. A grind that finishes
-                        // against a since-superseded commit produces a block the node
-                        // rejects as stale, and the next candidate starts a fresh grind
-                        // — so difficulty must be tuned (via the AI ASERT target) so the
-                        // grind completes inside the candidate refresh window.
-                        continue;
+                        info!(
+                            profile = profile_name,
+                            "new candidate replaces active gateway-free search"
+                        );
+                        cancel_and_await_canonical_worker(&mut worker, &grind_cancel).await?;
                     }
                     let inputs = match derive_nockchain_candidate_inputs(&candidate) {
                         Ok(x) => x,
@@ -1180,15 +1431,18 @@ pub async fn run_canonical_with_backend(
                     let commit = inputs.nock_block_commitment;
                     let target = inputs.target;
                     info!(
+                        profile = profile_name,
                         commit = %hex::encode(commit),
                         pow_len = inputs.pow_len,
                         target = %hex::encode(target),
-                        "new %mine-ai candidate; grinding canonical AI-PoW block against target"
+                        "new %mine-ai candidate; starting AI-PoW search"
                     );
+                    grind_cancel.store(false, Ordering::Relaxed);
                     let cancel = grind_cancel.clone();
                     let backend = backend.clone();
+                    let profile = profile.clone();
                     worker = Some(tokio::task::spawn_blocking(move || {
-                        grind_canonical_block_with_backend(commit, target, cancel, &*backend)
+                        profile.grind(commit, target, cancel, &*backend)
                     }));
                 }
                 joined = await_canonical_worker(&mut worker) => {
@@ -1204,12 +1458,13 @@ pub async fn run_canonical_with_backend(
                         }
                         CanonicalOutcome::Joined(Ok(Ok(Some(block)))) => {
                             info!(
-                                commit = %hex::encode(block.commit),
-                                trace_height = block.certificate.trace_height,
-                                "canonical AI-PoW block proved; submitting %pow to node"
+                                profile = profile_name,
+                                commit = %hex::encode(block.commit()),
+                                trace_height = block.trace_height(),
+                                "AI-PoW block proved; submitting %pow to node"
                             );
                             let poke_start = Instant::now();
-                            match build_canonical_poke(&block) {
+                            match block.build_poke() {
                                 Ok(poke) => {
                                     let poke_build_ms = poke_start.elapsed().as_millis();
                                     let jam_start = Instant::now();
@@ -1234,7 +1489,7 @@ pub async fn run_canonical_with_backend(
                                             transport_ms = submit_timings.transport_ms,
                                             submit_status = ?submit_timings.status,
                                             send_started = submit_timings.send_started,
-                                            "canonical %ai-pow submission acked by node"
+                                            "gateway-free %ai-pow submission acked by node"
                                         ),
                                         Err(e) => warn!(
                                             error = %e,
@@ -1243,18 +1498,24 @@ pub async fn run_canonical_with_backend(
                                             transport_ms = submit_timings.transport_ms,
                                             submit_status = ?submit_timings.status,
                                             send_started = submit_timings.send_started,
-                                            "submit canonical %pow failed (likely stale candidate)"
+                                            "submit gateway-free %pow failed (likely stale candidate)"
                                         ),
                                     }
                                 }
-                                Err(e) => warn!(error = %e, "build canonical poke failed"),
+                                Err(e) if profile.worker_errors_are_fatal() => return Err(e),
+                                Err(e) => warn!(error = %e, "build gateway-free poke failed"),
                             }
                         }
                         CanonicalOutcome::Joined(Ok(Ok(None))) => {
                             // Grind cancelled (shutdown) or exhausted the nonce space.
                         }
+                        CanonicalOutcome::Joined(Ok(Err(e)))
+                            if profile.worker_errors_are_fatal() =>
+                        {
+                            return Err(MinerError::ProductionWorker(e.to_string()));
+                        }
                         CanonicalOutcome::Joined(Ok(Err(e))) => {
-                            warn!(error = %e, "canonical AI-PoW grind/prove failed");
+                            warn!(error = %e, profile = profile_name, "gateway-free AI-PoW grind/prove failed");
                         }
                         CanonicalOutcome::Joined(Err(e)) => {
                             return Err(MinerError::WorkerJoin(format!("{e}")));
@@ -2550,6 +2811,49 @@ mod tests {
         assert!(error
             .to_string()
             .contains("disagrees with canonical scalar oracle"));
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn peak_backend_winner_must_match_scalar_recheck_before_proving() {
+        let params = MatmulParams {
+            m: 16,
+            k: 1024,
+            n: 16,
+            noise_rank: 64,
+            tile: 8,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        };
+        let (a, b) = ai_pow::synth::synth_matrices(ai_pow::synth::AI_POW_PROD_SYNTH_SEED, &params);
+        let template =
+            PreparedCanonicalDenseTemplate::new(&params, [0x5a; 32], Arc::new(a), Arc::new(b))
+                .expect("dense template");
+        let prepared = template.prepare_search(0).expect("search transcript");
+        let scalar_prepared = template.prepare(0).expect("scalar preparation");
+        let scalar = scalar_prepared
+            .evaluate(0, 0, &mut scalar_prepared.scratch())
+            .expect("scalar ticket");
+        let mut corrupt = scalar.jackpot_hash;
+        corrupt[0] ^= 1;
+        let mut target = [0xff; 32];
+        target[30] = 0;
+        target[31] = 0;
+
+        let error = revalidate_peak_winner(
+            &template,
+            &prepared,
+            SearchWinner {
+                ordinal: 0,
+                jackpot_hash: corrupt,
+            },
+            scalar_prepared.commitments(),
+            &target,
+        )
+        .expect_err("corrupt peak result must not reach the prover");
+        assert!(error
+            .to_string()
+            .contains("disagrees with scalar winner recheck"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/ai-pow-miner/src/search.rs
+++ b/crates/ai-pow-miner/src/search.rs
@@ -9,12 +9,16 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle, Thread};
 use std::time::{Duration, Instant};
 
+#[cfg(all(feature = "node", feature = "gpu"))]
+use ai_pow::pearl_compat::PearlWorkCommitments;
 use ai_pow::pearl_compat::{
     PearlCompatError, PreparedPearlPatternJob, PreparedPearlPatternScratch,
 };
 use ai_pow::tile_hash::hash_le_target;
 use thiserror::Error;
 
+#[cfg(all(feature = "node", feature = "gpu"))]
+use crate::canonical::PreparedCanonicalDenseSearch;
 #[cfg(feature = "node")]
 use crate::canonical::{PreparedCanonicalMoeScratch, PreparedCanonicalMoeTemplate};
 
@@ -66,6 +70,15 @@ impl SearchBatch {
 pub struct SearchWinner {
     pub ordinal: u64,
     pub jackpot_hash: [u8; 32],
+}
+
+#[cfg(all(feature = "node", feature = "gpu"))]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PeakSearchOutcome {
+    pub winner: Option<SearchWinner>,
+    pub commitments: PearlWorkCommitments,
+    pub commitment_ms: f32,
+    pub noise_ms: f32,
 }
 
 /// Terminal condition for an ordered search schedule.
@@ -218,6 +231,17 @@ pub trait SearchBackend: Send + Sync {
         batch: SearchBatch,
     ) -> Result<Option<SearchWinner>, SearchBackendError>;
 
+    #[cfg(all(feature = "node", feature = "gpu"))]
+    fn search_peak(
+        &self,
+        _template: Arc<PreparedCanonicalDenseSearch>,
+        _batch: SearchBatch,
+    ) -> Result<PeakSearchOutcome, SearchBackendError> {
+        Err(SearchBackendError::BackendUnavailable(
+            "backend does not accept peak dense jobs".to_string(),
+        ))
+    }
+
     /// Preferred upper bound for one scheduler dispatch.
     ///
     /// Backends with fixed launch geometry can override this value. The caller
@@ -291,6 +315,25 @@ impl SearchBackend for MeteredSearchBackend {
         let result = self.inner.search_canonical(template, batch);
         if result.is_ok() {
             self.record(batch.len, shape_work_factor);
+        }
+        result
+    }
+
+    #[cfg(all(feature = "node", feature = "gpu"))]
+    fn search_peak(
+        &self,
+        template: Arc<PreparedCanonicalDenseSearch>,
+        batch: SearchBatch,
+    ) -> Result<PeakSearchOutcome, SearchBackendError> {
+        let shape_work_factor = template.config().shape_work_factor()?;
+        let result = self.inner.search_peak(template, batch);
+        if let Ok(outcome) = &result {
+            self.record(batch.len, shape_work_factor);
+            tracing::debug!(
+                commitment_ms = outcome.commitment_ms,
+                noise_ms = outcome.noise_ms,
+                "peak CUDA transcript preparation"
+            );
         }
         result
     }

--- a/crates/ai-pow-zk/src/canonical.rs
+++ b/crates/ai-pow-zk/src/canonical.rs
@@ -591,22 +591,42 @@ impl StripIndexSchedule {
     }
 }
 
-/// Covering-range id span (`max lane + 1`) for one side: the sweep lane is
-/// `index − chunk_base`, so the span is `last − chunk_base + 1` (indices are
-/// validated strictly increasing). Errors instead of underflowing when the
-/// chunk base exceeds the last index (a `k > 1024` non-origin schedule — the
-/// lane arithmetic has no representation for it).
-pub fn covering_id_span(name: &str, indices: &[u32], chunk_base: usize) -> Result<usize, String> {
+/// Matrix-row origin represented by a selected BLAKE3 chunk base.
+///
+/// The positioned ID lane is relative to this row, not to the chunk index.
+/// A chunk base that starts inside a matrix row cannot use the lane encoding.
+pub fn covering_id_lane_base(name: &str, chunk_base: usize, k: usize) -> Result<usize, String> {
+    let byte_base = chunk_base
+        .checked_mul(crate::blake3_tree::CHUNK_LEN)
+        .ok_or_else(|| format!("{name} strip chunk byte offset overflow"))?;
+    if k == 0 || !byte_base.is_multiple_of(k) {
+        return Err(format!(
+            "{name} strip chunk base is not matrix-row aligned \
+             (chunk_base={chunk_base}, byte_base={byte_base}, k={k})"
+        ));
+    }
+    Ok(byte_base / k)
+}
+
+/// Covering-range ID span (`max lane + 1`) for one matrix side.
+pub fn covering_id_span(
+    name: &str,
+    indices: &[u32],
+    chunk_base: usize,
+    k: usize,
+) -> Result<usize, String> {
+    let lane_base = covering_id_lane_base(name, chunk_base, k)?;
     let last = *indices
         .last()
         .expect("validated strip schedule is nonempty") as usize;
-    last.checked_sub(chunk_base).map(|d| d + 1).ok_or_else(|| {
-        format!(
-            "{name} strip schedule covering range starts above its last index \
-                 (last={last}, chunk_base={chunk_base}); k > 1024 non-origin \
-                 schedules are not representable"
-        )
-    })
+    last.checked_sub(lane_base)
+        .map(|distance| distance + 1)
+        .ok_or_else(|| {
+            format!(
+                "{name} strip row origin exceeds its last index \
+                 (last={last}, lane_base={lane_base})"
+            )
+        })
 }
 
 fn validate_strip_indices(name: &str, indices: &[u32], dimension: u32) -> Result<(), String> {
@@ -969,6 +989,8 @@ pub fn strip_opening_rows_set(sel: &[usize], num_chunks: usize) -> usize {
 struct StripPlan {
     ca0: usize,
     cb0: usize,
+    a_lane_base: usize,
+    b_lane_base: usize,
     w_tile: usize,
     a_id_base: u64,
     b_id_base: u64,
@@ -998,18 +1020,22 @@ impl StripPlan {
             crate::blake3_tree::indexed_strips_chunk_set(&strip_schedule.b_indices, k, b_nc * 1024);
         let ca0 = a_chunks[0];
         let cb0 = b_chunks[0];
+        let a_lane_base = covering_id_lane_base("A", ca0, k)?;
+        let b_lane_base = covering_id_lane_base("B", cb0, k)?;
         let w_tile = strip_schedule.b_indices.len();
-        // Bases from the full covering-range lane span, not h_tile —
-        // side-disjoint for scattered openings; identical to the tile-height
-        // derivation for contiguous tiles (span == h_tile).
+        // Bases cover every lane from the row containing the first selected
+        // chunk through the last opened row or column. This keeps the matrix
+        // sides disjoint for sparse and non-origin schedules.
         let (a_id_base, b_id_base) = crate::composite_trace::try_noised_id_bases(
-            covering_id_span("A", &strip_schedule.a_indices, ca0)? - 1,
-            covering_id_span("B", &strip_schedule.b_indices, cb0)? - 1,
+            covering_id_span("A", &strip_schedule.a_indices, ca0, k)? - 1,
+            covering_id_span("B", &strip_schedule.b_indices, cb0, k)? - 1,
             k,
         )?;
         Ok(StripPlan {
             ca0,
             cb0,
+            a_lane_base,
+            b_lane_base,
             w_tile,
             a_id_base,
             b_id_base,
@@ -1319,15 +1345,13 @@ fn row_descriptor(
             let c0 = chunk * TILE_D;
             let w = (r - c0).min(TILE_D);
             let ids_for = |side_a: bool, sb_base: usize| -> [u64; 4] {
-                // Map the tile-local sub-block row to the actual opened
-                // (possibly non-contiguous) matrix row, then to its covering-range
-                // position (`row - c_base`) — the key the strip-opening producer
-                // publishes. For a contiguous tile `indices[i] - c_base == i`, so
-                // this is byte-identical to the previous tile-geometry path.
-                let (indices, c_base) = if side_a {
-                    (&sp.a_indices, sp.ca0)
+                // Map each tile-local row to its opened matrix row, then to the
+                // lane relative to the matrix row at the selected chunk base.
+                // This is the same byte origin that the strip producer uses.
+                let (indices, lane_base) = if side_a {
+                    (&sp.a_indices, sp.a_lane_base)
                 } else {
-                    (&sp.b_indices, sp.cb0)
+                    (&sp.b_indices, sp.b_lane_base)
                 };
                 core::array::from_fn(|jc| {
                     let mut src = [None; 8];
@@ -1335,7 +1359,7 @@ fn row_descriptor(
                         let f = jc * 8 + m;
                         let (di, col) = (f / TILE_D, f % TILE_D);
                         if col < w {
-                            let lane = indices[sb_base + di] as usize - c_base;
+                            let lane = indices[sb_base + di] as usize - lane_base;
                             src[m] = Some((lane as u32, (lo + c0 + col) as u32));
                         }
                     }
@@ -1772,7 +1796,7 @@ mod tests {
         assert_eq!(sp.a_id_base, crate::composite_trace::NOISED_CHUNK_ID_BASE);
         assert_eq!(sp.b_id_base, 8 + 74 * 128);
         for &i in &sched.a_indices {
-            let lane = (i as usize) - sp.ca0;
+            let lane = (i as usize) - sp.a_lane_base;
             for l in (0..p.k as usize).step_by(8) {
                 let mut src = [None; 8];
                 src[0] = Some((lane as u32, l as u32));
@@ -1790,9 +1814,8 @@ mod tests {
         );
     }
 
-    /// The canonical program build rejects schedules whose id span
-    /// overflows the pack_ab_id budget, and k>1024 non-origin schedules
-    /// (unrepresentable lanes), as clean errors rather than panics.
+    /// The canonical program rejects an ID span that exceeds the packed-key
+    /// budget.
     #[test]
     fn canonical_program_rejects_unprovable_id_spans() {
         let bp = bp0();
@@ -1810,8 +1833,12 @@ mod tests {
         let err = canonical_program_for_strip_schedule(&huge, &sched, &bp, 1 << 16)
             .expect_err("budget-overflowing schedule must be rejected");
         assert!(err.contains("pack_ab_id"), "unexpected error: {err}");
+    }
 
-        // k > 1024 non-origin: the lane arithmetic has no representation.
+    /// A non-origin schedule uses a matrix-row lane origin even when one row
+    /// spans multiple BLAKE3 chunks.
+    #[test]
+    fn strip_plan_supports_wide_non_origin_schedule() {
         let wide = ZkParams {
             m: 64,
             k: 2048,
@@ -1821,9 +1848,12 @@ mod tests {
             difficulty_bits: 0,
         };
         let sched = StripIndexSchedule::from_tile(&wide, 1, 1).expect("tile in grid");
-        let err = canonical_program_for_strip_schedule(&wide, &sched, &bp, 1 << 15)
-            .expect_err("k>1024 non-origin schedule must be rejected cleanly");
-        assert!(err.contains("not representable"), "unexpected error: {err}");
+        let plan = StripPlan::build_for_strip_schedule(&wide, &sched).expect("plan builds");
+        assert_eq!(plan.ca0, 16);
+        assert_eq!(plan.cb0, 16);
+        assert_eq!(plan.a_lane_base, 8);
+        assert_eq!(plan.b_lane_base, 8);
+        assert_eq!(plan.b_id_base, 8 + 8 * 256);
     }
 
     #[test]

--- a/crates/ai-pow-zk/tests/noised_packed_key_audit.rs
+++ b/crates/ai-pow-zk/tests/noised_packed_key_audit.rs
@@ -1,22 +1,21 @@
 //! Adversarial-audit regression — `noised_packed` side-disjoint keys.
 //!
-//! Deriving `b_id_base` from the tile height (`a_id_base + h_tile·k/8`)
-//! covers only tile-local lanes. For a SCATTERED opening the A-side lane
-//! is the covering-range position (`row − ca0`), which reaches beyond
-//! `h_tile` and collides with the B-side key space. The LogUp
-//! fingerprint's packed value only binds a read to *some* committed
-//! store entry, so the collision admits committed-B-value substitution
-//! at colliding A positions — an XOR-delta jackpot-grinding amplifier.
+//! `b_id_base` must cover every A-side positioned key. The lane origin is
+//! the matrix row at the first selected BLAKE3 chunk, not the chunk index.
+//! These units differ when `k != 1024`.
 //!
-//! Deriving the bases from the full A covering-range span
-//! (`max_a_lane + 1`) makes every A-side key `< b_id_base` and every
-//! B-side key `>= b_id_base`, for any schedule. Contiguous tiles have
-//! span == h_tile, so the tile-height derivation is byte-identical
-//! there. This test pins the disjointness invariant, the contiguous
-//! parity, the separation of the historical collision pair, and the
-//! 26-bit id-budget guard.
+//! A base derived only from the tile height does not cover sparse schedules.
+//! A base derived by subtracting the chunk index from the matrix row does not
+//! cover non-origin schedules when one row spans multiple chunks. Either error
+//! can overlap the A and B key spaces. The LogUp fingerprint then permits a
+//! committed B value to substitute for an A value at a colliding key.
+//!
+//! The full covering-range span keeps every A key below `b_id_base` and every
+//! B key at or above it. Contiguous origin tiles keep the original IDs. These
+//! tests pin side disjointness, matrix-row origin arithmetic, and the packed-ID
+//! budget.
 
-use ai_pow_zk::canonical::covering_id_span;
+use ai_pow_zk::canonical::{covering_id_lane_base, covering_id_span};
 use ai_pow_zk::composite_trace::{
     noised_chunk_id, noised_id_bases, try_noised_id_bases, NOISED_CHUNK_ID_BASE,
 };
@@ -133,9 +132,11 @@ fn noised_packed_id_budget_guard() {
         try_noised_id_bases((1 << 24) - 1, 1, 1 << 16).is_err(),
         "span overflowing the 26-bit pack_ab_id budget must be rejected"
     );
-    // covering_id_span rejects k > 1024 non-origin schedules (the lane
-    // arithmetic has no representation for them) instead of underflowing.
-    assert!(covering_id_span("A", &[64, 65], 128).is_err());
-    assert_eq!(covering_id_span("A", &[64, 65], 64).unwrap(), 2);
-    assert_eq!(covering_id_span("A", &[0, 1, 8], 0).unwrap(), 9);
+    // Chunk 128 begins at matrix row 64 when k=2048.
+    assert_eq!(covering_id_lane_base("A", 128, 2048).unwrap(), 64);
+    assert_eq!(covering_id_span("A", &[64, 65], 128, 2048).unwrap(), 2);
+    assert_eq!(covering_id_span("A", &[64, 65], 64, 1024).unwrap(), 2);
+    assert_eq!(covering_id_span("A", &[0, 1, 8], 0, 64).unwrap(), 9);
+    // A selected chunk that starts inside a matrix row cannot use lane IDs.
+    assert!(covering_id_span("A", &[1, 2], 1, 1536).is_err());
 }

--- a/crates/ai-pow/src/pearl_compat.rs
+++ b/crates/ai-pow/src/pearl_compat.rs
@@ -1565,6 +1565,14 @@ impl PreparedPearlPatternJob {
         &self.commitments
     }
 
+    /// Complete noised matrices for a prepared dense accelerator session.
+    ///
+    /// `A'` is row-major and `B'` is transposed row-major (one original
+    /// matrix column per contiguous `k`-element row).
+    pub fn prepared_matrices(&self) -> (&[i8], &[i8]) {
+        (&self.matrices.a_prime, &self.matrices.b_prime)
+    }
+
     pub fn row_offsets(&self) -> &[u32] {
         &self.row_offsets
     }

--- a/crates/ai-pow/src/zk_bridge.rs
+++ b/crates/ai-pow/src/zk_bridge.rs
@@ -3010,8 +3010,10 @@ fn prove_ai_pow_scheduled_full_with_context<F: FnOnce(&mut CompositeTrace)>(
     let (a_chunks, a_nc) = indexed_strips_chunk_set(a_indices, kk, a_bytes.len());
     let (_oa, a_sibs) = open_strip_set(a_bytes, &zctx.kappa, &a_chunks);
     let a_strip_bytes = padded_chunk_bytes(a_bytes, &a_chunks);
-    // Producer-key / sweep-lane base = min selected chunk (== the range c0).
+    // First selected chunk and its matrix-row origin for positioned IDs.
     let ca0 = a_chunks[0];
+    let a_lane_base = ai_pow_zk::canonical::covering_id_lane_base("A", ca0, kk)
+        .map_err(BridgeError::ZkParamsInvalid)?;
     // c-exact g=1 co-location: the Pearl `noise_ref`
     // byte parallel to the opened A strip — entry j = noise at the
     // committed matrix position of `a_pad[ca0*1024 + j]` (A is
@@ -3033,15 +3035,15 @@ fn prove_ai_pow_scheduled_full_with_context<F: FnOnce(&mut CompositeTrace)>(
     let b_indices = &strip_schedule.b_indices;
     let (b_chunks, b_nc) = indexed_strips_chunk_set(b_indices, kk, b_bytes.len());
     let cb0 = b_chunks[0];
-    // Bases from the full covering-range lane spans (lane =
-    // index − chunk base), never the tile height — side-disjoint for
-    // scattered openings; identical to the tile-height derivation for
-    // contiguous tiles (span == h_tile).
+    let b_lane_base = ai_pow_zk::canonical::covering_id_lane_base("B", cb0, kk)
+        .map_err(BridgeError::ZkParamsInvalid)?;
+    // Bases cover the selected chunks' matrix-row lanes. The chunk index and
+    // matrix row use different units whenever k != 1024.
     let (a_id_base, b_id_base) = ai_pow_zk::composite_trace::try_noised_id_bases(
-        ai_pow_zk::canonical::covering_id_span("A", a_indices, ca0)
+        ai_pow_zk::canonical::covering_id_span("A", a_indices, ca0, kk)
             .map_err(BridgeError::ZkParamsInvalid)?
             - 1,
-        ai_pow_zk::canonical::covering_id_span("B", b_indices, cb0)
+        ai_pow_zk::canonical::covering_id_span("B", b_indices, cb0, kk)
             .map_err(BridgeError::ZkParamsInvalid)?
             - 1,
         kk,
@@ -3230,19 +3232,17 @@ fn prove_ai_pow_scheduled_full_with_context<F: FnOnce(&mut CompositeTrace)>(
         };
     let real_m = if sx_bound {
         let sweep_start = mh_end + 3;
-        // Opened row/col lanes = covering-range positions (index − chunk
-        // base), matching the strip-opening producer keys and the canonical
-        // program's sweep. Contiguous ⇒ [0,1,…]; non-contiguous carries the
-        // actual opened positions.
+        // Opened row and column lanes are relative to the matrix row at the
+        // selected chunk base. This matches the strip producer's byte origin.
         let a_lanes: Vec<usize> = strip_schedule
             .a_indices
             .iter()
-            .map(|&i| i as usize - ca0)
+            .map(|&i| i as usize - a_lane_base)
             .collect();
         let b_lanes: Vec<usize> = strip_schedule
             .b_indices
             .iter()
-            .map(|&i| i as usize - cb0)
+            .map(|&i| i as usize - b_lane_base)
             .collect();
         let (rows_used, x_steps) = trace.place_useful_work_chain_hw_indexed(
             sweep_start, &a_strips, &b_strips, h_tile, w_tile, r, num_stripes, &a_lanes, &b_lanes,
@@ -3253,25 +3253,20 @@ fn prove_ai_pow_scheduled_full_with_context<F: FnOnce(&mut CompositeTrace)>(
         let xs: Vec<i32> = x_steps[..num_stripes].iter().map(|&u| u as i32).collect();
         trace.place_fold_chain(fold_start, &xs)
     } else {
-        // R-b: stripe-major useful-work chain with the FoldChip row
-        // INTERLEAVED after each stripe's sub-block sweep (one call, no
-        // separate `place_fold_chain`). It returns the FoldChip state M
-        // directly — that IS `real_m`. Uses the EXPLICIT opened lanes
-        // (`index − c_base`, identical to the ≤64 branch), so the
-        // `noised_packed` IDs are correct for ANY opened schedule — non-origin
-        // tiles, Pearl periodic patterns, and MoE `outer_indices` gathers — not
-        // only contiguous-from-origin. Matches the canonical R-b program's
-        // `ids_for`.
+        // The R-b path interleaves one FoldChip row after each stripe's
+        // sub-block sweep. It returns the FoldChip state M directly. Its
+        // explicit lanes use the same matrix-row origins as the bounded stripe
+        // path, so both paths publish identical positioned IDs.
         let sweep_start = mh_end + 3;
         let a_lanes: Vec<usize> = strip_schedule
             .a_indices
             .iter()
-            .map(|&i| i as usize - ca0)
+            .map(|&i| i as usize - a_lane_base)
             .collect();
         let b_lanes: Vec<usize> = strip_schedule
             .b_indices
             .iter()
-            .map(|&i| i as usize - cb0)
+            .map(|&i| i as usize - b_lane_base)
             .collect();
         let (rows_used, m) = trace.place_useful_work_chain_rb_indexed(
             sweep_start, &a_strips, &b_strips, h_tile, w_tile, r, num_stripes, &a_lanes, &b_lanes,

--- a/crates/ai-pow/src/zk_bridge.rs
+++ b/crates/ai-pow/src/zk_bridge.rs
@@ -1839,6 +1839,21 @@ fn prove_pearl_moe_l0_and_ticket(
     ))
 }
 
+/// Return the Layer-0 trace height for one dense Pearl tile.
+///
+/// `tile_i` and `tile_j` are zero-based tile indices. The result is the
+/// verifier setup key used by the compact recursive certificate.
+pub fn pearl_dense_canonical_trace_height(
+    params: &MatmulParams,
+    tile_i: u32,
+    tile_j: u32,
+) -> Result<usize, BridgeError> {
+    let zk_params = zk_params_from(params);
+    let schedule = StripIndexSchedule::from_tile(&zk_params, tile_i, tile_j)
+        .map_err(BridgeError::ZkParamsInvalid)?;
+    Ok(expected_layer0_rows_for_strip_schedule(params, &schedule)?.required_trace_len())
+}
+
 /// The Layer-0 trace height a canonical MoE block at this shape WOULD have —
 /// computed WITHOUT proving AND without the (large) synthesized matrices. The
 /// opened schedule (`outer_indices` from routing + `inner_a_rows`; `b_cols_global`
@@ -8595,6 +8610,39 @@ mod tests {
             "non-contiguous: a sweep on a row-permuted committed matrix \
              MUST be rejected by the position-keyed noised_packed bus even for a \
              non-contiguous opened row set."
+        );
+    }
+
+    #[test]
+    fn peak_dense_profile_fits_production_setup_band() {
+        let params = MatmulParams {
+            m: 4096,
+            k: 8192,
+            n: 32768,
+            noise_rank: 512,
+            tile: 16,
+            spot_checks: 1,
+            difficulty_bits: 0,
+        };
+        params
+            .validate_prod_envelope()
+            .expect("peak profile must satisfy the consensus envelope");
+
+        let first = pearl_dense_canonical_trace_height(&params, 0, 0)
+            .expect("first peak tile trace height");
+        let last = pearl_dense_canonical_trace_height(
+            &params,
+            params.row_tiles() - 1,
+            params.col_tiles() - 1,
+        )
+        .expect("last peak tile trace height");
+
+        assert_eq!(first, 1 << 17, "peak profile setup bucket");
+        assert_eq!(last, first, "all peak tiles must select one setup bucket");
+        assert!(first >= ai_pow_zk::composite_layout::MIN_STARK_LEN);
+        assert!(
+            first <= crate::params::AI_POW_MAX_TRACE_HEIGHT,
+            "peak trace height {first} exceeds the production setup cap"
         );
     }
 

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -87,9 +87,7 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64
 COPY --from=builder /tmp/ai-pow-mine /usr/local/bin/ai-pow-mine
 COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 
-ENV CANONICAL=true \
-    CUDA_DEVICES=all \
-    GPU_BATCH_ATTEMPTS=32768 \
+ENV CUDA_DEVICES=all \
     MINING_PKH=2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j \
     RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info
 ENTRYPOINT ["/usr/local/bin/ai-pow-miner-entrypoint"]

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -74,6 +74,9 @@ CMD ["sleep", "infinity"]
 
 FROM ubuntu:24.04
 LABEL org.opencontainers.image.source="https://github.com/nockchain/nockchain"
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    NVIDIA_REQUIRE_CUDA="cuda>=12.8"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl3 libstdc++6 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.ai-pow-miner-gpu
+++ b/docker/Dockerfile.ai-pow-miner-gpu
@@ -73,6 +73,7 @@ ENV AI_POW_SEARCH_BENCH_CANONICAL_ATTEMPTS=8192
 CMD ["sleep", "infinity"]
 
 FROM ubuntu:24.04
+LABEL org.opencontainers.image.source="https://github.com/nockchain/nockchain"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl3 libstdc++6 \
     && rm -rf /var/lib/apt/lists/*
@@ -84,7 +85,7 @@ COPY --from=builder /tmp/ai-pow-mine /usr/local/bin/ai-pow-mine
 COPY docker/ai-pow-miner-entrypoint.sh /usr/local/bin/ai-pow-miner-entrypoint
 
 ENV CANONICAL=true \
-    CUDA_DEVICE=0 \
+    CUDA_DEVICES=all \
     GPU_BATCH_ATTEMPTS=32768 \
     MINING_PKH=2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j \
     RUST_LOG=info,ai_pow_miner=info,nockchain_mining_common=info

--- a/docker/ai-pow-miner-entrypoint.sh
+++ b/docker/ai-pow-miner-entrypoint.sh
@@ -8,7 +8,7 @@ args=(
   --gpu
   --node-addr "$NODE_ADDR"
   --mining-pkh "$MINING_PKH"
-  --cuda-device "${CUDA_DEVICE:-0}"
+  --cuda-devices "${CUDA_DEVICES:-all}"
   --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-32768}"
 )
 

--- a/docker/ai-pow-miner-entrypoint.sh
+++ b/docker/ai-pow-miner-entrypoint.sh
@@ -6,17 +6,10 @@ set -euo pipefail
 
 args=(
   --gpu
+  --canonical
   --node-addr "$NODE_ADDR"
   --mining-pkh "$MINING_PKH"
   --cuda-devices "${CUDA_DEVICES:-all}"
-  --gpu-batch-attempts "${GPU_BATCH_ATTEMPTS:-32768}"
 )
-
-if [[ "${CANONICAL:-true}" == "true" ]]; then
-  args+=(--canonical)
-else
-  : "${PEARL_GATEWAY:?PEARL_GATEWAY is required when CANONICAL is not true}"
-  args+=(--pearl-gateway "$PEARL_GATEWAY")
-fi
 
 exec /usr/local/bin/ai-pow-mine "${args[@]}" "$@"

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -138,10 +138,15 @@ All four checks must pass without suppressed errors. Confirm that the steady-sta
 1. Build the GPU image for Linux/amd64 with CUDA 12.8 and `sm_120` support.
 2. Start an RTX 5090 Runpod instance with a persistent container command.
 3. Confirm the allocated device with `nvidia-smi`.
-4. Run the miner with the mining public key, node address, CUDA device ordinal, and batch size.
-5. Connect it to a fakenet Nockchain node.
-6. Observe a GPU-found ticket, recursive proof construction, `%ai-pow` submission, and node acceptance.
-7. Restart the container with only its production environment configuration and repeat the connection path.
+4. Run the image with `NODE_ADDR=http://23.252.122.18:5556`. Do not override
+   the image's default `MINING_PKH`,
+   `2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j`.
+5. Submit proofs to the mainnet API node maintained by the sibling `solo/`
+   Ansible directory. Do not start or connect to a fakenet for a Runpod test.
+6. Observe a GPU-found ticket, recursive proof construction, `%ai-pow`
+   submission, and acceptance in the solo node logs.
+7. Restart the container with the same production environment and observe
+   another accepted block through the solo node.
 
 ### Stage 7: Measure performance
 
@@ -174,10 +179,11 @@ state, jackpot hashes, and extranonces at `0`, `1`, `7`, `UINT32_MAX - 1`, and
 pass. Maximum-target, zero-target, adjacent-batch, template-replacement, scalar
 winner, recursive proof, production verifier, and proof-wire checks pass.
 
-A Runpod RTX 5090 completed the production CLI flow through a fakenet Nockchain
-node. The node accepted the submitted `%ai-pow` blocks. A four-RTX-5090 pod also
-completed the same flow with devices `[0, 1, 2, 3]`. An eight-GPU run is not
-validated because an eight-RTX-5090 allocation was not available.
+Runpod proof-submission validation uses the public mainnet API node maintained
+by the sibling `solo/` Ansible directory at `http://23.252.122.18:5556`. The
+container uses its default Docker mining key. A Runpod validation must not
+start or connect to a fakenet. The eight-GPU gate remains open because an
+eight-RTX-5090 allocation was not available.
 
 The throughput metric is
 `attempts_per_second * M * N * K / 10^12`, which is the same raw MAC-rate formula
@@ -203,3 +209,31 @@ The Linux/amd64 production image is available as
 A one-RTX-5090 Runpod started the image with only `NODE_ADDR` set, submitted
 accepted `%ai-pow` blocks, restarted from the same environment, and submitted
 accepted blocks again.
+
+## RTX 5090 peak-path evidence
+
+The isolated dense peak path uses:
+
+- $m=4096$, $n=32768$, $k=8192$, and rank 512;
+- $16 \times 16$ tickets;
+- a $256 \times 128 \times 64$ CTA;
+- two `cp.async` pipeline stages;
+- one persistent device session for each prepared dense template.
+
+On one Runpod RTX 5090, the five-second median is 348.179 TMAC/s and
+166.025 million complete tickets/s. A 60-second run is 334.740 TMAC/s and
+159.617 million tickets/s at 575 W. The matching raw GEMM is 368.1 TMAC/s.
+
+The hot kernel uses 248 registers per thread, 8,192 bytes of static shared
+memory, 49,152 bytes of dynamic shared memory, and one active CTA per SM. It
+has no stack frame and no spills.
+
+The scalar/device differential covers 1,000 deterministic tickets with three
+fused device repetitions for each ticket. It compares all debug transcript
+words and brackets every fused search hash with its exact target and unsigned
+predecessor. Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, and
+`synccheck` report no errors on persistent, adjacent range searches.
+
+The peak library backend is not a production miner mode. Its CLI selector,
+recursive proof gate, Docker entrypoint, accepted-block validation, restart
+validation, and multi-GPU extension remain open.

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -1,0 +1,182 @@
+# Pearl V3 GPU Miner Goal and Plan
+
+## Goal
+
+Deliver a production GPU mode for `ai-pow-miner` that reproduces the active Pearl V3 puzzle exactly, searches tickets on NVIDIA GPUs, builds the existing recursive proof on the host after a GPU hit, and submits an accepted `%ai-pow` block to a Nockchain node.
+
+The production interface must require only the mining public key, the Nockchain node address, and optional GPU tuning values. The container must run on Runpod and similar NVIDIA container hosts.
+
+## Required invariants
+
+1. The GPU derives the complete Pearl V3 attempt transcript for every extranonce.
+2. The GPU result matches the scalar Rust implementation byte for byte.
+3. The GPU returns the lowest successful ordinal in each batch.
+4. Rust recomputes and validates every GPU winner before proof construction.
+5. A requested GPU backend fails closed. It does not fall back to CPU search.
+6. The recursive proof format and consensus verifier remain unchanged.
+7. Persistent device allocations do not cross a prepared-template boundary.
+8. The steady-state no-hit path does not allocate device or host buffers per attempt.
+
+## Active production shape
+
+| Property | Value |
+|---|---:|
+| Matrix rows (`m`) | 64 |
+| Matrix columns (`n`) | 64 |
+| Inner dimension (`k`) | 1,024 |
+| Noise rank | 64 |
+| Opened rows | 8 |
+| Opened columns | 8 |
+| Routing experts | 2 |
+| Top-k | 1 |
+| Rolling stripes | 16 |
+| Tile-state words | 16 × `i32` |
+
+Pearl's large consumer-GPU geometry does not apply to this canonical job. Reuse its persistent-session, signed INT8 MMA, fused fold/hash/target, and scalar winner-check design rather than its dimensions.
+
+## Compatibility boundary
+
+Rust remains authoritative for job construction, ticket validation, and proof construction. CUDA must reproduce these operations:
+
+- `PearlIncompleteBlockHeader::to_bytes`;
+- `PearlMiningConfig::to_bytes`;
+- `pearl_kappa`;
+- `pearl_matrix_commitments`;
+- `canonical_noise_seeds_moe`;
+- Pearl `E_L`, `E_R`, `F_L`, and `F_R` expansion;
+- `compute_pattern_tile_state_from_slices`;
+- `pearl_jackpot_hash`;
+- `hash_le_target`.
+
+The transcript is:
+
+```text
+kappa  = BLAKE3(sigma || mu)
+H_A    = BLAKE3(pad_1024(A), key=kappa)
+H_B    = BLAKE3(pad_1024(B), key=kappa)
+A'     = BLAKE3(H_A || LE32(m)   || zeroes, key=SEED_SALT_A)
+B'     = BLAKE3(H_B || LE32(n/e) || zeroes, key=SEED_SALT_B)
+rroot  = BLAKE3(pad_1024(routing_data),    key=kappa)
+hoff   = BLAKE3(pad_1024(routing_offsets), key=kappa)
+hrout  = BLAKE3(rroot || hoff)
+hact   = BLAKE3(A' || hrout)
+s_B    = BLAKE3(kappa || B')
+s_A    = BLAKE3(s_B || hact)
+jackpot = BLAKE3(tile_state_le, key=s_A)
+```
+
+Each extranonce changes `sigma.timestamp`. No commitment, seed, noised strip, tile state, or jackpot can be reused across extranonces.
+
+## Implementation plan
+
+### Stage 1: Make the device transcript exact
+
+1. Compare CUDA BLAKE3 against Rust for 64-byte, 128-byte, and 1,024-byte inputs.
+2. Compare keyed and unkeyed modes, parent compression, tree-root finalization, and padding.
+3. Export focused debug output for `kappa`, `H_A`, `H_B`, routing roots, `s_A`, and `s_B`.
+4. Correct the first differing primitive before testing downstream values.
+5. Remove diagnostic-only global buffers after the differential tests pass.
+
+### Stage 2: Validate noising and matrix state
+
+1. Compare every opened A and B byte for several deterministic extranonces.
+2. Include extranonces `0`, `1`, `u32::MAX - 1`, and `u32::MAX` where a batch can represent them.
+3. Validate signed INT8 multiplication and saturating `i32` accumulation with non-uniform inputs.
+4. Compare all 16 rolling state words with the scalar Rust evaluator.
+5. Test the exact row and expert-column routing order used by the canonical job.
+
+### Stage 3: Validate search semantics and session lifetime
+
+1. Use a maximum target and confirm that a multi-attempt batch returns ordinal zero.
+2. Use a zero target and confirm that the batch reports no winner.
+3. Exercise adjacent batches on one prepared template.
+4. Replace the template and confirm that device state is recreated.
+5. Confirm cancellation, attempt accounting, deadline handling, and lowest-winner ordering.
+6. Confirm that a device false positive is a fatal backend error after scalar revalidation.
+
+### Stage 4: Validate memory and synchronization
+
+Run CUDA Compute Sanitizer against the focused differential binary:
+
+```text
+compute-sanitizer --tool memcheck
+compute-sanitizer --tool racecheck
+compute-sanitizer --tool initcheck
+compute-sanitizer --tool synccheck
+```
+
+All four checks must pass without suppressed errors. Confirm that the steady-state no-hit batch path has no `cudaMalloc`, `cudaFree`, stream creation, or variable-size host allocation.
+
+### Stage 5: Validate proof construction
+
+1. Find a ticket with the GPU backend.
+2. Recompute it with `PreparedCanonicalMoeTemplate::evaluate`.
+3. Build the normal compact recursive certificate.
+4. Verify it with the production V3 verifier context.
+5. Confirm that no CUDA-specific value enters the proof or noun wire format.
+
+### Stage 6: Validate the Runpod production flow
+
+1. Build the GPU image for Linux/amd64 with CUDA 12.8 and `sm_120` support.
+2. Start an RTX 5090 Runpod instance with a persistent container command.
+3. Confirm the allocated device with `nvidia-smi`.
+4. Run the miner with the mining public key, node address, CUDA device ordinal, and batch size.
+5. Connect it to a fakenet Nockchain node.
+6. Observe a GPU-found ticket, recursive proof construction, `%ai-pow` submission, and node acceptance.
+7. Restart the container with only its production environment configuration and repeat the connection path.
+
+### Stage 7: Measure performance
+
+On the same RTX 5090 host:
+
+1. measure attempts per second and TMAC per second;
+2. measure commitment, noising, and MMA/jackpot kernel time separately;
+3. measure full-batch GPU and wall time;
+4. compare with the dedicated CPU backend;
+5. tune batch size only after all correctness gates pass.
+
+GPU throughput must exceed the pod CPU backend before the image is presented as a production accelerator.
+
+## Current implementation state
+
+The production path has:
+
+- persistent, template-scoped CUDA sessions;
+- byte-identical Pearl V3 transcript and jackpot evaluation;
+- scalar winner revalidation before proof construction;
+- fatal handling for CUDA startup, execution, and winner-validation errors;
+- explicit CUDA device selection for one to eight visible devices;
+- deterministic contiguous batch partitioning and global lowest-winner reduction;
+- allocation-free steady-state CUDA search buffers;
+- a CUDA 12.8 `sm_120` production image and Runpod entrypoint.
+
+The CUDA differential test covers transcript commitments, noised strips, rolling tile
+state, jackpot hashes, and extranonces at `0`, `1`, `7`, `UINT32_MAX - 1`, and
+`UINT32_MAX`. Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, and `synccheck`
+pass. Maximum-target, zero-target, adjacent-batch, template-replacement, scalar
+winner, recursive proof, production verifier, and proof-wire checks pass.
+
+A Runpod RTX 5090 completed the production CLI flow through a fakenet Nockchain
+node. The node accepted the submitted `%ai-pow` blocks. A four-RTX-5090 pod also
+completed the same flow with devices `[0, 1, 2, 3]`. An eight-GPU run is not
+validated because an eight-RTX-5090 allocation was not available.
+
+The throughput metric is
+`attempts_per_second * M * N * K / 10^12`, which is the same raw MAC-rate formula
+used by the Pearl wheel benchmark. For 65,536 canonical attempts on RTX 5090:
+
+- one GPU: 2.92 million attempts/s and 0.1915 TMAC/s;
+- two GPUs: 5.68 million attempts/s and 0.3723 TMAC/s;
+- four GPUs: 10.73 million attempts/s and 0.7034 TMAC/s;
+- the 120-worker pod CPU backend: 147 thousand attempts/s and 0.00965 TMAC/s.
+
+The commitment kernel takes about 90% of CUDA batch time. The production kernel
+keeps rolling tile state in shared memory and writes transcript diagnostics only
+for differential tests. The `sm_120` build has no local-memory spills in the
+commitment, noising, tile, or winner kernels.
+
+The host library compiles with
+`cargo check --locked -p ai-pow-miner --features node,gpu --lib`.
+
+The final image publication and restart check remain blocked until the
+consensus-target proof gate is present on the image base branch.

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -169,21 +169,24 @@ The production path has:
 - allocation-free steady-state CUDA search buffers;
 - a CUDA 12.8 `sm_120` production image and Runpod entrypoint.
 
-The CUDA differential test covers transcript commitments, noised strips, rolling tile
-state, jackpot hashes, and extranonces at `0`, `1`, `7`, `UINT32_MAX - 1`, and
-`UINT32_MAX`. Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, and `synccheck`
-pass. Maximum-target, zero-target, adjacent-batch, template-replacement, scalar
-winner, recursive proof, production verifier, and proof-wire checks pass.
+The CUDA differential test covers transcript commitments, noised strips, rolling
+tile state, jackpot hashes, and extranonces at `0`, `1`, `7`,
+`UINT32_MAX - 1`, and `UINT32_MAX`. Compute Sanitizer `memcheck`, `racecheck`,
+`initcheck`, and `synccheck` pass for single-device persistent and adjacent
+searches and for the two-device winner-reduction path. Maximum-target,
+zero-target, adjacent-batch, template-replacement, scalar-winner, recursive
+proof, production-verifier, and proof-wire checks pass.
 
 Runpod proof-submission validation uses the public mainnet API node maintained
 by the sibling `solo/` Ansible directory at `http://23.252.122.18:5556`. The
 container uses its default Docker mining key. A Runpod validation must not
-start or connect to a fakenet. The eight-GPU gate remains open because an
-eight-RTX-5090 allocation was not available.
+start or connect to a fakenet. One-device and two-device RTX 5090 sessions have
+completed the production startup and search gates.
 
-The throughput metric is
-`attempts_per_second * M * N * K / 10^12`, which is the same raw MAC-rate formula
-used by the Pearl wheel benchmark. For 65,536 canonical attempts on RTX 5090:
+The small MoE regression-kernel throughput metric is
+`attempts_per_second * M * N * K / 10^12`, which is the same raw MAC-rate
+formula used by the Pearl wheel benchmark. For 65,536 canonical attempts on
+RTX 5090:
 
 - one GPU: 2.92 million attempts/s and 0.1915 TMAC/s;
 - two GPUs: 5.68 million attempts/s and 0.3723 TMAC/s;
@@ -228,8 +231,11 @@ The scalar/device differential covers 1,000 deterministic tickets with three
 fused device repetitions for each ticket. It compares all debug transcript
 words and brackets every fused search hash with its exact target and unsigned
 predecessor. Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, and
-`synccheck` report no errors on persistent, adjacent range searches.
+`synccheck` report no errors.
 
-The peak library backend is not a production miner mode. Its CLI selector,
-recursive proof gate, Docker entrypoint, accepted-block validation, restart
-validation, and multi-GPU extension remain open.
+The production selector is `--gpu --canonical`. It runs the peak backend on
+every visible device unless `--cuda-devices` selects a subset. A two-RTX-5090
+production run sustained 576,716 to 594,191 complete tickets/s and 1.209 to
+1.246 TMAC/s across consecutive 60-second windows. Both devices stayed fully
+utilized. The multi-device reducer returned the global lowest winner, and all
+four Compute Sanitizer tools passed on the two-device search.

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -34,6 +34,24 @@ The production interface must require only the mining public key, the Nockchain 
 
 Pearl's large consumer-GPU geometry does not apply to this canonical job. Reuse its persistent-session, signed INT8 MMA, fused fold/hash/target, and scalar winner-check design rather than its dimensions.
 
+## RTX 5090 peak dense path
+
+The canonical MoE path remains the stable production path. Its small geometry is
+commitment-bound and cannot approach the RTX 5090 Tensor Core limit.
+
+The opt-in `peak` path evaluates the existing dense Pearl tile space as one full
+GEMM. One prepared transcript supplies millions of ordered tile tickets, so
+operand reuse and transcript work remain on the GPU. These documents define the
+independent path:
+
+- `pearl-v3-rtx5090-roofline.md`
+- `pearl-v3-rtx5090-architecture.md`
+- `pearl-v3-rtx5090-implementation-plan.md`
+
+The peak path must preserve the same scalar winner check, recursive proof, and
+consensus wire format. It cannot replace the canonical path until all correctness,
+sanitizer, performance, proof, and accepted-block gates pass.
+
 ## Compatibility boundary
 
 Rust remains authoritative for job construction, ticket validation, and proof construction. CUDA must reproduce these operations:

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -178,5 +178,10 @@ commitment, noising, tile, or winner kernels.
 The host library compiles with
 `cargo check --locked -p ai-pow-miner --features node,gpu --lib`.
 
-The final image publication and restart check remain blocked until the
-consensus-target proof gate is present on the image base branch.
+The Linux/amd64 production image is available as
+`docker.io/loganallc/nockchain-ai-pow-miner:gpu` and as the immutable
+`gpu-c142d390` tag. Both tags resolve to manifest
+`sha256:61022736c85e895925f3ac74080c83c9186054e67de86832eb5df7eb17c5f401`.
+A one-RTX-5090 Runpod started the image with only `NODE_ADDR` set, submitted
+accepted `%ai-pow` blocks, restarted from the same environment, and submitted
+accepted blocks again.

--- a/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-gpu-miner-plan.md
@@ -14,72 +14,68 @@ The production interface must require only the mining public key, the Nockchain 
 4. Rust recomputes and validates every GPU winner before proof construction.
 5. A requested GPU backend fails closed. It does not fall back to CPU search.
 6. The recursive proof format and consensus verifier remain unchanged.
-7. Persistent device allocations do not cross a prepared-template boundary.
+7. Attempt-dependent device state does not cross a prepared-template boundary. Immutable source matrices may remain resident across templates.
 8. The steady-state no-hit path does not allocate device or host buffers per attempt.
 
 ## Active production shape
 
 | Property | Value |
 |---|---:|
-| Matrix rows (`m`) | 64 |
-| Matrix columns (`n`) | 64 |
-| Inner dimension (`k`) | 1,024 |
-| Noise rank | 64 |
-| Opened rows | 8 |
-| Opened columns | 8 |
-| Routing experts | 2 |
-| Top-k | 1 |
+| Matrix rows (`m`) | 4,096 |
+| Matrix columns (`n`) | 32,768 |
+| Inner dimension (`k`) | 8,192 |
+| Noise rank | 512 |
+| Opened rows | 16 |
+| Opened columns | 16 |
+| Dense tile tickets | 524,288 |
 | Rolling stripes | 16 |
 | Tile-state words | 16 × `i32` |
+| Layer-0 trace height | $2^{17}$ |
 
-Pearl's large consumer-GPU geometry does not apply to this canonical job. Reuse its persistent-session, signed INT8 MMA, fused fold/hash/target, and scalar winner-check design rather than its dimensions.
+The dense peak kernel is the primary production kernel for
+`--gpu --canonical`. The small MoE kernel remains available for CPU diagnosis
+and regression tests. Pearl Gateway work continues to use the backend that
+matches the Gateway-supplied shape.
 
-## RTX 5090 peak dense path
+The peak path evaluates one complete dense Pearl tile space as one GEMM. One
+prepared transcript supplies 524,288 ordered tile tickets. Operand reuse,
+rolling transcript updates, jackpot hashing, and target comparison stay on the
+GPU.
 
-The canonical MoE path remains the stable production path. Its small geometry is
-commitment-bound and cannot approach the RTX 5090 Tensor Core limit.
-
-The opt-in `peak` path evaluates the existing dense Pearl tile space as one full
-GEMM. One prepared transcript supplies millions of ordered tile tickets, so
-operand reuse and transcript work remain on the GPU. These documents define the
-independent path:
+These documents define the path:
 
 - `pearl-v3-rtx5090-roofline.md`
 - `pearl-v3-rtx5090-architecture.md`
 - `pearl-v3-rtx5090-implementation-plan.md`
 
-The peak path must preserve the same scalar winner check, recursive proof, and
-consensus wire format. It cannot replace the canonical path until all correctness,
-sanitizer, performance, proof, and accepted-block gates pass.
+The production cutover requires every correctness, sanitizer, complete-template
+performance, proof, multi-GPU, restart, failure, and accepted-block gate.
 
 ## Compatibility boundary
 
-Rust remains authoritative for job construction, ticket validation, and proof construction. CUDA must reproduce these operations:
+Rust remains authoritative for job construction, winner validation, and proof
+construction. CUDA must reproduce these dense operations:
 
 - `PearlIncompleteBlockHeader::to_bytes`;
 - `PearlMiningConfig::to_bytes`;
 - `pearl_kappa`;
 - `pearl_matrix_commitments`;
-- `canonical_noise_seeds_moe`;
+- `canonical_noise_seeds_from_matrix_commitments`;
 - Pearl `E_L`, `E_R`, `F_L`, and `F_R` expansion;
 - `compute_pattern_tile_state_from_slices`;
 - `pearl_jackpot_hash`;
 - `hash_le_target`.
 
-The transcript is:
+The dense transcript is:
 
 ```text
 kappa  = BLAKE3(sigma || mu)
-H_A    = BLAKE3(pad_1024(A), key=kappa)
-H_B    = BLAKE3(pad_1024(B), key=kappa)
-A'     = BLAKE3(H_A || LE32(m)   || zeroes, key=SEED_SALT_A)
-B'     = BLAKE3(H_B || LE32(n/e) || zeroes, key=SEED_SALT_B)
-rroot  = BLAKE3(pad_1024(routing_data),    key=kappa)
-hoff   = BLAKE3(pad_1024(routing_offsets), key=kappa)
-hrout  = BLAKE3(rroot || hoff)
-hact   = BLAKE3(A' || hrout)
+H_A    = MerkleTree(pad_1024(A), key=kappa).root
+H_B    = MerkleTree(pad_1024(B), key=kappa).root
+A'     = BLAKE3(H_A || LE32(m) || zeroes, key=SEED_SALT_A)
+B'     = BLAKE3(H_B || LE32(n) || zeroes, key=SEED_SALT_B)
 s_B    = BLAKE3(kappa || B')
-s_A    = BLAKE3(s_B || hact)
+s_A    = BLAKE3(s_B || A')
 jackpot = BLAKE3(tile_state_le, key=s_A)
 ```
 

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-architecture.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-architecture.md
@@ -1,0 +1,131 @@
+# Pearl V3 RTX 5090 Search Architecture
+
+## Decision
+
+Use the existing dense Pearl ticket semantics and evaluate the complete tile grid in one CUDA launch. Do not use one extranonce per small opened tile.
+
+The dense route is the correct throughput shape for this kernel:
+
+- one prepared header binds `A'`, `B'`, `s_A`, and `s_B`;
+- each valid `(t_rows, t_cols)` pair is one ticket ordinal;
+- all tickets share the same noised matrices and commitment roots;
+- the GPU reuses each operand tile across many output tiles;
+- the recursive proof opens only the winning row and column strips.
+
+MoE remains useful for model routing, but it adds routing preparation and reduces the regular output grid. It does not improve the dense Tensor Core roofline. The first peak kernel therefore supports dense, contiguous $16 \times 16$ patterns only.
+
+## Search identity
+
+For `row_tiles = m/16` and `col_tiles = n/16`, define:
+
+$$ordinal = row\_tile \times col\_tiles + col\_tile.$$
+
+This is the current `PreparedPearlPatternJob::offsets_at_ordinal` order. The device uses `atomicMin` on this ordinal. Grid scheduling cannot change winner order.
+
+The kernel accepts a half-open ordinal range. A tile outside the range still follows the same regular main loop when a rectangular launch cannot exclude it, but it cannot update the winner. The production scheduler aligns batches to complete tile grids.
+
+## Prepared-template boundary
+
+The host does these steps once for each Pearl work header:
+
+1. Validate the Pearl configuration and proof envelope.
+2. Derive the matrix commitments and noise seeds.
+3. Build `A'` in row-major order and `B'` in column-major order.
+4. Build the Merkle state needed for a later winning strip opening.
+5. Create a device session.
+6. Copy `A'`, `B'`, `s_A`, and fixed geometry to that session.
+
+A session cannot cross a header or mining-configuration boundary. Template replacement destroys the old session after its stream stops.
+
+## Device pipeline
+
+### Persistent state
+
+Each device owns:
+
+- one non-blocking CUDA stream;
+- immutable `A'` and `B'` buffers;
+- one 256-bit target buffer;
+- one 64-bit lowest-winner slot;
+- one 256-bit winning jackpot slot;
+- timing events used only by the benchmark API.
+
+The steady-state search call copies only the target and resets the winner. It does not allocate.
+
+### CTA schedule
+
+Use a fixed grid of two CTAs per SM. Each CTA walks the logical $256 \times 128$ output tiles with a grid-stride loop. The logical mapping is deterministic and covers every output tile exactly once.
+
+The K loop uses:
+
+- 16-byte `cp.async.cg.shared.global.L2::128B` copies;
+- the CUTLASS crosswise shared-memory swizzle;
+- `ldmatrix.x4` fragment loads;
+- `mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite`;
+- compile-time K-stage and transcript-cadence indices.
+
+The hot loop has no data-dependent branch. Geometry branches are CTA-uniform. Lane ownership uses predicated instructions and fixed masks; no warp takes different K-loop control flow.
+
+### Transcript
+
+Each warp owns sixteen $16 \times 16$ hash tiles. At each 512-element cadence boundary, it XOR-reduces the cumulative INT32 accumulator for each owned tile.
+
+`k/r = 16`. Each cadence writes a different one of the 16 transcript slots. The usual `rotl13(previous) XOR value` recurrence reduces to a direct write because `previous` is zero for every slot. This removes the shared-memory read-modify-write dependency without changing bytes.
+
+After the main loop, whole warps finalize independent hash tiles with keyed BLAKE3. Finalizer warps do not execute Tensor Core work for another tile until the CTA barrier completes. A target hit computes the canonical ticket ordinal and updates the global winner with `atomicMin`.
+
+No full C matrix is written to global memory.
+
+## CPU and GPU boundary
+
+The GPU returns:
+
+- `UINT64_MAX` for no winner; or
+- the lowest ticket ordinal and its 32-byte jackpot hash.
+
+Rust then:
+
+1. checks that the ordinal is inside the dispatched range;
+2. maps it to `(t_rows, t_cols)` with the prepared job;
+3. recomputes the complete ticket with the scalar evaluator;
+4. compares the scalar jackpot with the device jackpot;
+5. checks the target again;
+6. constructs the existing compact recursive certificate;
+7. submits the existing noun wire format.
+
+Any mismatch is fatal for that requested backend. There is no CPU search fallback.
+
+## Cancellation and template replacement
+
+CUDA kernels are not preempted by the miner. Cancellation is observed after the current launch. The selected shape must keep one launch below 100 ms.
+
+A template replacement follows this order:
+
+1. stop dispatch of new launches;
+2. synchronize the owned stream;
+3. discard the prior winner header;
+4. free the old session;
+5. create and populate the new session;
+6. resume at the new template's first ordinal.
+
+A stale device result cannot enter proof construction because the Rust backend also checks template identity under its dispatch lock.
+
+## Multi-GPU mapping
+
+Each device receives one contiguous ordinal interval. The intervals are adjacent, disjoint, and cover the requested batch. Every device returns its local minimum. The host returns the global minimum after all active devices complete.
+
+Do not interleave ordinals by device. Contiguous intervals preserve the scalar lexicographic order and make cancellation accounting exact.
+
+## Supported first release
+
+The peak path supports only:
+
+- compute capability 12.0;
+- dense Pearl jobs;
+- contiguous $16 \times 16$ row and column patterns;
+- `k=8192`, `r=512`, and full-dot tickets;
+- dimensions divisible by 256 rows and 128 columns;
+- at most 32 GiB of device memory;
+- one prepared template per device session.
+
+Any unsupported shape fails closed. The existing generic CUDA and canonical V3 paths remain available under their existing selectors and are not modified by this path.

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-architecture.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-architecture.md
@@ -54,7 +54,7 @@ The steady-state search call copies only the target and resets the winner. It do
 
 ### CTA schedule
 
-Use a fixed grid of two CTAs per SM. Each CTA walks the logical $256 \times 128$ output tiles with a grid-stride loop. The logical mapping is deterministic and covers every output tile exactly once.
+Use a fixed launch grid of two CTAs per SM. The selected kernel permits one active CTA per SM because each thread uses 248 registers. Each CTA walks the logical $256 \times 128$ output tiles with a grid-stride loop. The logical mapping is deterministic and covers every output tile exactly once.
 
 The K loop uses:
 

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
@@ -127,59 +127,96 @@ and little-endian predecessor. Each vector runs three fused device repetitions.
 First, last, CTA-boundary, maximum-target, zero-target, and adjacent range cases
 pass.
 
-## Stage 6: Opt-in miner integration
+## Stage 6: Production pipeline integration
 
-Add `peak` as a separate backend selector in the CUDA miner CLI and Docker entrypoint. It must require the peak dense profile and must conflict with the existing canonical V3 selector.
+The production GPU path uses the dense `AIP1` artifact. One synthetic Pearl
+header binds the Nockchain block commitment and one extranonce. Its complete
+tile grid is one prepared template. A miss advances the extranonce and creates
+a new template. The host keeps the winning template until proof construction
+finishes.
 
-The worker keeps the current order:
+The worker uses this order:
 
-1. search;
-2. scalar recheck;
-3. target recheck;
-4. recursive proof;
-5. artifact encoding;
-6. node submission.
+1. derive the header, commitments, noise seeds, and noised matrices;
+2. search every valid dense tile on the selected GPUs;
+3. select the lowest global tile ordinal;
+4. recompute the winner with the scalar evaluator;
+5. check the Nockchain target again;
+6. build and verify the compact recursive certificate;
+7. encode the existing dense `AIP1` artifact;
+8. submit the `%ai-pow` block.
 
-Gate: one GPU winner builds and verifies the existing compact recursive certificate. The certificate and noun wire contain no CUDA-specific field.
+The certificate binds the header, configuration, matrix commitments, winning
+row and column strips, jackpot, and Nockchain auxiliary commitment. CUDA state
+does not enter the certificate or noun wire.
 
-Status: the opt-in library backend is available. The production CLI selector,
-recursive-proof gate, and Docker entrypoint remain Stage 6 work.
+The production `--gpu --canonical` mode selects the peak backend. The Pearl
+Gateway mode keeps its existing generic backend because Gateway work controls
+the puzzle shape. CPU canonical mode remains available for diagnosis.
 
-## Stage 7: Runpod production flow
+Gate: one peak GPU winner builds a compact recursive certificate that the
+production verifier accepts.
 
-Build a CUDA 12.8 or newer Linux/amd64 image for `sm_120`. Start one RTX 5090
-pod with only `NODE_ADDR=http://23.252.122.18:5556` plus optional GPU tuning.
-Keep the image's default Docker `MINING_PKH`,
-`2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j`.
+The profile satisfies the consensus parameter envelope. Its first and last
+dense tiles both require a $2^{17}$ Layer-0 trace. The production verifier table
+contains the matching `sx_bound=true` setup key.
+
+## Stage 7: Prepared-template throughput
+
+Measure the complete template cycle. Include header derivation, keyed matrix
+commitments, noise expansion, noised matrix construction, device transfer, and
+the search kernel. Repeated searches of one prepared template are not a valid
+production throughput measurement.
+
+Move transcript preparation to the GPU when host preparation or PCIe transfer
+keeps the complete cycle below 80% of the measured search-kernel rate. Keep the
+original matrices resident on each device. Derive the keyed commitments, noise
+factors, and noised matrices for each new header on the device. Return the
+commitments and noise seeds that the host needs for scalar validation and proof
+construction.
+
+Gate: the production miner reports complete-template ticket and TMAC rates for
+at least 60 seconds.
+
+## Stage 8: Multi-GPU production backend
+
+Each device owns one session and stream. All devices prepare the same template.
+For each ordered batch, partition the tile ordinals into adjacent, disjoint
+ranges. Each device returns its local minimum. The host waits for every active
+device and returns the lowest global ordinal.
+
+A device initialization, preparation, launch, synchronization, or result error
+is fatal. The backend does not retry the range on the CPU or on another GPU.
+Candidate replacement stops new launches, waits for the current launches, and
+destroys every stale session before it prepares the next template.
+
+Gate on every available device count:
+
+- exact range coverage with no gaps or overlaps;
+- global lowest winner with the maximum target;
+- no winner with the zero target;
+- scalar recheck of the selected global winner;
+- cancellation after candidate replacement;
+- throughput scaling against one device.
+
+## Stage 9: Runpod production flow
+
+Build a CUDA 12.8 or newer Linux/amd64 image for `sm_120`. Start RTX 5090 pods
+with only `NODE_ADDR=http://23.252.122.18:5556` and the production mining key.
+Do not start or connect to a fakenet.
 
 Verify:
 
 1. GPU enumeration and peak-backend startup;
-2. persistent template allocation;
-3. steady no-hit mining and progress accounting;
-4. connection to the mainnet API node maintained by the sibling `solo/`
-   Ansible directory;
-5. accepted `%ai-pow` block in the solo node logs;
+2. one persistent session per selected device;
+3. complete-template progress accounting;
+4. connection to the mainnet API node;
+5. an accepted `%ai-pow` block in the node logs;
 6. candidate replacement during a launch;
-7. full pod stop and restart with the same configuration;
-8. no CPU-search fallback after an injected CUDA failure.
+7. a full container stop and restart with the same configuration;
+8. no CPU fallback after an injected CUDA failure.
 
-Do not start or connect to a fakenet for a Runpod test.
-
-Gate: the solo node logs an accepted block before and after the restart.
-
-## Stage 8: Multi-GPU extension
-
-Partition each ordered batch into contiguous device ranges. Preserve one session and stream per device. Reduce device results by global ordinal.
-
-Gate on two, four, and eight devices:
-
-- exact range coverage with no gaps or overlaps;
-- global lowest winner under maximum target;
-- zero-target miss;
-- cancellation after a candidate replacement;
-- scalar recheck of the selected global winner;
-- throughput scaling recorded against one device.
+Gate: the node accepts a block before and after the restart.
 
 ## Stop rules
 

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
@@ -1,0 +1,165 @@
+# Pearl V3 RTX 5090 Kernel Implementation Plan
+
+## Scope
+
+Add an opt-in dense search path named `peak`. Keep the existing generic and canonical V3 CUDA paths byte-for-byte unchanged until the peak path passes every gate.
+
+The implementation uses the architecture in `pearl-v3-rtx5090-architecture.md` and the limits in `pearl-v3-rtx5090-roofline.md`.
+
+## Stage 1: Independent kernel and harness
+
+Add new files only:
+
+- `crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.cu`
+- `crates/ai-pow-miner-cuda/csrc/ai_pow_v3_peak.h`
+- `crates/ai-pow-miner-cuda/csrc/test_ai_pow_v3_peak.cu`
+
+The kernel starts from the measured Pearl $256 \times 128 \times 64$ Tensor Core main loop. Remove Pearl process state, Gateway state, and nonce-generation code. Retain only full-grid GEMM, transcript construction, keyed BLAKE3, target comparison, and lowest-ordinal selection.
+
+The harness must:
+
+1. generate deterministic patterned `A'` and `B'`;
+2. run a small shape that covers more than one CTA tile;
+3. compute every ticket with an independent scalar oracle;
+4. compare all 16 transcript words and jackpot bytes for selected tiles;
+5. check maximum and zero targets;
+6. repeat each vector three times.
+
+Gate: the standalone CUDA executable prints exact equality for every vector. No Rust integration starts before this gate passes.
+
+## Stage 2: Stable C ABI and persistent session
+
+Add an opaque `AiPowCudaPeakSession` API:
+
+- create from device ordinal, geometry, matrices, and `s_A`;
+- search an ordinal range and target;
+- capture one ticket transcript for tests;
+- return timing counters for benchmarks;
+- destroy all owned resources.
+
+Validate all lengths and supported geometry before allocation. Use checked `size_t` products. Return CUDA status codes without process exit.
+
+Gate: adjacent searches on one session, template replacement, maximum target, zero target, and boundary ordinals all match the standalone oracle. The no-hit path performs no allocation.
+
+## Stage 3: Rust differential oracle
+
+Expose immutable noised matrix slices from `PreparedPearlPatternJob`. This is an additive read-only API.
+
+Add `PeakGpuSearchBackend` beside `GpuSearchBackend`. It accepts only the supported dense geometry. It never handles the canonical MoE path and never falls back to CPU search.
+
+Add focused tests that compare:
+
+- ordinal-to-offset mapping;
+- all 16 `TileState` words;
+- keyed jackpot bytes;
+- lowest-winner selection;
+- adjacent batch boundaries;
+- session reuse and replacement;
+- scalar rejection of a corrupted device result.
+
+Gate: Rust scalar/device differential passes on RTX 5090 for 1,000 deterministic tickets, including first, last, and CTA-boundary tiles.
+
+## Stage 4: Safety and determinism
+
+Run these tools on the focused CUDA harness and Rust differential:
+
+1. Compute Sanitizer `memcheck`;
+2. Compute Sanitizer `racecheck`;
+3. Compute Sanitizer `initcheck`;
+4. Compute Sanitizer `synccheck`;
+5. `cuobjdump -res-usage` or the equivalent `ptxas` report.
+
+Gate:
+
+- no sanitizer findings;
+- three identical transcript sweeps;
+- zero local stack and zero spills;
+- at least two resident CTAs per SM;
+- no out-of-range winner under adversarial targets.
+
+## Stage 5: RTX 5090 shape and topology sweep
+
+Build `sm_120` variants for:
+
+- `m`: 4,096; 8,192; 16,384; 32,768;
+- `n`: 32,768 and 57,344 where memory permits;
+- CTA: $128 \times 128$ and $256 \times 128$;
+- stages: 2 and 3;
+- fixed `k=8192`, `r=512`, and tile 16.
+
+For each valid variant, measure:
+
+- matrix preparation and upload time;
+- kernel time;
+- total search wall time;
+- raw GEMM TOPS;
+- complete ticket TMAC/s and tickets/s;
+- finalizer share;
+- power, clock, temperature, registers, stack, and occupancy.
+
+Select the smallest shape within 98% of the best complete-ticket rate. Reject a faster shape if one launch exceeds 100 ms.
+
+Gate: at least 600 sustained TOPS, 300 TMAC/s, 140 million tickets/s, and 80% of same-session raw GEMM.
+
+## Stage 6: Opt-in miner integration
+
+Add `peak` as a separate backend selector in the CUDA miner CLI and Docker entrypoint. It must require the peak dense profile and must conflict with the existing canonical V3 selector.
+
+The worker keeps the current order:
+
+1. search;
+2. scalar recheck;
+3. target recheck;
+4. recursive proof;
+5. artifact encoding;
+6. node submission.
+
+Gate: one GPU winner builds and verifies the existing compact recursive certificate. The certificate and noun wire contain no CUDA-specific field.
+
+## Stage 7: Runpod production flow
+
+Build a CUDA 12.8 or newer Linux/amd64 image for `sm_120`. Start one RTX 5090 pod with only the documented miner arguments.
+
+Verify:
+
+1. GPU enumeration and peak-backend startup;
+2. persistent template allocation;
+3. steady no-hit mining and progress accounting;
+4. fakenet node connection;
+5. accepted `%ai-pow` block;
+6. candidate replacement during a launch;
+7. full pod stop and restart with the same configuration;
+8. no CPU-search fallback after an injected CUDA failure.
+
+Gate: the node logs an accepted block before and after the restart.
+
+## Stage 8: Multi-GPU extension
+
+Partition each ordered batch into contiguous device ranges. Preserve one session and stream per device. Reduce device results by global ordinal.
+
+Gate on two, four, and eight devices:
+
+- exact range coverage with no gaps or overlaps;
+- global lowest winner under maximum target;
+- zero-target miss;
+- cancellation after a candidate replacement;
+- scalar recheck of the selected global winner;
+- throughput scaling recorded against one device.
+
+## Stop rules
+
+Stop performance work and correct the first failure when any condition occurs:
+
+- one transcript word differs;
+- one jackpot byte differs;
+- the winner is not the lowest ordinal;
+- a sanitizer reports an error;
+- the hot kernel spills;
+- an unsupported shape falls back to another backend;
+- proof or node verification rejects a scalar-valid winner.
+
+Do not tune around a failed correctness gate.
+
+## Final evidence
+
+Record the selected shape, compile flags, measured table, sanitizer results, scalar differential count, proof verification, accepted block timestamp, and image digest in the GPU miner goal document. Commit each validated stage separately.

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-implementation-plan.md
@@ -74,8 +74,12 @@ Gate:
 - no sanitizer findings;
 - three identical transcript sweeps;
 - zero local stack and zero spills;
-- at least two resident CTAs per SM;
+- one active CTA per SM with a two-CTA-per-SM launch grid;
 - no out-of-range winner under adversarial targets.
+
+Runpod validation has zero findings from `memcheck`, `racecheck`, `initcheck`,
+and `synccheck` on adjacent range searches across persistent CTA tiles. The
+`sm_120` kernel has 248 registers per thread, no stack frame, and no spills.
 
 ## Stage 5: RTX 5090 shape and topology sweep
 
@@ -101,6 +105,28 @@ Select the smallest shape within 98% of the best complete-ticket rate. Reject a 
 
 Gate: at least 600 sustained TOPS, 300 TMAC/s, 140 million tickets/s, and 80% of same-session raw GEMM.
 
+### Stage 5 evidence
+
+The selected shape is $4096 \times 32768 \times 8192$ with rank 512, a
+$256 \times 128 \times 64$ CTA, and two pipeline stages. After five seconds of
+warmup, the median of 21 searches is:
+
+- 3.158 ms kernel time;
+- 3.184 ms wall time;
+- 166.025 million complete tickets/s;
+- 348.179 TMAC/s;
+- 696.359 TOPS.
+
+A 60-second power-limited run produces 334.740 TMAC/s and 159.617 million
+tickets/s. The matching raw GEMM is 368.1 TMAC/s. The complete search keeps
+94.6% of the five-second raw rate and 90.9% under sustained power load.
+
+The 1,000-ticket Rust differential compares all transcript words from the
+device debug kernel and brackets every fused search hash with its exact target
+and little-endian predecessor. Each vector runs three fused device repetitions.
+First, last, CTA-boundary, maximum-target, zero-target, and adjacent range cases
+pass.
+
 ## Stage 6: Opt-in miner integration
 
 Add `peak` as a separate backend selector in the CUDA miner CLI and Docker entrypoint. It must require the peak dense profile and must conflict with the existing canonical V3 selector.
@@ -116,22 +142,31 @@ The worker keeps the current order:
 
 Gate: one GPU winner builds and verifies the existing compact recursive certificate. The certificate and noun wire contain no CUDA-specific field.
 
+Status: the opt-in library backend is available. The production CLI selector,
+recursive-proof gate, and Docker entrypoint remain Stage 6 work.
+
 ## Stage 7: Runpod production flow
 
-Build a CUDA 12.8 or newer Linux/amd64 image for `sm_120`. Start one RTX 5090 pod with only the documented miner arguments.
+Build a CUDA 12.8 or newer Linux/amd64 image for `sm_120`. Start one RTX 5090
+pod with only `NODE_ADDR=http://23.252.122.18:5556` plus optional GPU tuning.
+Keep the image's default Docker `MINING_PKH`,
+`2nFsk7KTv9Fm5zMU3ckWAM4p9eLhUSVeVEKUoPFkfzehyjuzmpXAN8j`.
 
 Verify:
 
 1. GPU enumeration and peak-backend startup;
 2. persistent template allocation;
 3. steady no-hit mining and progress accounting;
-4. fakenet node connection;
-5. accepted `%ai-pow` block;
+4. connection to the mainnet API node maintained by the sibling `solo/`
+   Ansible directory;
+5. accepted `%ai-pow` block in the solo node logs;
 6. candidate replacement during a launch;
 7. full pod stop and restart with the same configuration;
 8. no CPU-search fallback after an injected CUDA failure.
 
-Gate: the node logs an accepted block before and after the restart.
+Do not start or connect to a fakenet for a Runpod test.
+
+Gate: the solo node logs an accepted block before and after the restart.
 
 ## Stage 8: Multi-GPU extension
 

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md
@@ -24,8 +24,8 @@ Use these fixed transcript dimensions for the first kernel family:
 | Noise rank `r` | 512 | `k/r = 16`; each of the 16 transcript slots is written once. |
 | Ticket tile | $16 \times 16$ | Matches the native hash tile and the Pearl limit $h\cdot w \le 256$. |
 | MMA | `m16n8k32.s8.s8.s32.satfinite` | Matches the scalar INT8-to-INT32 result for this range. |
-| CTA tile | $256 \times 128 \times 64$ initially | Best measured local Pearl mining topology. |
-| Pipeline depth | 2 and 3 stages in the sweep | Both fit the RTX 5090 shared-memory limit; the winner is measurement-dependent. |
+| CTA tile | $256 \times 128 \times 64$ | Highest measured complete-ticket rate. |
+| Pipeline depth | 2 stages | Faster than the measured 3-stage variants. |
 
 The maximum absolute dot product is below $2^{31}$:
 
@@ -47,7 +47,54 @@ Each $16 \times 16$ ticket costs $256 \times 8192 = 2,097,152$ MACs. At 600 TOPS
 
 The full $32768 \times 57344 \times 8192$ shape has 41,705 INT8 operations per input byte. The RTX 5090 compute-to-bandwidth ridge is approximately 468 operations per byte. The main loop is compute-bound by a factor of approximately 89 if tile reuse is correct.
 
-The initial production choice is not a hard-coded assumption. The Runpod sweep must select the smallest shape that reaches at least 98% of the best measured ticket rate. This rule limits cancellation latency and template-stale work without giving up meaningful throughput.
+The selected shape is the smallest shape that reaches at least 98% of the best measured ticket rate. This rule limits cancellation latency and template-stale work without giving up meaningful throughput.
+
+## RTX 5090 measured selection
+
+The `sm_120` build uses CUDA 12.8 and real deterministic INT8 data. The
+topology screening on one Runpod RTX 5090 produced these complete-ticket
+rates for $m=4096$, $n=32768$, $k=8192$, and $r=512$:
+
+| CTA | Stages | Registers/thread | Static shared memory | TMAC/s |
+|---:|---:|---:|---:|---:|
+| $128 \times 128$ | 2 | 232 | 4,096 B | 332.979 |
+| $128 \times 128$ | 3 | 234 | 4,096 B | 322.721 |
+| $256 \times 128$ | 2 | 248 | 8,192 B | 348.179 |
+| $256 \times 128$ | 3 | 234 | 8,192 B | 347.510 |
+
+The selected two-stage topology uses 49,152 bytes of dynamic shared memory.
+The CUDA occupancy API reports one active CTA per SM. The launch grid contains
+two CTAs per SM, so another CTA is ready when the active CTA completes.
+
+Each shape ran after at least five seconds of warmup. Each table row is the
+median of 21 complete searches:
+
+| `m` | `n` | Kernel ms | Wall ms | Million tickets/s | TMAC/s |
+|---:|---:|---:|---:|---:|---:|
+| 4,096 | 32,768 | 3.158 | 3.184 | 166.025 | 348.179 |
+| 8,192 | 32,768 | 6.385 | 6.409 | 164.216 | 344.386 |
+| 16,384 | 32,768 | 12.653 | 12.678 | 165.742 | 347.587 |
+| 32,768 | 32,768 | 25.755 | 25.784 | 162.854 | 341.530 |
+| 4,096 | 57,344 | 5.631 | 5.653 | 162.938 | 341.705 |
+| 8,192 | 57,344 | 11.393 | 11.421 | 161.070 | 337.787 |
+| 16,384 | 57,344 | 22.371 | 22.403 | 164.050 | 344.037 |
+
+The selected shape is $4096 \times 32768 \times 8192$. It is the smallest
+tested shape and has the highest measured complete-ticket rate. One launch is
+3.158 ms, well below the 100 ms cancellation limit.
+
+A 60-second sustained run at the selected shape produced 3.285 ms per kernel,
+159.617 million tickets/s, and 334.740 TMAC/s. Device samples showed 99% SM
+activity, 575 W, 2,355–2,370 MHz, and 51–55 °C. The equivalent complete-search
+rate is 669.480 TOPS.
+
+The same pod produced 736.2 TOPS, or 368.1 TMAC/s, with the matching
+$256 \times 128 \times 64$ two-stage raw GEMM. The five-second complete-search
+rate is 94.6% of that raw rate. The sustained complete-search rate is 90.9%.
+
+The hot kernel uses 248 registers per thread, has no stack frame, and has no
+local-memory spills. Nsight Compute hardware counters are not available on the
+Runpod host because the NVIDIA driver denies performance-counter access.
 
 ## Proof capacity
 
@@ -71,7 +118,7 @@ A production candidate must satisfy all limits:
 
 1. Exact scalar/GPU transcript equality for at least 1,000 patterned vectors, all boundary ordinals, and three deterministic repeats.
 2. No Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, or `synccheck` errors.
-3. No local-memory stack or spill in the hot kernel. Register use must permit at least two resident CTAs per SM.
+3. No local-memory stack or spill in the hot kernel. The measured occupancy must match the launch model.
 4. At least 600 sustained TOPS or 300 TMAC/s with real patterned inputs on an RTX 5090.
 5. At least 80% of the same-session raw-GEMM rate after transcript and BLAKE3 work.
 6. At least 140 million complete tickets/s for the selected shape.

--- a/docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md
+++ b/docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md
@@ -1,0 +1,90 @@
+# Pearl V3 RTX 5090 Roofline
+
+## Purpose
+
+Define the hardware limits and puzzle shapes for a Pearl V3 CUDA miner on one RTX 5090. Measurements must use the exact ticket transcript and real INT8 data. A raw GEMM number is only a ceiling.
+
+## Hardware limits
+
+The RTX 5090 has 170 streaming multiprocessors, 32 GiB of GDDR7, and 1,792 GB/s of memory bandwidth. At the 2.407 GHz boost clock, its dense INT8 Tensor Core ceiling is approximately:
+
+$$170 \times 4 \times 512 \times 2.407\text{ GHz} = 838\text{ TOPS}.$$
+
+The local Pearl benchmark measured 858.2 TOPS with cuBLAS Lt at $32768 \times 57344 \times 8192$. Clock boost can move this value by approximately 3%. The production comparison must therefore use same-session ratios and record the sustained SM clock, power, and temperature.
+
+Real mining data reaches a lower power-limited ceiling. The local Pearl records show approximately 620–674 TOPS for the full transcript workload and approximately 314–366 TMAC/s. Synthetic all-one inputs can inflate the result by 22–30% and are not valid performance inputs.
+
+## Puzzle geometry
+
+Use these fixed transcript dimensions for the first kernel family:
+
+| Field | Value | Reason |
+|---|---:|---|
+| `k` | 8,192 | Long enough to saturate the Tensor Core main loop. |
+| Noise rank `r` | 512 | `k/r = 16`; each of the 16 transcript slots is written once. |
+| Ticket tile | $16 \times 16$ | Matches the native hash tile and the Pearl limit $h\cdot w \le 256$. |
+| MMA | `m16n8k32.s8.s8.s32.satfinite` | Matches the scalar INT8-to-INT32 result for this range. |
+| CTA tile | $256 \times 128 \times 64$ initially | Best measured local Pearl mining topology. |
+| Pipeline depth | 2 and 3 stages in the sweep | Both fit the RTX 5090 shared-memory limit; the winner is measurement-dependent. |
+
+The maximum absolute dot product is below $2^{31}$:
+
+$$8192 \times 128 \times 128 = 134,217,728.$$
+
+`mma.sync.satfinite` therefore has the same result as wrapping scalar accumulation for every valid input.
+
+## Candidate shape model
+
+Each $16 \times 16$ ticket costs $256 \times 8192 = 2,097,152$ MACs. At 600 TOPS, every shape below has the same ideal rate of 143.05 million tickets/s. Larger shapes improve occupancy and amortization, but they increase stale-work latency and memory use.
+
+| `m` | `n` | MAC/launch | Input bytes | Ideal launch time at 600 TOPS | Tickets/launch |
+|---:|---:|---:|---:|---:|---:|
+| 4,096 | 32,768 | 1.100 TMAC | 288 MiB | 3.67 ms | 524,288 |
+| 8,192 | 32,768 | 2.199 TMAC | 320 MiB | 7.33 ms | 1,048,576 |
+| 16,384 | 32,768 | 4.398 TMAC | 384 MiB | 14.66 ms | 2,097,152 |
+| 32,768 | 32,768 | 8.796 TMAC | 512 MiB | 29.32 ms | 4,194,304 |
+| 32,768 | 57,344 | 15.393 TMAC | 704 MiB | 51.31 ms | 7,340,032 |
+
+The full $32768 \times 57344 \times 8192$ shape has 41,705 INT8 operations per input byte. The RTX 5090 compute-to-bandwidth ridge is approximately 468 operations per byte. The main loop is compute-bound by a factor of approximately 89 if tile reuse is correct.
+
+The initial production choice is not a hard-coded assumption. The Runpod sweep must select the smallest shape that reaches at least 98% of the best measured ticket rate. This rule limits cancellation latency and template-stale work without giving up meaningful throughput.
+
+## Proof capacity
+
+For `tile=16`, `k=8192`, and `r=512`, the conservative Layer-0 row budget is:
+
+| Component | Rows |
+|---|---:|
+| A strip opening | 19,592 |
+| B strip opening | 19,592 |
+| Matmul sweep | 32,768 |
+| Noised packed store | 262,145 |
+| Fixed rows | 43 |
+| Total before padding | 334,140 |
+| Trace length | $2^{19}=524,288$ |
+
+The trace is below the $2^{22}$ Pearl bound and the Nockchain $2^{19}$ production verifier cap. Full `m` and `n` do not increase this one-ticket trace because the proof opens only the selected strips and their authentication paths.
+
+## Measured acceptance limits
+
+A production candidate must satisfy all limits:
+
+1. Exact scalar/GPU transcript equality for at least 1,000 patterned vectors, all boundary ordinals, and three deterministic repeats.
+2. No Compute Sanitizer `memcheck`, `racecheck`, `initcheck`, or `synccheck` errors.
+3. No local-memory stack or spill in the hot kernel. Register use must permit at least two resident CTAs per SM.
+4. At least 600 sustained TOPS or 300 TMAC/s with real patterned inputs on an RTX 5090.
+5. At least 80% of the same-session raw-GEMM rate after transcript and BLAKE3 work.
+6. At least 140 million complete tickets/s for the selected shape.
+7. No-hit host traffic limited to a fixed result header per launch. No full output matrix is stored.
+8. No host or device allocation in the steady-state search loop.
+9. Kernel duration below 100 ms so candidate replacement and cancellation remain bounded.
+
+## Measurement protocol
+
+1. Build for `sm_120` with CUDA 12.8 or newer.
+2. Use deterministic patterned INT8 inputs in the valid `[-127,127]` range. Do not use all-one or zero-page input.
+3. Warm the GPU for at least five seconds.
+4. Measure at least five samples in one process. Report the median and range.
+5. Record SM clock, power, temperature, CUDA version, driver version, registers, stack, and occupancy.
+6. Measure raw GEMM and complete ticket search back-to-back in the same process.
+7. Report both TMAC/s and complete tickets/s. A ticket counts only after transcript finalization and target comparison.


### PR DESCRIPTION
## Summary

Make the dense Pearl V3 peak kernel the production path for `ai-pow-mine --gpu --canonical`.

- Build the canonical dense template from each `%mine-ai` candidate.
- Derive keyed matrix commitments and noised matrices in persistent CUDA sessions.
- Search the full ticket space on one or more GPUs with deterministic contiguous partitions.
- Return the global lowest winner and re-evaluate it with the scalar Rust evaluator before proof construction.
- Build the existing compact recursive certificate and use the existing consensus verifier contract.
- Fail closed on CUDA initialization, preparation, launch, synchronization, or winner-validation errors.
- Default the Linux/amd64 CUDA 12.8 image to the `sm_120` peak path.

## Validated performance

Hardware: Runpod RTX 5090, CUDA 12.8, `sm_120`, real deterministic INT8 mining data. A ticket includes transcript finalization and target comparison. `TMAC/s` is `tickets/s × tile_height × tile_width × k / 10^12`, which is the work factor used by mining difficulty.

### Isolated one-GPU kernel

| Metric | `master` generic CUDA | This PR, 60 s sustained | Improvement |
|---|---:|---:|---:|
| Complete tickets/s | 2.92 million | 159.617 million | **54.7×** |
| Ticket work rate | 0.1915 TMAC/s | 334.740 TMAC/s | **1,748×** |

The five-second median is 166.025 million tickets/s and 348.179 TMAC/s. The matching raw GEMM is 368.1 TMAC/s. The complete 60-second search sustains **90.9%** of that raw rate at 575 W.

### Node-connected two-GPU production path

The complete production binary connected to the Nockchain node and sustained these consecutive 60-second windows after it prepared the candidate transcript on the GPUs:

| Metric | `master`, 2× RTX 5090 | This PR, 2× RTX 5090 | Improvement |
|---|---:|---:|---:|
| Complete tickets/s | 5.68 million | 104.080–106.911 million | **18.3–18.8×** |
| Ticket work rate | 0.3723 TMAC/s | 218.271–224.208 TMAC/s | **586–602×** |

Both GPUs stayed at 96–98% utilization and 575 W during the observed production run.

For reference, the 120-worker pod CPU backend produced 147 thousand tickets/s and 0.00965 TMAC/s. The two-GPU production path is **708–727×** faster by ticket rate and **22,619–23,234×** faster by ticket work rate.

## Correctness and safety evidence

- The Rust/CUDA differential compares the complete transcript, including commitments, opened and noised matrices, rolling tile state, and jackpot hashes.
- Exact production-shape vectors cover ordinary, boundary, and maximum ordinals.
- `memcheck`, `racecheck`, `initcheck`, and `synccheck` pass on the two-GPU search.
- The multi-GPU reducer returns the global lowest winner independent of device completion order.
- A CUDA winner must pass scalar Rust re-evaluation before proof construction.
- The production peak certificate passes the existing consensus noun entry point.
- The production container restarts with the same configuration and resumes dual-GPU search.
- An invalid CUDA device exits with status 1. It does not fall back to CPU search.

Full host regression results:

- `cargo test --locked -p ai-pow-zk -p ai-pow`: **759 passed**, 6 ignored.
- `cargo test --locked -p ai-pow-miner --features node`: **165 passed**, 10 ignored.

Live production validation reached node subscription, candidate replacement, sustained dual-GPU search, clean restart, and fail-closed error injection. The observed network target required an expected approximately 150 trillion tickets. The run ended before a hit, so this PR does not claim an observed live block acceptance.