### PR TITLE
docs(ai-pow): design note on a verifiable inference cloud

### DIFF
--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -97,7 +97,7 @@ One mechanism per purpose. Alternatives are named here and not carried further.
 | Set the price | **Auction, per MAC-equivalent** | Protocol price controller — supply is self-reported, so it is a cartel lever |
 | Accrue value, price fake demand | **Fixed burn fraction `β`** | Moving `β` — damps the supply response exactly when it should attract capacity |
 | Weight authenticity | **Onchain model manifest** | Trusting `HASH_B` alone — it binds *some* weights, not the certified model's |
-| Consensus integration | **One lock primitive (§6)** | A dispute-game NockApp, kernel changes, a second puzzle |
+| Consensus integration | **None — existing primitives only (§6)** | A new lock primitive up front — it is a tx-engine change putting a STARK verifier in transaction validation; deferred to §6 |
 
 Cut entirely: the challenger bounty (the client is the challenger, motivated by its
 own refund), the optional bonded assurance tier, per-layer bisection, and separate
@@ -238,39 +238,74 @@ a theorem, and it is a measurement gate (§7).
 Note the monotonicity: the more inference pays over mining, the less detection is
 needed. The mechanism gets safer as the market gets more valuable.
 
-## 6. The consensus route: one lock primitive
+## 6. The consensus route: none at first, `%aip` later
 
-Everything above composes from primitives the chain already has, except one thing.
+An earlier version of this section proposed a new lock primitive as *the* route and
+called it small because the verifier is already resident. That undersold it. The
+count is right and the risk assessment was not.
 
-The escrow output is spendable three ways:
+**A lock primitive is a transaction-engine change.** `lock-primitive` is a `$%` in
+[`hoon/common/tx-engine-1.hoon`](../../hoon/common/tx-engine-1.hoon) (`%pkh`, `%tim`,
+`%hax`, `%brn`), mirrored in
+[`crates/nockchain-types/src/tx_engine/v1/tx.rs`](../../crates/nockchain-types/src/tx_engine/v1/tx.rs).
+A fifth variant touches the mold, `based`, `hashable`, `hash`, and `check` in **two**
+call sites (`check-lock` and `check-multisig-lock`), plus Rust serialize, deserialize,
+and leaf-hash — with exact Hoon/Rust agreement required, and respecting the ordering
+constraint the `%brn` comment flags ("it's important that this be the default to break
+a type loop in the compiler"). It also grows the **witness**, since `check` reads its
+argument from `form` and a certificate is not a signature.
 
-1. **Happy path** — miner signature + client signature. Plain multisig, already
-   expressible.
-2. **Miner never delivered** — client alone after timeout. Plain timelock, already
-   expressible.
-3. **Client disputes but the miner was honest** — miner alone, by presenting a
-   certificate that verifies against the committed statement digest.
+That is the most consensus-critical component in the repository. The AI-PoW puzzle is
+an opt-in second puzzle; the transaction engine validates every transaction on the
+chain.
 
-Only path 3 needs anything new: **one lock primitive, `%aip`, satisfied by an
-AI-PoW certificate verifying against a statement digest committed in the output.**
+**And the cost profile is a genuine regression, not just a fee question.**
+`ai-pow-verify` is the *block puzzle* verifier: one certificate per block, at block
+admission. Putting a STARK verification inside `check-lock`'s `levy` over spend
+conditions runs it per primitive, per spend, per transaction — a different throughput
+regime entirely. Setup-table residency is necessary and nowhere near sufficient. This
+is the same class of hazard `SPOT_CHECKS_MAX` exists to bound, and the repository's own
+comment there names it: a crafted block driving CPU-time DoS.
 
-This is small because the work is already done. `ai_pow_verify_jet` exists, and
-production nodes "build and validate the complete setup table at boot" for every
-reachable trace height — the verifier and its setup are **already resident for block
-acceptance**. The primitive exposes a check the node already performs.
+### What to do instead, for a first deployment
 
-Everything else stays off the consensus path: matching and the request mempool are
-offchain, the manifest registry is a NockApp with a well-known root, the burn leg is
-an existing `%brn` output, and identities are ordinary keypairs. The kernel learns
-nothing about inference, prompts, models, or fingerprints. There is no dispute game
-in consensus, no seizure logic, and no second puzzle.
+**Nothing.** The escrow needs no new primitive if the certificate is verified
+*offchain*:
 
-**The one real risk of this route** is transaction-validation cost: a spend that
-forces certificate verification is far more expensive to validate than a signature
-check, so `%aip` spends need fee pricing that reflects it, and the bounded-verify
-discipline that already protects block acceptance has to extend to the mempool.
-That is a contained, well-understood problem, and it is the whole of the new
-consensus surface.
+- 2-of-2 between client and miner, with a timeout that refunds the client. Plain
+  multisig and timelock, both already expressible.
+- On dispute the miner publishes its certificate. Anyone — the client, the scheduler,
+  a competing miner — verifies it offchain with the machinery that already exists.
+- A client that ignores a verifying certificate is publicly identifiable, and the
+  miner declines to serve it again.
+
+The residual weakness is bounded and cheap: a griefing client can take **one payment
+per miner** before that miner stops serving it, and it burns its own reputation doing
+so in public. For the request sizes this market starts at, that is a smaller cost than
+a hard fork.
+
+Where a client's downside genuinely warrants adjudication, a 2-of-3 with a
+market-chosen adjudicator that verifies certificates offchain is also expressible
+today. It reintroduces a trusted third party — which is exactly the trade, and it
+should be the client's to make, not the protocol's.
+
+### When `%aip` earns its hard fork
+
+`%aip` removes the griefing window by making the certificate directly spendable. That
+is a real improvement and it is an **optimization of a working market, not a
+prerequisite for one.** Defer it until there is volume that justifies the fork, and
+until the cost question above has an answer — a per-transaction verification bound, a
+fee schedule reflecting it, and mempool admission policy that cannot be used to make
+every node re-verify STARKs on demand.
+
+If it is built, the versioned engine is the precedent to follow: `tx-engine-0` and
+`tx-engine-1` both exist and `tx-engine.hoon` imports both, so a `tx-engine-2` is the
+idiomatic path rather than mutating a deployed engine in place.
+
+**Net for a first deployment: the consensus surface is zero.** Matching, manifest,
+disputes, identities, and adjudication are all offchain; settlement uses `%pkh`,
+`%tim`, and `%brn` exactly as they exist today. The kernel learns nothing about
+inference, and nothing about this design requires a fork to start.
 
 ## 7. What must be measured first
 
@@ -287,7 +322,9 @@ consensus surface.
    latter and nothing repairs the former.
 4. **Tier-A overhead on the serving path** — confirm the async tee is free rather
    than assuming it from bandwidth arithmetic.
-5. **`%aip` verification cost** per spend, for mempool fee pricing.
+5. **Per-transaction certificate verification cost and a mempool admission bound** —
+   required *before* `%aip` is considered, not after. Until this has an answer, the
+   design ships on existing primitives.
 6. **Off-chain defection rate**, once a market exists. The only honest way to bound
    `β`, and the only gate that cannot be run before launch.
 
@@ -341,13 +378,14 @@ commitments that depend on it.
    free, no consensus involvement, and it closes the substitution cheat that
    dominates the economics.
 5. **Tier B** on a named tile via `from_tile`, verified offchain end to end.
-6. **`%aip` lock primitive** with mempool fee pricing — the only consensus change,
-   and the only stage owed a full protocol review.
-7. **Settlement and scheduler** — escrow, auction, burn split, admission tickets,
-   PoW/inference interleaving at the existing cancellation granularity.
+6. **Settlement and scheduler** — escrow on `%pkh`/`%tim`/`%brn` as they exist,
+   auction, burn split, admission tickets, PoW/inference interleaving at the existing
+   cancellation granularity.
 
-Stages 2–5 carry no consensus risk and can proceed in parallel once stage 1 lands.
-Stage 6 is the review gate.
+**No stage in this plan changes consensus.** `%aip` (§6) is deliberately excluded: it
+optimizes a working market rather than enabling one, and it is owed its own protocol
+review, its own cost bound, and plausibly its own `tx-engine-2` — none of which should
+gate shipping the rest.
 
 ## 10. Summary
 
@@ -365,9 +403,11 @@ the fleet needs no interconnect, and that KV-capped decode leaves ~92% of the IN
 tensor cores idle in exactly the units AI-PoW consumes. Verification is paid for out
 of compute the serving workload cannot use.
 
-The route into consensus is one lock primitive exposing a verifier every node
-already runs at boot. Everything else — matching, manifest, disputes, identities —
-stays offchain.
+**The route into consensus is that there is not one.** Settlement composes from
+`%pkh`, `%tim`, and `%brn` as they exist; certificates are verified offchain, where
+the machinery already runs. A `%aip` lock primitive would remove the residual
+griefing window, but it is a transaction-engine change that puts a STARK verifier in
+the transaction-validation loop — an optimization to earn later, not a prerequisite.
 
 The honest limits are that only one layer is sound and it samples the integer linear
 path, that end-to-end coverage rests on adversarial robustness nobody has tested with

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -15,7 +15,10 @@ tokens came from that model's real weights.
 It is a design exploration, not a protocol proposal. It does not change
 `PROTOCOL.md`, consensus activation, ASERT, fork choice, or block validity, and
 it deliberately stops short of code because the sampling rates it recommends
-depend on one quantity nobody in this repository has measured yet (§9).
+depend on one quantity nobody in this repository has measured yet (§9). It does
+assume the burn primitive (`%brn`) and the fixed-percentage-split precedent that
+Aletheia already established, rather than proposing new consensus machinery for
+either.
 
 ## 1. The claim
 
@@ -223,9 +226,10 @@ end-to-end proof coverage.
 - **Unit of supply:** one miner = one whole-model replica on one GPU. Request-level
   parallelism only.
 - **Matching:** clients post signed requests (manifest digest, prompt digest, max
-  tokens, sampling params, seed, price, deadline) to an offchain mempool; miners
-  claim them. Payment escrows in `$NOCK` through the existing UTXO and wallet
-  crates, releasing on Tier-1 commitment plus a quiet dispute window.
+  tokens, sampling params, seed, bid per MAC-equivalent, deadline) to an offchain
+  mempool; miners claim them. Payment escrows in `$NOCK` through the existing UTXO
+  and wallet crates and settles on Tier-1 commitment plus a quiet dispute window,
+  splitting `(1−β)` to the miner and `β` to a `%brn` output (§8).
 - **Interleaving:** the miner serves inference when paid demand exists and falls
   back to PoW otherwise — and per §3 it can do *both at once* during decode,
   because decode leaves the tensor cores mostly free.
@@ -234,30 +238,160 @@ end-to-end proof coverage.
   That is finer than a typical 20–50 ms per-token budget, so mining can yield to
   inference without violating interactive latency.
 
-## 8. Economics: PoW as the reserve price
+## 8. Settlement: burn-denominated inference
 
-The useful economic property is that Nockchain **already runs a continuous spot
-market for exactly this hardware doing exactly these GEMMs.** Block-reward EV per
-GPU-second is measurable from sustained TMAC/s and the current AI target — and
-`DIFFICULTY.md` is explicit that the target `T` prices one MAC-equivalent of
-matmul work, not one attempt, which is precisely the denomination needed.
+### 8.1 The reserve price already exists
+
+Nockchain already runs a spot market for exactly this hardware doing exactly
+these GEMMs. Block-reward EV per GPU-second is measurable from sustained TMAC/s
+and the current AI target — and `DIFFICULTY.md` is explicit that the target `T`
+prices *one MAC-equivalent of matmul work*, not one attempt, which is precisely
+the denomination needed.
 
 That gives a floor: inference must outbid mining EV per GPU-second, or the miner
-keeps mining. No token subsidy or bootstrapping incentive is required to price
-the fleet, and supply is elastic in both directions.
+keeps mining. No token subsidy is required to price the fleet, and supply is
+elastic in both directions.
 
-**Sampling rate.** With proof cost `C_p` and request cost `C_r` (both GPU-seconds)
-and sample rate `p`, verification overhead is `p · C_p / C_r`. Holding overhead
-to a budget `β` gives `p ≤ β · C_r / C_p`.
+### 8.2 Price per MAC-equivalent, quantity fixed by the manifest
 
-**Stake.** A miner skipping work gains at most the value of `C_r` and is detected
-with probability `p`, so honesty requires roughly `S > value(C_r) / p`.
-Substituting: `S > value(C_p) / β`. At `β = 5%`, the stake floor is about 20× the
-*value of a single proof* — not 20× the value of a request, and independent of
-request size. That is a mild requirement, and it is the reason this scheme can
-work with consumer-scale operators rather than only well-capitalized ones.
+Denominate inference in the same unit the puzzle already uses: **`$NOCK` per
+MAC-equivalent**. Two properties follow, and both remove trust rather than add it.
 
-Systematic cheating is bounded much more tightly than one-shot cheating, because
+A miner's allocation decision becomes a scalar comparison in one unit — mining EV
+per MAC-equivalent against the inference bid per MAC-equivalent — with no
+conversion and no oracle.
+
+And because the model manifest (§6) fixes every layer's shape, the MAC count of a
+request is **deterministic from `(manifest, prompt length, max tokens)` and
+computable by both parties before execution.** There is no metering to trust, no
+usage counter to falsify, and no billing dispute surface: the quantity is
+objective and known in advance, so only the price is negotiated.
+
+### 8.3 Burn is the right rail, and not primarily for deflation
+
+Payment should be a burn split: the client's payment settles as `(1−β)` to the
+serving miner and `β` to a provably unspendable output.
+
+The mechanism needs no new consensus primitive. `%brn` is already a first-class
+lock primitive in the v1 tx engine (`LockPrimitive::Burn` in
+`crates/nockchain-types/src/tx_engine/v1/tx.rs`, `%brn` in
+`hoon/common/tx-engine-1.hoon`), and Aletheia already established the precedent
+for splitting value by fixed percentage to a well-known destination — its 80/20
+miner/protocol-fund split of new issuance.
+
+The usual argument for a burn is deflation. That is real here given the 2³² hard
+cap, but it is the weaker reason. Two stronger ones:
+
+**Burn is the only self-dealing-proof payment rail.** The Tier-1/2/3 design in §5
+secures *correctness* — that a miner computed what it claimed — through stake and
+slashing. It does nothing whatsoever about **fake demand**: a miner paying itself
+to manufacture the appearance of volume. That matters wherever serving volume
+becomes visible and valuable — advertising utilization to attract real clients,
+reputation weighting in the scheduler, or any future rule that lets volume
+influence anything consensus-visible. Under a 100%-to-miner fee, a self-deal
+round-trips at *zero cost* and wash volume is free. Under a burn, every washed
+`$NOCK` costs exactly `β`.
+
+**This is the correct criterion for setting `β`**: not a revenue-split intuition
+about what feels fair to miners, but the price at which faking demand stops being
+profitable relative to the largest plausible benefit of faking it.
+
+**Burn is the only way to raise miner revenue against a hard cap.** Aletheia
+deliberately sustains a 64-NOCK floor for ~68 years to extend the chain's revenue
+tail, because the original schedule "front-loads ~99% of emissions into the
+chain's first thirty years… forcing the network onto fee revenue earlier than the
+application ecosystem can sustain." That floor is denominated in NOCK, so its
+*real* value is exactly what a burn improves — and improving it by issuance is
+impossible against a fixed cap. The loop closes:
+
+```text
+inference demand -> burn -> scarcer $NOCK -> higher real value of the
+64-NOCK floor -> more hashrate -> more serving capacity -> inference demand
+```
+
+A burn converts inference demand into security budget for the whole network
+rather than private revenue for whichever miner happened to serve. Given that
+Aletheia's stated motivation is precisely the long-run security-budget
+transition, the fit is unusually good.
+
+### 8.4 Modulate the market, not the price
+
+"Adjust the rate with supply and demand" is right as an objective and dangerous
+as an implementation, and the distinction is where this design most needs care.
+
+**A protocol-set price requires observing supply, and supply is not observable.**
+Settled demand is onchain and honest. Total idle GPU capacity across the fleet is
+not: it is self-reported. An EIP-1559-style controller works because block space
+is a hard cap the protocol *knows*; here the protocol has no idea what the fleet
+can do. A controller keyed on self-reported capacity is a cartel lever —
+under-report capacity, utilization appears high, the protocol raises the price —
+and it pays out precisely to coordinated under-reporting. The fewer large
+operators, the cheaper that attack.
+
+**So let the auction set the price and keep the protocol to the split.** Clients
+bid, miners accept, and the protocol burns `β` of whatever cleared. Price then
+modulates with supply and demand *automatically*, through a real two-sided market
+rather than an oracle reading, and there is nothing to manipulate: a miner that
+misrepresents its capacity moves no protocol variable, it just fails to win work.
+The burn *throughput* still rises and falls with real demand, which is the
+deflationary behavior the mechanism is meant to produce.
+
+**If `β` itself moves, key it to the security budget, not the demand cycle.**
+There is a defensible moving `β`, but the intuitive version is backwards. Burning
+a larger share when demand is high damps the miner-revenue signal exactly when
+that signal should be attracting capacity; the supply response is the one thing
+that must not be damped. The version that earns its complexity instead lets `β`
+*fall* as the block subsidy decays, shifting revenue toward miners as direct
+security funding is most needed — a slow monetary dial on a multi-month EMA,
+bounded within `[β_min, β_max]`, with hysteresis, and keyed on realized burn
+against subsidy rather than on anything a participant self-reports.
+
+### 8.5 What actually bounds `β`
+
+Not fairness, and not revenue maximization: **the off-chain escape hatch.**
+
+A miner and client can always settle privately and never touch the chain. The
+burn is a tax on using the onchain rail, so `β` must stay below what that rail is
+worth to the marginal client — escrow, the unpredictable beacon that makes Tier-2
+sampling unforgeable, slashing, and dispute adjudication. Sophisticated repeat
+counterparties who already trust each other will defect off-chain at *any* `β`;
+the rail's real market is strangers and one-shot interactions, which is also
+exactly where verifiability is worth paying for.
+
+That caps `β` well below a naive revenue-maximizing choice — my instinct is a
+10–30% band rather than 50%+ — and it should be set against *observed* off-chain
+defection once there is a market to observe, not guessed in advance.
+
+One consequence: keep the split two-way. Adding the Aletheia protocol fund as a
+third claimant on inference revenue raises the tax on the rail without a clear
+need, and the fund is already financed from issuance. Cheap rail, narrow split.
+
+### 8.6 Slashing, refunds, and paying the challenger
+
+The burn interacts with §5's dispute tier, and getting this wrong makes Tier 3
+theater.
+
+- **The client's payment is refunded, never burned, on a failed proof.** If
+  clients bore the cost of miner misbehavior the service would be unusable.
+- **Slashed stake splits between challenger bounty and burn.** Burning 100% leaves
+  challengers unfunded — nobody spends a forward pass to catch a cheat for free,
+  and the whole tier collapses. Paying 100% to the challenger funds griefing
+  between competing miners. Size the bounty to somewhat exceed replay cost and
+  burn the remainder.
+
+### 8.7 Sampling rate and stake
+
+With proof cost `C_p` and request cost `C_r`, sample rate `p` gives verification
+overhead `p · C_p / C_r`. Holding it to a budget `β_v` gives `p ≤ β_v · C_r / C_p`.
+
+A miner skipping work gains at most `value(C_r)` and is detected with probability
+`p`, so honesty requires `S > value(C_r) / p`. Substituting:
+**`S > value(C_p) / β_v`**. At a 5% verification budget, the stake floor is ~20×
+the value of a *single proof* — not of a request, and independent of request size.
+That mildness is why this can work with consumer-scale operators rather than only
+well-capitalized ones.
+
+Systematic cheating is bounded far more tightly than one-shot cheating, because
 Tier-3 replay is cheap and available to anyone: a miner that cheats repeatedly
 faces detection probability approaching 1.
 
@@ -285,6 +419,10 @@ Required before any of this is committed to:
    here too).
 4. **Cost of the zero-noise inference statement**, and confirmation that
    domain-separating it cannot weaken the PoW anti-reuse invariant.
+5. **Off-chain defection rate** once a market exists. This is the only honest way
+   to bound `β` (§8.5), and unlike the others it cannot be measured before
+   launch — which is the argument for shipping a deliberately low constant `β`
+   and raising it against evidence, rather than starting high.
 
 ## 10. Risks and honest limits
 
@@ -341,14 +479,19 @@ that the measurement gate precedes the design commitments that depend on it.
    roots emitted on the serving path, with the overhead measured against §9.2.
 5. **Tier-2 spot proof**, driven by block-hash beacon selection through
    `StripIndexSchedule::from_tile`.
-6. **Tier-3 bisection game** as a NockApp, with escrow and slashing; consensus
-   untouched.
-7. **Scheduler and interleaving**, including PoW/inference preemption at the
+6. **Burn-split settlement** over the existing `%brn` primitive: per-MAC bid
+   escrow, `(1−β)/β` split on success, refund on failed proof. No price
+   controller; `β` fixed for the first deployment.
+7. **Tier-3 bisection game** as a NockApp, with slashing and the challenger
+   bounty; consensus untouched.
+8. **Scheduler and interleaving**, including PoW/inference preemption at the
    existing cancellation granularity.
 
-Stages 2–5 are additive and carry no consensus risk. Stage 6 is where the real
+Stages 2–6 are additive and carry no consensus risk. Stage 7 is where the real
 design review is owed, and it should be reviewed against the existing dual-puzzle
-audit findings rather than in isolation.
+audit findings rather than in isolation. A moving `β` (§8.4) is explicitly *not*
+in this plan: ship a constant, observe the market, and only then decide whether a
+dial is worth its attack surface.
 
 ## 12. Summary
 
@@ -363,7 +506,17 @@ on one card — so the fleet needs no interconnect — and that KV-capped decode
 leaves ~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes.
 The verification is paid for out of compute that the serving workload cannot use.
 
+Settlement should be a burn split, denominated per MAC-equivalent so the manifest
+makes every request's quantity objective in advance. The burn's primary job is not
+deflation but making fake demand cost something — it is the only payment rail on
+which a miner cannot wash its own volume for free — and, against a hard supply cap,
+the only way inference demand can raise the real value of the 64-NOCK floor that
+funds long-run security. Price should be set by auction rather than by a protocol
+controller: supply is self-reported and therefore a cartel lever, so the protocol
+should fix the split and let the market fix the price.
+
 The honest limits are that proof coverage is a sample over the INT7 linear layers
-rather than the whole forward pass, that miners see prompts, and that the dispute
+rather than the whole forward pass, that miners see prompts, that `β` is bounded by
+an off-chain escape hatch nobody can measure before launch, and that the dispute
 game is the one genuinely risky addition — which is why it belongs in a NockApp
 and not in the consensus kernel.

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -95,7 +95,8 @@ One mechanism per purpose. Alternatives are named here and not carried further.
 | Make cheating unprofitable | **Forfeiture: never pay before verify** | Bonds — redundant once detection is near-certain (§5) |
 | Sybil / claim-abandon resistance | **One PoW admission ticket per claim** | Reputation, capital deposits, whitelists |
 | Set the price | **Auction, per MAC-equivalent** | Protocol price controller — supply is self-reported, so it is a cartel lever |
-| Post and match jobs | **Offchain mempool; assigned, not raced** | Jobs as transactions carrying prompts — 150 s blocks vs ~24 ms prefill, permanent public prompts, duplicated work, result front-running (§5) |
+| Post and match jobs | **Gossiped offer carrying prompt *length*, not the prompt** | Jobs as transactions carrying prompts — 150 s blocks vs ~24 ms prefill, permanent public prompts, duplicated work, result front-running (§5) |
+| Deliver the prompt | **Direct, encrypted to the winning miner's serving key** | Gossiping it to the fleet — every miner would see every prompt |
 | Pay per request | **Standing escrow, settled in batches** | One settlement transaction per request — impossible at a 150 s cadence |
 | Accrue value, price fake demand | **Fixed burn fraction `β`** | Moving `β` — damps the supply response exactly when it should attract capacity |
 | Weight authenticity | **Onchain model manifest** | Trusting `HASH_B` alone — it binds *some* weights, not the certified model's |
@@ -238,6 +239,60 @@ with a latency or privacy requirement stays off it:
 The chain never sees a prompt, never sees a result, and never sits in the serving
 path. It sees an output before, and an output after.
 
+### How prompts reach miners
+
+The prompt never touches the chain (above) and never gossips to the fleet. It goes
+to exactly one miner, over a direct authenticated channel, after that miner has been
+selected.
+
+**A separate network, on the crate patterns that already exist.**
+`nockchain-libp2p-io` already provides QUIC/TLS transport, Kademlia discovery,
+request/response, gossip, bounded untrusted input, and peer/IP abuse controls. The
+inference network reuses those patterns under **its own protocol IDs**, not the
+consensus mesh — inference traffic must never be able to degrade block propagation,
+and the two have opposite tuning: consensus wants global flood, inference wants
+point-to-point.
+
+**Two phases, and the first one carries no prompt.**
+
+1. **Offer (gossiped, ~hundreds of bytes).** Manifest digest, **prompt length**,
+   max tokens, sampling params, seed, bid per MAC-equivalent, deadline, escrow
+   reference, client pubkey.
+2. **Claim (direct).** Miners with capacity respond, signed by a serving identity and
+   carrying an admission ticket.
+3. **Prompt (direct, encrypted to the winner).** The client selects a miner and sends
+   the prompt to that miner only, encrypted to its serving-identity key — the keypair
+   §5 already requires doubles as the transport key.
+4. **Response (direct).** Tokens stream back, followed by the signed fingerprint.
+
+The offer works because of a property already established: **a miner can price a job
+without seeing it.** MAC count is deterministic from `(manifest, prompt length, max
+tokens)`, so `prompt length` — not the prompt — is all a miner needs to bid. The
+economics and the privacy boundary happen to want exactly the same field.
+
+**Discovery is per session, not per request.** A gossip round trip before every
+request would put network latency in front of ~24 ms of prefill. It does not have to:
+after the first match the client keeps talking to the same miner directly, and
+re-enters discovery only on failure, deadline miss, or deliberate rotation. Combined
+with batched settlement, **both the chain and the gossip mesh are amortized across a
+session, and only serving is per request.**
+
+**What this leaks, stated plainly.** The assigned miner sees the prompt in full —
+unavoidable here (§8). Beyond that, the *offer* is public: prompt length, token
+counts, timing, and client identity go to every listening miner. Length and timing
+are a real side channel over a session, and padding token counts to buckets is the
+obvious mitigation at some cost in price granularity. The direct connection also
+reveals client network identity to the serving miner unless separately routed.
+
+**A griefing vector this transport creates.** A miner can claim a job, receive the
+prompt, and never serve — harvesting prompts for the price of one admission ticket.
+The client loses no money, since escrow never releases, but it has already disclosed
+the prompt. Ticket difficulty is therefore doing double duty: it prices claim-abandon
+*and* prompt harvesting, and the second is the harder one to price, because a
+harvested prompt may be worth far more than the compute the ticket represents.
+Deprioritizing identities that claim without delivering bounds repetition, not the
+first offence. This is a limit of the design, not a solved problem.
+
 **Settle in batches, not per request.** Even with the prompt offchain, one settlement
 transaction per request cannot work at a 150 s cadence for a service billing in
 milliseconds. A standing escrow covering many requests, settled periodically against
@@ -376,12 +431,15 @@ inference, and nothing about this design requires a fork to start.
    quantization. Calibrate across the fleet's real hardware tail — a false positive
    on an honest miner is worse than a missed detection, since Tier B catches the
    latter and nothing repairs the former.
-4. **Tier-A overhead on the serving path** — confirm the async tee is free rather
+4. **Discovery round-trip latency** on the inference mesh, against the per-session
+   amortization assumption — the claim that gossip cost disappears across a session
+   holds only if session reuse is high in practice.
+5. **Tier-A overhead on the serving path** — confirm the async tee is free rather
    than assuming it from bandwidth arithmetic.
-5. **Per-transaction certificate verification cost and a mempool admission bound** —
+6. **Per-transaction certificate verification cost and a mempool admission bound** —
    required *before* `%aip` is considered, not after. Until this has an answer, the
    design ships on existing primitives.
-6. **Off-chain defection rate**, once a market exists. The only honest way to bound
+7. **Off-chain defection rate**, once a market exists. The only honest way to bound
    `β`, and the only gate that cannot be run before launch.
 
 ## 8. Limits
@@ -406,6 +464,12 @@ verdict** — payment moves only on a certificate or a timeout, which also means
 honest miner on unusual hardware gets challenged and then exonerated. And thresholds
 are versioned, consensus-visible parameters; a silently loosened tolerance weakens
 everything with no outward sign.
+
+**A miner can harvest prompts for the price of a ticket.** Claiming a job and never
+serving costs one admission ticket and yields the prompt; escrow protects the client's
+money but not its disclosure. Ticket difficulty prices both claim-abandon and prompt
+harvesting, and the latter is harder to price because a prompt may be worth far more
+than the compute a ticket represents (§5).
 
 **Forfeiture prices griefing rather than preventing it.** §5 shows cheating does not
 pay; it does not constrain an attacker indifferent to profit. No bond would fix that

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -1,0 +1,369 @@
+# Aggregating AI-PoW miners into a verifiable inference cloud
+
+Status: Draft (design consideration)
+Owner: Nockchain Maintainers
+Last Reviewed: 2026-08-15
+Canonical/Legacy: Legacy (design exploration; no protocol authority)
+
+## Scope
+
+This document considers a mechanism for aggregating Nockchain's AI-PoW miner
+fleet into a consumer-GPU cloud that sells *verifiable inference*: a client pays
+for tokens from a named model and receives a settlement-grade guarantee that the
+tokens came from that model's real weights.
+
+It is a design exploration, not a protocol proposal. It does not change
+`PROTOCOL.md`, consensus activation, ASERT, fork choice, or block validity, and
+it deliberately stops short of code because the sampling rates it recommends
+depend on one quantity nobody in this repository has measured yet (§9).
+
+## 1. The claim
+
+Nockchain is already most of the way to a verifiable inference network, and
+almost none of the remaining distance is cryptography.
+
+The AI-PoW puzzle does not mine a synthetic matmul that merely *resembles*
+inference. Per [`crates/ai-pow/src/quant.rs`](../../crates/ai-pow/src/quant.rs),
+the production model is `pearl-ai/Llama-3.1-8B-Instruct-pearl`, served through a
+vLLM mining plugin, and the quant-extraction contract `Q` is documented as
+**bit-lossless**: a pure reindex of the operands vLLM already computed into
+`ai-pow`'s `(A, B)` layout, with no requantization. The mined integers *are* the
+inference integers.
+
+So the primitive on offer is not "a chain that could someday host inference." It
+is a fleet of consumer GPUs already executing real Llama-3.1-8B GEMMs, already
+committing to their operands, and already able to produce a compact recursive
+STARK certificate that a named tile of a named committed matmul was computed
+correctly. What is missing is the *service layer*: provenance, addressing,
+sampling, dispute, and settlement.
+
+## 2. What the repository already provides
+
+| Capability | Where | Why it matters here |
+|---|---|---|
+| Real-model INT7/INT8 GEMM as the mined unit | `ai-pow/src/quant.rs`, `params.rs::LLAMA_3_1_8B_GATE_UP` | The work is inference, not an inference-shaped mimic |
+| Merkle commitments over operand matrices | `ai-pow/src/commit.rs` (`matrix_commitment`, `a_row_leaf_hash`, `b_col_leaf_hash`) | Weights and activations can both be pinned before challenge |
+| **Proof of an arbitrary named tile** | `ai_pow_zk::canonical::StripIndexSchedule::from_tile(zk_params, tile_i, tile_j)` | Verification can target a tile *chosen after the fact*, not just a lottery winner |
+| Compact recursive certificate | `ai-pow-zk` Layers 0/1/2, `zk_bridge` | Small, verifier-owned-setup proof suitable for onchain settlement |
+| Verifier-owned setup, prover supplies none | `ai-pow-zk/docs/ARCHITECTURE.md` | A dishonest server cannot substitute its own public parameters |
+| Grouped-GEMM / MoE routing binding | `ai-pow/src/pearl_moe_routing.rs` | Extends to MoE models without a new proof system |
+| Production consumer-GPU throughput | `docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md`; commits `c8d6b13`, `330bece` | ~335–348 TMAC/s sustained on a single RTX 5090 |
+
+`StripIndexSchedule::from_tile` is the load-bearing one. The PoW path proves
+whichever tile happened to win the jackpot; that same constructor will prove a
+tile that someone else names. Every verification scheme below is built on that,
+and it already exists.
+
+The repository is also explicit that it does *not* supply what a service layer
+needs. `synth.rs` states outright that "model provenance, economic usefulness,
+and uniqueness are network policy concerns outside this deterministic generator,"
+and `ai-pow-zk/docs/SECURITY.md` disclaims "model provenance, economic
+usefulness, confidentiality, or uniqueness." Those disclaimers are precisely the
+gap this design fills — and they are policy gaps, not cryptographic ones.
+
+## 3. The load-bearing observation: decode leaves the tensor cores idle
+
+This is the fact that makes a *consumer* GPU cloud coherent rather than a
+worse-priced imitation of a datacenter one. It comes out of the roofline.
+
+An RTX 5090 has 32 GiB of GDDR7 at 1,792 GB/s and sustains ~335 TMAC/s on the
+real mining transcript. Llama-3.1-8B is ~8.03B parameters, ~8.5 GB at the shipped
+quantization, and costs ~8.03 GMAC per token.
+
+**Weights fit on one card.** No tensor parallelism, no NVLink, no collectives,
+no interconnect-sensitive placement. Each miner holds a whole model replica and
+the cloud is embarrassingly parallel at the *request* level. This is the single
+biggest reason the aggregation is tractable here and is not tractable for a
+400B-class model on the same hardware.
+
+**KV cache, not weights, caps the batch.** With ~23 GB free after weights and
+GQA KV at ~128 KiB per token across all 32 layers, the card holds ~175k KV
+tokens: roughly 20 concurrent sequences at 8k context, ~85 at 2k. That ceiling
+sits *below* the compute/bandwidth crossover, which the same roofline puts near
+batch ~198. Consumer decode is therefore permanently memory-bound.
+
+Work the consequence through at batch 32, 2k context:
+
+| Quantity | Value |
+|---|---|
+| Weight traffic per decode step | ~8.5 GB |
+| KV traffic per decode step | ~8.6 GB |
+| Step time at 1,792 GB/s | ~9.5 ms |
+| Throughput | ~3.4k tok/s |
+| Tensor-core time actually used | 32 × 24 µs ≈ 0.77 ms |
+| **INT8 tensor-core utilization** | **~8%** |
+
+During decode a consumer GPU is using something like a twelfth of its INT8
+compute. The remaining ~92% is not merely idle — it is idle *in exactly the units
+AI-PoW consumes*, with a tiny working set that does not contend for the bandwidth
+decode is starving on.
+
+Prefill is the mirror image: it is compute-bound and shaped like the puzzle
+already. `LLAMA_3_1_8B_GATE_UP` is `m=4096, k=4096, n=14336` — and in the `Q`
+convention `A` is the *activation* matrix with `m` tokens of rows. The mined work
+unit is literally a 4,096-token prefill batch. A 1,000-token prompt's prefill is
+~8.03 TMAC, ~24 ms at 335 TMAC/s.
+
+So the two workloads are complements, not competitors:
+
+- **Prefill** is compute-bound and is *already the mined shape* — serving it and
+  mining it are close to the same act.
+- **Decode** is bandwidth-bound and leaves ~92% of the tensor cores free for PoW
+  mining and for proof generation.
+
+A datacenter operator cannot exploit this as cleanly, because their economics
+assume high-batch decode on HBM parts where the idle fraction is much smaller.
+The consumer fleet's structural weakness — small memory, capped batch — is what
+creates the spare compute that pays for verification.
+
+## 4. What is missing
+
+| Gap | Severity | Note |
+|---|---|---|
+| **Coverage.** PoW proves one tile (`h·w ≤ 256`) out of a 4096×14336 = 58.7M-element output — a ~4×10⁻⁶ sample | Fundamental | Full-forward-pass ZK for 8B is out of reach; consensus caps Layer-0 trace at 2¹⁹ (`AI_POW_MAX_TRACE_HEIGHT`) |
+| **Noise.** The puzzle proves `(A+E)(B+F)`, with commitment-keyed low-rank noise for anti-reuse | Design | Inference needs clean `A·B`; needs a domain-separated statement |
+| **Provenance.** `HASH_B` binds *some* weights, not *the certified model's* | Blocking | Needs a published model manifest |
+| **Addressing.** No request mempool, matching, or escrow | Blocking | Service layer, not protocol |
+| **Privacy.** Miners see prompts and activations in the clear | Honest limit | See §10 |
+
+The coverage gap is the central one, and it does not have a cryptographic
+solution at this model scale. Proving every GEMM in a 32-layer forward pass is
+not within a factor of a few of the 2¹⁹-row Layer-0 budget; it is off by orders
+of magnitude. **The mechanism must therefore rest on a sampling-and-stake
+argument, with cryptography used to make sampling unforgeable rather than to make
+verification exhaustive.** That is the honest framing, and the rest of this
+document takes it as the premise.
+
+## 5. The mechanism: commit, sample, dispute
+
+Three tiers. Each is cheap where it is common and expensive only where it is
+rare.
+
+### Tier 1 — Commitment (every request, effectively free)
+
+The miner returns the output tokens together with a signed commitment to the
+whole computation:
+
+- the model manifest digest (§6),
+- the request digest — prompt, sampling parameters, and an explicit seed, so the
+  forward pass is deterministic and independently replayable,
+- a Merkle root over the **per-layer activation stream**, and
+- the miner's staked identity.
+
+Per-layer activations are small: 4,096 dims × 4 bytes ≈ 16 KiB per token per
+layer, ~512 KiB per token across 32 layers. Hashing that is microseconds and does
+not perturb the decode roofline in §3. Committing at layer boundaries — rather
+than to every intermediate GEMM output — is what keeps Tier 1 free.
+
+The purpose is to **pin every intermediate value before any challenge is
+issued**. After Tier 1 the miner has no remaining freedom to choose what it
+"computed."
+
+### Tier 2 — Sampled spot proofs (rare, expensive)
+
+Once the commitment is published, a public beacon the miner could not predict —
+the next block hash is already available and already unpredictable to it —
+selects a `(layer ℓ, tile i, j)`. The miner must produce the existing compact
+recursive certificate for exactly that tile:
+
+- `B` (weights) opened against the model manifest,
+- `A` (activations) opened against the Tier-1 activation root for layer ℓ,
+- the schedule from `StripIndexSchedule::from_tile`,
+- the claimed output tile.
+
+This is the current `ai-pow-zk` statement with the jackpot/target comparison
+removed and the noise zeroed. It proves: *the certified weights, times the
+activations this miner already committed to, produce the tile it claims.*
+Chained through the per-layer activation roots, a miner that fabricated any layer
+is caught whenever the beacon lands on it.
+
+Commit-then-challenge is what makes a 4×10⁻⁶ tile sample meaningful. The sample
+is tiny, but the miner must be correct *everywhere* to survive a uniformly random
+draw it cannot anticipate.
+
+### Tier 3 — Dispute by bisection (very rare)
+
+Execution is deterministic given the manifest and the seed, so any second miner,
+client, or watchtower can replay a request for roughly one forward pass of
+consumer GPU time and compare Tier-1 roots. On disagreement it opens a challenge.
+
+Because Tier 1 already commits per layer, the parties bisect over the 32-layer
+chain to the first divergent layer in ~5 rounds, then over tiles within that
+layer. The terminal step of the bisection is exactly a Tier-2 proof. One proof
+system serves both tiers; the dispute game adds no new cryptography.
+
+Failure to answer within the timeout, or an answer that verifies against a
+different value, slashes the stake.
+
+The three tiers compose into: cheap always, cryptographic sometimes, adversarial
+rarely — with cost concentrated where dishonesty is, not where throughput is.
+
+## 6. Model provenance
+
+Tier 2 is worthless if `HASH_B` can bind arbitrary weights. The network needs a
+**model manifest**: for each certified model, the per-tensor BLAKE3 Merkle roots
+in the exact layout `commit.rs` uses, plus shape, quantization group, and the
+`MatmulParams` profile per layer.
+
+Publishing the manifest onchain makes "this certificate is for the real
+Llama-3.1-8B-Instruct-pearl" a checkable statement rather than a claim. This is
+the concrete discharge of the provenance concern `synth.rs` explicitly routes to
+network policy.
+
+Note the INT-only production scoping already encoded in `params.rs`: `down_proj`
+is group_0 FP8 and is guarded off as non-mineable (`Fp8LayerNotMineable`). A
+manifest must record which layers are provable and which are attested only by
+Tier-1 commitment and Tier-3 replay. **Verifiable inference on this model is
+therefore verifiable over its INT7 group_1 linear layers, not over every FLOP in
+the forward pass** — and the service must say so plainly rather than imply
+end-to-end proof coverage.
+
+## 7. Aggregation and scheduling
+
+- **Unit of supply:** one miner = one whole-model replica on one GPU. Request-level
+  parallelism only.
+- **Matching:** clients post signed requests (manifest digest, prompt digest, max
+  tokens, sampling params, seed, price, deadline) to an offchain mempool; miners
+  claim them. Payment escrows in `$NOCK` through the existing UTXO and wallet
+  crates, releasing on Tier-1 commitment plus a quiet dispute window.
+- **Interleaving:** the miner serves inference when paid demand exists and falls
+  back to PoW otherwise — and per §3 it can do *both at once* during decode,
+  because decode leaves the tensor cores mostly free.
+- **Preemption granularity:** the CUDA miner already runs 3–50 ms batched launches
+  with cancellation on candidate replacement (`ai-pow-miner`'s stale-work path).
+  That is finer than a typical 20–50 ms per-token budget, so mining can yield to
+  inference without violating interactive latency.
+
+## 8. Economics: PoW as the reserve price
+
+The useful economic property is that Nockchain **already runs a continuous spot
+market for exactly this hardware doing exactly these GEMMs.** Block-reward EV per
+GPU-second is measurable from sustained TMAC/s and the current AI target — and
+`DIFFICULTY.md` is explicit that the target `T` prices one MAC-equivalent of
+matmul work, not one attempt, which is precisely the denomination needed.
+
+That gives a floor: inference must outbid mining EV per GPU-second, or the miner
+keeps mining. No token subsidy or bootstrapping incentive is required to price
+the fleet, and supply is elastic in both directions.
+
+**Sampling rate.** With proof cost `C_p` and request cost `C_r` (both GPU-seconds)
+and sample rate `p`, verification overhead is `p · C_p / C_r`. Holding overhead
+to a budget `β` gives `p ≤ β · C_r / C_p`.
+
+**Stake.** A miner skipping work gains at most the value of `C_r` and is detected
+with probability `p`, so honesty requires roughly `S > value(C_r) / p`.
+Substituting: `S > value(C_p) / β`. At `β = 5%`, the stake floor is about 20× the
+*value of a single proof* — not 20× the value of a request, and independent of
+request size. That is a mild requirement, and it is the reason this scheme can
+work with consumer-scale operators rather than only well-capitalized ones.
+
+Systematic cheating is bounded much more tightly than one-shot cheating, because
+Tier-3 replay is cheap and available to anyone: a miner that cheats repeatedly
+faces detection probability approaching 1.
+
+## 9. What must be measured first
+
+**The sampling rates above are unresolved until `C_p` is measured, and I have not
+found a measurement of it in this repository.** Everything else in this design is
+grounded in code or in the existing roofline; this one number is not, and I have
+deliberately not invented a value for it.
+
+Required before any of this is committed to:
+
+1. **Wall-clock cost of one compact recursive certificate** at each production
+   trace bucket 2¹³…2¹⁹ — Layer 0 + Layer 1 recursion + Layer 2 — on the target
+   consumer GPU and on CPU. `zk_bridge` already instruments `l1_circuit_build_ms`,
+   `l1_in_circuit_verify_ms`, and `l1_outer_cert_ms`, so the harness largely
+   exists. This sets `p`, and therefore the entire security/overhead trade.
+2. **Whether proving can overlap decode** without disturbing the §3 roofline, or
+   whether it contends for bandwidth after all. The 92% headroom claim is an
+   arithmetic upper bound, not a measurement.
+3. **Real served throughput** at realistic context lengths, against the roofline's
+   ~3.4k tok/s estimate, following the same measurement discipline as the RTX 5090
+   roofline (sustained clocks, real data, median of repeated runs — the roofline
+   doc's warning that synthetic all-ones inputs inflate results by 22–30% applies
+   here too).
+4. **Cost of the zero-noise inference statement**, and confirmation that
+   domain-separating it cannot weaken the PoW anti-reuse invariant.
+
+## 10. Risks and honest limits
+
+**No prompt privacy.** The miner sees prompts and activations in the clear, and
+mid-stack activations are substantially invertible. The ZK layer here proves
+*correctness*, not confidentiality — the client's input is not a secret from the
+prover, it is an input to it. Any claim otherwise would be false. Realistic
+options are to scope the service to non-sensitive workloads, or to keep the first
+and last layers client-side so miners see only mid-stack activations, which
+narrows but does not close the exposure.
+
+**Statement separation is a security requirement, not hygiene.** An inference
+certificate must never be replayable as a PoW certificate or vice versa. Zeroing
+the noise removes the anti-reuse property the puzzle depends on
+(`ai-pow/docs/2026-07-17_DUAL_PUZZLE_CONSENSUS_AUDIT.md`, finding F01: cached
+nonce-independent state let a miner grind without fresh inference). Domain
+separation must be enforced at the statement level and tested adversarially in
+both directions.
+
+**Consensus surface growth is the main systemic risk.** This repository's own
+audit record — the dual-puzzle consensus audit and
+`2026-07-29_TIME_BANKED_FORK_EXPLOIT.md` — shows how readily dual-puzzle
+economics produce exploits that are invisible in the component crates. A dispute
+game with timeouts and slashing added to the consensus kernel is a large new
+attack surface against a chain whose fork choice is already carrying two puzzles.
+
+The mitigation follows the repository's own stated architecture rather than
+fighting it. `README.md`: "Applications execute offchain as sovereign NockApps and
+can settle verifiable results to the shared chain." **The inference cloud should
+be a NockApp** — mempool, matching, escrow, and the bisection game all offchain,
+settling only outcomes to the chain. The consensus kernel should learn nothing
+about inference beyond what it already verifies. Only the model manifest registry
+plausibly belongs onchain, and even that could start as a NockApp with a
+well-known root.
+
+**Verification is partial by construction.** Tier 2 covers INT7 group_1 linears.
+Attention, normalization, activation functions, sampling, and the FP8 layers are
+covered by Tier-1 commitment and Tier-3 replay determinism, not by proof. This is
+a real and permanent limit at this model scale, and the service must market
+itself accordingly.
+
+## 11. Staged plan
+
+Ordered so that each stage produces something independently checkable, and so
+that the measurement gate precedes the design commitments that depend on it.
+
+1. **Measure `C_p`** (§9). Nothing downstream is well-posed without it.
+2. **Model manifest format and registry**, offline first: per-tensor roots in
+   `commit.rs` layout, per-layer provable/attested classification, conformance KAT
+   against the shipped model.
+3. **Zero-noise inference statement** in `ai-pow`, domain-separated from the PoW
+   statement, with cross-replay rejection tests in both directions.
+4. **Tier-1 commitment path** in the vLLM plugin boundary: per-layer activation
+   roots emitted on the serving path, with the overhead measured against §9.2.
+5. **Tier-2 spot proof**, driven by block-hash beacon selection through
+   `StripIndexSchedule::from_tile`.
+6. **Tier-3 bisection game** as a NockApp, with escrow and slashing; consensus
+   untouched.
+7. **Scheduler and interleaving**, including PoW/inference preemption at the
+   existing cancellation granularity.
+
+Stages 2–5 are additive and carry no consensus risk. Stage 6 is where the real
+design review is owed, and it should be reviewed against the existing dual-puzzle
+audit findings rather than in isolation.
+
+## 12. Summary
+
+The cryptography for verifiable inference on Nockchain largely exists; the
+missing pieces are provenance, addressing, sampling policy, and settlement. The
+mechanism that fits the hardware is commit-then-challenge with staked dispute:
+free commitments on every request, unforgeable random spot proofs, and cheap
+deterministic replay as the backstop.
+
+The structural argument for consumer GPUs specifically is that an 8B model fits
+on one card — so the fleet needs no interconnect — and that KV-capped decode
+leaves ~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes.
+The verification is paid for out of compute that the serving workload cannot use.
+
+The honest limits are that proof coverage is a sample over the INT7 linear layers
+rather than the whole forward pass, that miners see prompts, and that the dispute
+game is the one genuinely risky addition — which is why it belongs in a NockApp
+and not in the consensus kernel.

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -133,8 +133,8 @@ creates the spare compute that pays for verification.
 The coverage gap is the central one, and it does not have a cryptographic
 solution at this model scale. Proving every GEMM in a 32-layer forward pass is
 not within a factor of a few of the 2¹⁹-row Layer-0 budget; it is off by orders
-of magnitude. **The mechanism must therefore rest on a sampling-and-stake
-argument, with cryptography used to make sampling unforgeable rather than to make
+of magnitude. **The mechanism must therefore rest on a detection-and-forfeiture
+argument, with cryptography used to make detection unforgeable rather than to make
 verification exhaustive.** That is the honest framing, and the rest of this
 document takes it as the premise.
 
@@ -188,7 +188,7 @@ The miner signs, and publishes, a commitment binding:
   disputes can bisect (32 layers × 258 B/32 tokens ≈ 8 KiB per 32 tokens — still
   negligible),
 - the BLAKE3 roots of the **integer GEMM operands** for the provable layers, and
-- the miner's staked identity.
+- the miner's **work-backed serving identity** (§8.6).
 
 The purpose is to **pin the computation before any challenge is issued.** After
 Tier 1 the miner has no remaining freedom to choose what it "computed."
@@ -242,9 +242,11 @@ divergent layer in ~5 rounds, then to tiles within it. The terminal step is
 exactly a Tier-2 proof: one proof system serves both, and the dispute game adds
 no new cryptography.
 
-**A fingerprint mismatch escalates; it never slashes directly.** Tier 0 is a
-trigger, not a verdict — see §10.5. Slashing follows only from a failed or
-contradicted Tier-2 certificate, or from a timeout.
+**A fingerprint mismatch escalates; it is never itself an adverse finding.** Tier 0
+is a trigger, not a verdict — see §10.5. Consequences follow only from a failed or
+contradicted Tier-2 certificate, or from a timeout, and they are forfeiture of
+payment plus retirement of the serving identity — never seizure of posted capital
+(§8.6).
 
 ### Why both, and not either alone
 
@@ -287,9 +289,10 @@ end-to-end proof coverage.
   parallelism only.
 - **Matching:** clients post signed requests (manifest digest, prompt digest, max
   tokens, sampling params, seed, bid per MAC-equivalent, deadline) to an offchain
-  mempool; miners claim them. Payment escrows in `$NOCK` through the existing UTXO
-  and wallet crates and settles on Tier-1 commitment plus a quiet dispute window,
-  splitting `(1−β)` to the miner and `β` to a `%brn` output (§8).
+  mempool; miners claim them with an admission ticket signed by a work-backed
+  serving identity (§8.7). Payment escrows in `$NOCK` through the existing UTXO and
+  wallet crates and settles only *after* verification, splitting `(1−β)` to the
+  miner and `β` to a `%brn` output (§8). Miners post no capital at any point.
 - **Interleaving:** the miner serves inference when paid demand exists and falls
   back to PoW otherwise — and per §3 it can do *both at once* during decode,
   because decode leaves the tensor cores mostly free.
@@ -343,8 +346,8 @@ The usual argument for a burn is deflation. That is real here given the 2³² ha
 cap, but it is the weaker reason. Two stronger ones:
 
 **Burn is the only self-dealing-proof payment rail.** The Tier-1/2/3 design in §5
-secures *correctness* — that a miner computed what it claimed — through stake and
-slashing. It does nothing whatsoever about **fake demand**: a miner paying itself
+secures *correctness* — that a miner computed what it claimed — through detection
+and forfeiture. It does nothing whatsoever about **fake demand**: a miner paying itself
 to manufacture the appearance of volume. That matters wherever serving volume
 becomes visible and valuable — advertising utilization to attract real clients,
 reputation weighting in the scheduler, or any future rule that lets volume
@@ -413,7 +416,7 @@ Not fairness, and not revenue maximization: **the off-chain escape hatch.**
 A miner and client can always settle privately and never touch the chain. The
 burn is a tax on using the onchain rail, so `β` must stay below what that rail is
 worth to the marginal client — escrow, the unpredictable beacon that makes Tier-2
-sampling unforgeable, slashing, and dispute adjudication. Sophisticated repeat
+sampling unforgeable, and dispute adjudication. Sophisticated repeat
 counterparties who already trust each other will defect off-chain at *any* `β`;
 the rail's real market is strangers and one-shot interactions, which is also
 exactly where verifiability is worth paying for.
@@ -426,66 +429,140 @@ One consequence: keep the split two-way. Adding the Aletheia protocol fund as a
 third claimant on inference revenue raises the tax on the rail without a clear
 need, and the fund is already financed from issuance. Cheap rail, narrow split.
 
-### 8.6 Slashing, refunds, and paying the challenger
+### 8.6 No bonds: forfeiture is the whole enforcement mechanism
 
-The burn interacts with §5's dispute tier, and getting this wrong makes Tier 3
-theater.
+**This is a pure proof-of-work system, and nothing about serving inference should
+require posting capital.** A bond that can be seized is stake under another name —
+attaching a signing pubkey to it changes who signs, not what is at risk. If the
+objective is to keep the chain's security denominated in work rather than capital,
+the bond has to go, not be renamed.
 
-- **The client's payment is refunded, never burned, on a failed proof.** If
-  clients bore the cost of miner misbehavior the service would be unusable.
-- **Slashed stake splits between challenger bounty and burn.** Burning 100% leaves
-  challengers unfunded — nobody spends a forward pass to catch a cheat for free,
-  and the whole tier collapses. Paying 100% to the challenger funds griefing
-  between competing miners. Size the bounty to somewhat exceed replay cost and
-  burn the remainder.
+It can go, and the analogy that shows how is already in the protocol: **an invalid
+block does not seize anything from the miner who produced it. It simply wastes the
+work.** Orphaning is a complete deterrent with no capital at risk, because the
+miner has already spent the electricity. Serving should work the same way.
 
-### 8.7 Sampling rate and stake
+**Verify before pay, never pay before verify.** Restructure so a miner is never
+paid ahead of verification. Then there is nothing to claw back and nothing to
+seize, because the escrow simply never releases. What a cheating miner loses is:
 
-With proof cost `C_p` and request cost `C_r`, sample rate `p` gives verification
-overhead `p · C_p / C_r`. Holding it to a budget `β_v` gives `p ≤ β_v · C_r / C_p`.
+- the payment, which returns to the client;
+- the GPU-seconds it already spent, which are sunk; and
+- the **mining EV it forwent** by serving instead of mining that window.
 
-A miner skipping work gains at most `value(C_r)` and is detected with probability
-`p`, so honesty requires `S > value(C_r) / p`. Substituting:
-**`S > value(C_p) / β_v`**. At a 5% verification budget, the stake floor is ~20×
-the value of a *single proof* — not of a request, and independent of request size.
-That mildness is why this can work with consumer-scale operators rather than only
-well-capitalized ones.
+That third term is the collateral, and it is denominated in proof-of-work. The
+miner posted nothing — it *spent* something, which is the only currency a PoW
+chain should ask for.
 
-**Tier 0 changes what `p` has to buy, and this is its largest economic effect.**
+**Ordering.** Client escrows payment with the request; miner claims with an
+admission ticket (below) signed by its serving identity; miner serves and publishes
+tokens, fingerprint, and commitment; client verifies at ~1% of serving cost, or
+accepts; escrow releases `(1−β)/β` on pass. On failure the beacon selects a tile
+and the miner must answer with a Tier-2 certificate. A verifying certificate
+releases the escrow to the miner — a spurious challenge does not win. A failed or
+absent certificate refunds the client and retires the identity.
 
-The most profitable cheat in a consumer GPU cloud is not fabricating outputs —
-those have to look plausible, which is hard. It is **serving a cheaper precision
-or a smaller model than was paid for**: a 2–4× cost saving on *every* request,
-indefinitely, with outputs that read as fine. Under ZK sampling alone that is
-caught at rate `p`, so the cheat earns roughly `1/p` requests of free margin
-before detection. TOPLOC detects precision and model substitution on **every**
-request, collapsing detection latency from `~1/p` requests to one.
+### 8.7 Work-backed serving identity
 
-So `p` no longer has to deter the cheap, high-volume cheats. It only has to deter
-the residual adversary who constructs activations that spoof top-`k` under the
-published tolerance while actually running a cheaper computation — a far narrower
-and far more expensive attack. **The same security is bought at a materially lower
-`p`**, which lowers verification overhead and, through `S > value(C_p) / β_v`, the
-stake floor with it.
+The salvageable half of the bond idea is the **pubkey**, without the capital behind
+it. A serving identity is a keypair whose standing comes from work rather than from
+a deposit:
 
-That feeds back into §8.5: a cheaper verification layer makes the onchain rail
-cheaper overall, which widens the headroom between `β` and the off-chain escape
-hatch.
+- **Admission costs work.** Activating an identity requires a PoW ticket — the same
+  puzzle at lower difficulty, priced in the same MAC-equivalents as everything else
+  (§8.2). This is what makes identities Sybil-resistant without capital.
+- **Claiming a request costs a ticket too.** A miner that claims work and abandons
+  it has burned real compute for nothing, which is the bondless answer to
+  claim-and-abandon griefing.
+- **Challenging costs a ticket, symmetrically.** This is what stops a client from
+  disputing every request to avoid paying; the certificate resolves who was right,
+  and the challenger's ticket is spent either way.
+- **History accrues to the identity.** Verified served requests earn scheduler
+  preference and access to higher-value work.
+- **A proven failure retires the identity** rather than seizing anything. The cost
+  of misbehavior is having to redo the admission work and rebuild the history —
+  exactly the cost structure of losing a block to a reorg.
 
-Two second-order effects, both favorable:
+No capital is locked at any point, so there is no minimum-capital barrier to a
+consumer operator joining, and no capital-seizure logic anywhere in the protocol.
 
-- **Challenger economics.** §8.6 needs a bounty large enough to pay someone to
-  catch a cheat. At up to 100× cheaper than generation, a challenge costs ~1% of
-  serving, so the bounty can be small — which also shrinks the griefing incentive
-  that an oversized bounty would create.
-- **Client-side verification becomes the default posture.** At that cost a client
-  can verify *all* of its own traffic rather than trusting a sampled deterrent.
-  The trust model shifts from "sampled deterrence" to "client-verified by default,
-  with the STARK as the escalation path when a client and miner disagree."
+### 8.8 What forfeiture alone actually buys
 
-Systematic cheating is bounded far more tightly than one-shot cheating: replay is
-cheap and available to anyone, so a repeat cheat faces detection probability
-approaching 1.
+Let `M` be mining EV per GPU-second (§8.1), `C_r` the GPU-seconds to serve
+honestly, `γ > 1` the cheat's compute advantage (so cheating costs `C_r/γ` and the
+remainder can be spent mining), `P` the payment, and `q` the probability of
+detection *before escrow releases*. Write `ρ = P / (M·C_r)` for the premium
+inference pays over simply mining — necessarily `ρ > 1`, or nobody serves.
+
+Over a window of `C_r` GPU-seconds, honest serving earns `P`, while cheating earns
+`(1−q)P + M·C_r(1 − 1/γ)`. Cheating fails to pay when:
+
+```text
+q  >  (1 − 1/γ) / ρ
+```
+
+| `γ` (cheat advantage) | `ρ = 1` | `ρ = 1.5` | `ρ = 2` | `ρ = 3` |
+|---|---:|---:|---:|---:|
+| 1.5 | 0.333 | 0.222 | 0.167 | 0.111 |
+| 2 | 0.500 | 0.333 | 0.250 | 0.167 |
+| 4 (INT4 for INT7) | 0.750 | 0.500 | 0.375 | 0.250 |
+| 8 | 0.875 | 0.583 | 0.438 | 0.292 |
+
+Two readings, and the second is why this design can drop bonds at all.
+
+**Without Tier 0, bondless enforcement is hopeless.** ZK sampling gives `q = p ≈
+0.01–0.05`. Every row of that table is out of reach. This is precisely why the
+earlier drafts needed stake: capital was substituting for a detection probability
+the verification layer could not deliver.
+
+**With Tier 0, `q ≈ 1` for exactly the cheats that have favourable `γ`.** Precision
+and model substitution — the high-`γ`, high-volume cheats that dominate the
+economics (§8.9) — are caught on every response, and cheaply enough that clients
+verify their own traffic in full. Every row is satisfied with enormous margin.
+
+Note also the reassuring monotonicity: **the more inference pays over mining, the
+less detection is needed**, because forfeiting a larger premium hurts more. The
+mechanism gets safer exactly as the market gets more valuable.
+
+**The residual adversary closes the argument.** For the attack Tier 0 cannot bound
+— constructing activations that spoof top-`k` under tolerance — the attacker
+plausibly needs the honest result to aim at, so `γ ≤ 1` and the right-hand side
+goes non-positive: **an attack that costs more than honest work needs no deterrent
+at all.** The gap between "cheats TOPLOC catches" and "cheats worth attempting" is
+what makes the bondless construction close. That is an argument, not a theorem, and
+`γ` for adversarial spoofing is a measurement gate (§9), not an assumption.
+
+### 8.9 Which cheat the economics are actually about
+
+The dominant cheat in a consumer GPU cloud is not fabricating outputs — those must
+look plausible, which is hard. It is **serving a cheaper precision or a smaller
+model than was paid for**: a 2–4× saving on *every* request, indefinitely, with
+outputs that read as fine. That is the `γ = 2…4` row above, and it is the case
+Tier 0 detects on every response at essentially no cost.
+
+Under ZK sampling alone that cheat earns roughly `1/p` requests of free margin
+before detection. Under Tier 0 it earns none.
+
+### 8.10 Funding the challenge, without a bond to seize
+
+The earlier draft paid challengers out of seized stake. With no stake, the burn leg
+funds it: **on a proven failure, the `β` that would have burned pays the
+challenger instead**, and the client is refunded in full. No new money, no bond,
+and the burn simply does not happen in the case where verification had to be paid
+for.
+
+This matters much less than it would have. At ~100× cheaper verification the
+natural challenger is the *client itself*, already motivated by its own refund, so
+third-party watchtowers are a supplement rather than the load-bearing role. And
+because challenging costs an admission ticket (§8.7), the griefing incentive an
+oversized bounty would create is bounded by work rather than by policy.
+
+Two invariants survive from the bonded design:
+
+- **The client's payment is refunded, never burned, on a failed proof.** If clients
+  bore the cost of miner misbehavior the service would be unusable.
+- **A certificate, not an assertion, decides.** Escrow releases on cryptography, so
+  neither party can win a dispute by insisting.
 
 ## 9. What must be measured first
 
@@ -521,7 +598,12 @@ Required before any of this is committed to:
    the former.
 6. **Tier-0 overhead on the serving path**: confirm the async tee costs neither
    TTFT nor throughput, rather than assuming it from the bandwidth arithmetic.
-7. **Off-chain defection rate** once a market exists. This is the only honest way
+7. **`γ` for adversarial top-`k` spoofing** (§8.8). The bondless construction closes
+   on the claim that spoofing the fingerprint costs *more* than serving honestly.
+   That is an argument, not a theorem, and it is the load-bearing one now that no
+   capital backstops a mistake. Attack it directly: try to produce a materially
+   cheaper computation whose top-`k` last-hidden-state values survive tolerance.
+8. **Off-chain defection rate** once a market exists. This is the only honest way
    to bound `β` (§8.5), and unlike the others it cannot be measured before
    launch — which is the argument for shipping a deliberately low constant `β`
    and raising it against evidence, rather than starting high.
@@ -548,8 +630,11 @@ both directions.
 audit record — the dual-puzzle consensus audit and
 `2026-07-29_TIME_BANKED_FORK_EXPLOIT.md` — shows how readily dual-puzzle
 economics produce exploits that are invisible in the component crates. A dispute
-game with timeouts and slashing added to the consensus kernel is a large new
-attack surface against a chain whose fork choice is already carrying two puzzles.
+game with timeouts added to the consensus kernel is a large new attack surface
+against a chain whose fork choice is already carrying two puzzles. Dropping bonds
+helps here as well as economically: with no capital to seize, the kernel never
+needs seizure logic, and the worst outcome of a dispute bug is a misrouted payment
+rather than a confiscation.
 
 The mitigation follows the repository's own stated architecture rather than
 fighting it. `README.md`: "Applications execute offchain as sovereign NockApps and
@@ -569,6 +654,15 @@ halves: soundly proven on a sampled tile of the integer linear path, empirically
 fingerprinted end to end. No amount of layering turns the second into the first at
 this model scale.
 
+**Forfeiture does not deter a griefer.** The §8.8 argument shows cheating does not
+*pay*; it does not show that an attacker indifferent to profit will not serve
+garbage to degrade the network. No bond fixes this either — a well-funded griefer
+posts and forfeits capital just as readily — but the honest statement is that the
+bondless design's protection here is the per-claim admission ticket (§8.7), which
+prices griefing in work rather than preventing it. Whether that price is high
+enough is a live question and depends on ticket difficulty, which is a policy dial
+this document does not set.
+
 **Tier 0 must not be allowed to displace Tier 2**, and this is the most likely way
 the design degrades in practice — it will arrive looking like a cost optimization.
 
@@ -583,11 +677,11 @@ perturbation is a strictly stronger property and is not established.
 
 Three consequences:
 
-- **Tier 0 escalates; it never slashes.** A fingerprint mismatch opens a Tier-2
-  challenge. Money moves on a failed or contradicted certificate, or on a timeout,
-  never on a fingerprint alone. This also contains the false-positive risk from
-  §9.5 — an honest miner on unusual hardware gets challenged, not slashed, and the
-  certificate exonerates it.
+- **Tier 0 escalates; it is never itself a verdict.** A fingerprint mismatch opens
+  a Tier-2 challenge. Payment is withheld only on a failed or contradicted
+  certificate, or on a timeout, never on a fingerprint alone. This also contains the
+  false-positive risk from §9.5 — an honest miner on unusual hardware gets
+  challenged, and the certificate exonerates it and releases its payment.
 - **Keep `p` strictly positive** however good Tier 0 looks in production. Its whole
   job is deterring the adversary Tier 0 cannot bound, and that adversary's absence
   from the logs is not evidence of their impossibility: a cheat designed to pass
@@ -614,8 +708,8 @@ that the measurement gate precedes the design commitments that depend on it.
 6. **Burn-split settlement** over the existing `%brn` primitive: per-MAC bid
    escrow, `(1−β)/β` split on success, refund on failed proof. No price
    controller; `β` fixed for the first deployment.
-8. **Tier-3 bisection game** as a NockApp, with slashing and the challenger
-   bounty; consensus untouched.
+8. **Tier-3 bisection game** as a NockApp: challenge, certificate, forfeiture, and
+   identity retirement. No capital-seizure path anywhere; consensus untouched.
 9. **Scheduler and interleaving**, including PoW/inference preemption at the
    existing cancellation granularity.
 
@@ -627,33 +721,48 @@ dial is worth its attack surface.
 
 ## 12. Summary
 
-The cryptography for verifiable inference on Nockchain largely exists; the
-missing pieces are provenance, addressing, sampling policy, and settlement. The
-mechanism that fits the hardware is commit-then-challenge with staked dispute:
-free commitments on every request, unforgeable random spot proofs, and cheap
-deterministic replay as the backstop.
+The cryptography for verifiable inference on Nockchain largely exists; the missing
+pieces are provenance, addressing, verification policy, and settlement. The
+mechanism that fits the hardware is layered commit-then-challenge with
+forfeiture-based dispute: a near-free locality-sensitive activation fingerprint on
+every response, unforgeable random STARK spot proofs, and cheap replay as the
+backstop. The two verification layers are chosen for complementary blind spots —
+the fingerprint covers the whole forward pass but is statistical, the STARK is
+sound but covers one tile — and neither suffices alone.
 
-The structural argument for consumer GPUs specifically is that an 8B model fits
-on one card — so the fleet needs no interconnect — and that KV-capped decode
-leaves ~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes.
-The verification is paid for out of compute that the serving workload cannot use.
+The structural argument for consumer GPUs specifically is that an 8B model fits on
+one card — so the fleet needs no interconnect — and that KV-capped decode leaves
+~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes. The
+verification is paid for out of compute that the serving workload cannot use.
+
+**Nothing in it requires posting capital.** Because the miner is never paid before
+verification, a cheat forfeits the payment, the compute it already spent, and the
+mining EV it gave up to serve — collateral denominated in work, not capital, which
+is what a proof-of-work chain should be asking for. Identities are backed by
+admission tickets rather than bonds, and a proven failure retires an identity
+instead of seizing anything, exactly as an orphaned block wastes work without
+confiscating it. That construction closes only because Tier 0 pushes detection
+probability near 1 on the cheats worth attempting; with STARK sampling alone the
+required detection rates are unreachable and capital would have to substitute for
+them.
 
 Settlement should be a burn split, denominated per MAC-equivalent so the manifest
 makes every request's quantity objective in advance. The burn's primary job is not
-deflation but making fake demand cost something — it is the only payment rail on
-which a miner cannot wash its own volume for free — and, against a hard supply cap,
-the only way inference demand can raise the real value of the 64-NOCK floor that
-funds long-run security. Price should be set by auction rather than by a protocol
+deflation but making fake demand cost something — it is the only rail on which a
+miner cannot wash its own volume for free — and, against a hard supply cap, the
+only way inference demand can raise the real value of the 64-NOCK floor that funds
+long-run security. Price should come from auction rather than a protocol
 controller: supply is self-reported and therefore a cartel lever, so the protocol
-should fix the split and let the market fix the price.
+fixes the split and the market fixes the price.
 
 The honest limits are that only one verification layer is cryptographically sound
 and it samples the INT7 linear path, that end-to-end coverage is statistical and
 rests on adversarial robustness nobody has yet stress-tested with money on the
-line, that miners see prompts, that `β` is bounded by
-an off-chain escape hatch nobody can measure before launch, and that the dispute
-game is the one genuinely risky addition — which is why it belongs in a NockApp
-and not in the consensus kernel.
+line, that miners see prompts, that forfeiture deters profit-seeking cheats but
+only prices griefing rather than preventing it, that `β` is bounded by an
+off-chain escape hatch nobody can measure before launch, and that the dispute game
+is the one genuinely risky addition — which is why it belongs in a NockApp and not
+in the consensus kernel.
 
 ## References
 

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -429,18 +429,52 @@ One consequence: keep the split two-way. Adding the Aletheia protocol fund as a
 third claimant on inference revenue raises the tax on the rail without a clear
 need, and the fund is already financed from issuance. Cheap rail, narrow split.
 
-### 8.6 No bonds: forfeiture is the whole enforcement mechanism
+### 8.6 Forfeiture, and why it makes bonds redundant rather than forbidden
 
-**This is a pure proof-of-work system, and nothing about serving inference should
-require posting capital.** A bond that can be seized is stake under another name —
-attaching a signing pubkey to it changes who signs, not what is at risk. If the
-objective is to keep the chain's security denominated in work rather than capital,
-the bond has to go, not be renamed.
+First, a distinction this document previously elided. **A non-yielding performance
+bond is not staking**, and it is worth being precise about why, because the
+imprecise version ("a bond you can seize is stake under another name") is
+rhetorically convenient and analytically wrong.
 
-It can go, and the analogy that shows how is already in the protocol: **an invalid
-block does not seize anything from the miner who produced it. It simply wastes the
-work.** Orphaning is a complete deterrent with no capital at risk, because the
-miner has already spent the electricity. Serving should work the same way.
+What makes staking *staking*, in the sense a proof-of-work chain should refuse, is
+three properties together:
+
+1. the bonded capital **earns yield** proportional to itself, so money begets money
+   without work;
+2. it confers **consensus weight** — capital buys the right to produce blocks or
+   order transactions; and
+3. it becomes **the security budget**, displacing work as the thing that secures
+   the chain.
+
+A performance bond that pays no yield, carries no fork-choice weight, and secures
+an application-layer service agreement has none of those. It is a surety deposit,
+closer to an escrowed damages cap than to a validator stake. Someone objecting to
+it on PoS grounds is objecting to the wrong thing.
+
+**So the argument against requiring one has to be made on its merits, and it is a
+different argument: with detection near-certain, a bond buys nothing.**
+
+The analogy is already in the protocol: **an invalid block does not seize anything
+from the miner who produced it. It simply wastes the work.** Orphaning is a
+complete deterrent with no capital at risk, because the miner has already spent the
+electricity. Serving can work the same way — and §8.8 shows that once Tier 0 pushes
+detection probability near 1, forfeited payment plus forgone mining EV *already*
+exceeds what any profitable cheat could gain. A bond stacked on top of that is
+redundant collateral against a loss the miner is already fully exposed to.
+
+Redundant is a weaker claim than forbidden, and it is the one that survives
+scrutiny. Two costs then decide it, and both argue for keeping the base path
+bondless:
+
+- **A bond is a capital barrier to entry.** §3's entire thesis is that one person
+  with one consumer card can join. Any mandatory locked balance sets a floor on
+  participation that has nothing to do with whether that person's GPU computes
+  correctly.
+- **Locked `$NOCK` has a real opportunity cost precisely because it does not
+  yield.** Against a hard-capped asset this design is deliberately making scarcer
+  (§8.3), capital that cannot be sold, spent, or moved is genuinely expensive to
+  post — which is a point in favour of the user's framing (no rentier dynamic,
+  no yield) and simultaneously a reason not to demand it of everyone.
 
 **Verify before pay, never pay before verify.** Restructure so a miner is never
 paid ahead of verification. Then there is nothing to claw back and nothing to
@@ -464,9 +498,10 @@ absent certificate refunds the client and retires the identity.
 
 ### 8.7 Work-backed serving identity
 
-The salvageable half of the bond idea is the **pubkey**, without the capital behind
-it. A serving identity is a keypair whose standing comes from work rather than from
-a deposit:
+Independently of whether anyone posts a bond, the base path needs an identity that
+is expensive to create and worth keeping. A serving identity is a keypair whose
+standing comes from work rather than from a deposit — which is what lets the
+default path require no capital at all:
 
 - **Admission costs work.** Activating an identity requires a PoW ticket — the same
   puzzle at lower difficulty, priced in the same MAC-equivalents as everything else
@@ -543,10 +578,10 @@ Tier 0 detects on every response at essentially no cost.
 Under ZK sampling alone that cheat earns roughly `1/p` requests of free margin
 before detection. Under Tier 0 it earns none.
 
-### 8.10 Funding the challenge, without a bond to seize
+### 8.10 Funding the challenge on the bondless path
 
-The earlier draft paid challengers out of seized stake. With no stake, the burn leg
-funds it: **on a proven failure, the `β` that would have burned pays the
+An earlier draft paid challengers out of seized collateral. With no bond on the
+base path, the burn leg funds it instead: **on a proven failure, the `β` that would have burned pays the
 challenger instead**, and the client is refunded in full. No new money, no bond,
 and the burn simply does not happen in the case where verification had to be paid
 for.
@@ -563,6 +598,31 @@ Two invariants survive from the bonded design:
   bore the cost of miner misbehavior the service would be unusable.
 - **A certificate, not an assertion, decides.** Escrow releases on cryptography, so
   neither party can win a dispute by insisting.
+
+### 8.11 Where a bond does real work: an optional assurance tier
+
+Forfeiture caps the miner's exposure at the fee. That is sufficient for deterrence
+(§8.8) and insufficient for **compensation** whenever a client's downside exceeds
+what it paid — inference costing a fraction of a cent feeding a decision worth far
+more. No detection probability fixes that; the gap is between deterrence and
+indemnity, and only capital closes it.
+
+So the useful form of the bond idea is **optional and market-priced, never
+protocol-mandated**:
+
+- A miner *may* post a non-yielding performance bond against its serving identity
+  to become eligible for higher-assurance work.
+- Clients needing recourse beyond fee forfeiture route to bonded miners and pay a
+  premium for it.
+- On a proven failure the bond compensates the client up to the posted amount, on
+  top of the refund.
+- The protocol pays no yield on it, grants it no fork-choice weight, and never
+  requires it.
+
+This keeps the base path pure proof-of-work and open to anyone with one GPU, while
+letting a market — rather than a protocol parameter — decide how much indemnity a
+given workload is worth. It is the same posture §8.4 takes on price: fix the
+structure, let the market set the level.
 
 ## 9. What must be measured first
 
@@ -735,8 +795,11 @@ one card — so the fleet needs no interconnect — and that KV-capped decode le
 ~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes. The
 verification is paid for out of compute that the serving workload cannot use.
 
-**Nothing in it requires posting capital.** Because the miner is never paid before
-verification, a cheat forfeits the payment, the compute it already spent, and the
+**Nothing in it requires posting capital**, though nothing forbids it either. A
+non-yielding performance bond is not staking — it earns no yield, carries no
+fork-choice weight, and does not become the security budget — so the case against
+*requiring* one rests on redundancy rather than principle: because the miner is
+never paid before a cheat forfeits the payment, the compute it already spent, and the
 mining EV it gave up to serve — collateral denominated in work, not capital, which
 is what a proof-of-work chain should be asking for. Identities are backed by
 admission tickets rather than bonds, and a proven failure retires an identity

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -95,6 +95,8 @@ One mechanism per purpose. Alternatives are named here and not carried further.
 | Make cheating unprofitable | **Forfeiture: never pay before verify** | Bonds — redundant once detection is near-certain (§5) |
 | Sybil / claim-abandon resistance | **One PoW admission ticket per claim** | Reputation, capital deposits, whitelists |
 | Set the price | **Auction, per MAC-equivalent** | Protocol price controller — supply is self-reported, so it is a cartel lever |
+| Post and match jobs | **Offchain mempool; assigned, not raced** | Jobs as transactions carrying prompts — 150 s blocks vs ~24 ms prefill, permanent public prompts, duplicated work, result front-running (§5) |
+| Pay per request | **Standing escrow, settled in batches** | One settlement transaction per request — impossible at a 150 s cadence |
 | Accrue value, price fake demand | **Fixed burn fraction `β`** | Moving `β` — damps the supply response exactly when it should attract capacity |
 | Weight authenticity | **Onchain model manifest** | Trusting `HASH_B` alone — it binds *some* weights, not the certified model's |
 | Consensus integration | **None — existing primitives only (§6)** | A new lock primitive up front — it is a tx-engine change putting a STARK verifier in transaction validation; deferred to §6 |
@@ -188,6 +190,60 @@ allocation decision is a scalar comparison. The manifest fixes every shape, so a
 request's MAC count is deterministic from `(manifest, prompt length, max tokens)` and
 computable by both parties **before** execution — no metering to trust, no billing
 dispute surface. Quantity is objective; only price is negotiated, by auction.
+
+### What stays offchain, and why
+
+A natural reading of "settle inference onchain" is that jobs are *posted* as
+transactions — an output carrying the prompt under a lock that anyone can spend by
+performing the inference. It is a clean idea and it does not survive contact with
+this chain's parameters. Four reasons, any one of which is disqualifying:
+
+**Latency.** Post-Aletheia block time is **150 s**. Prefill of a 1,000-token prompt
+is **~24 ms**. Posting a job as a transaction means waiting for inclusion before a
+miner can even see it, and waiting again to settle: roughly 300 s of round trip
+around 24 ms of work, ~4 orders of magnitude of overhead. Interactive serving is
+impossible at that cadence no matter how the lock is written.
+
+**Permanence and bloat.** A prompt in a transaction is public forever, replicated to
+every node. That is a much stronger disclosure than §8's "miners see prompts" — it is
+*everyone, permanently*. It also puts kilobytes of application payload into a UTXO
+chain's permanent state, which size-based fees will price but never un-store.
+
+**Racing wastes the exact resource this design exists to conserve.** If any miner can
+claim by doing the work, `N` miners race and `N−1` results are discarded. Mining
+races are fine because the work *is* the lottery; here the work has a client who
+wanted it done once. A job that is *assigned* is computed once; a job that is
+*claimable* is computed as many times as there are bidders.
+
+**Front-running.** If the result rides in the spending transaction, a second miner
+reads it from the mempool and re-submits with a higher fee, collecting the payment
+without doing the work. Fixing that needs commit–reveal, which costs another block
+round trip and makes the latency worse.
+
+There is a fifth, structural: "spendable by completing the inference properly" means
+the *lock* must verify the work — which is exactly the `%aip` transaction-engine
+change §6 argues out of a first deployment. The posting model does not avoid that
+cost, it requires it.
+
+**The split that does work.** The chain holds the *payment commitment*; everything
+with a latency or privacy requirement stays off it:
+
+| Onchain | Offchain |
+|---|---|
+| Escrowed payment, `%pkh` + `%tim` | The prompt |
+| Request **digest** only | Matching and claiming |
+| Settlement: `(1−β)` + `%brn` | The result |
+| A certificate, only on dispute | Certificate verification, normally |
+
+The chain never sees a prompt, never sees a result, and never sits in the serving
+path. It sees an output before, and an output after.
+
+**Settle in batches, not per request.** Even with the prompt offchain, one settlement
+transaction per request cannot work at a 150 s cadence for a service billing in
+milliseconds. A standing escrow covering many requests, settled periodically against
+an accumulated balance, keeps per-request latency purely offchain and amortizes the
+onchain cost across a session. This needs no new primitives — a batch settlement is
+one ordinary transaction closing out `N` verified responses.
 
 **Why burn.** Not primarily deflation. Two stronger reasons:
 

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -97,6 +97,7 @@ One mechanism per purpose. Alternatives are named here and not carried further.
 | Set the price | **Auction, per MAC-equivalent** | Protocol price controller — supply is self-reported, so it is a cartel lever |
 | Post and match jobs | **Gossiped offer carrying prompt *length*, not the prompt** | Jobs as transactions carrying prompts — 150 s blocks vs ~24 ms prefill, permanent public prompts, duplicated work, result front-running (§5) |
 | Deliver the prompt | **Direct, encrypted to the winning miner's serving key** | Gossiping it to the fleet — every miner would see every prompt |
+| Reach ordinary users | **Gateways with an OpenAI-compatible API, passing signed receipts through** | Assuming users run clients and hold `$NOCK`; or gateways that absorb verification and ask to be trusted (§5) |
 | Pay per request | **Standing escrow, settled in batches** | One settlement transaction per request — impossible at a 150 s cadence |
 | Accrue value, price fake demand | **Fixed burn fraction `β`** | Moving `β` — damps the supply response exactly when it should attract capacity |
 | Weight authenticity | **Onchain model manifest** | Trusting `HASH_B` alone — it binds *some* weights, not the certified model's |
@@ -159,7 +160,7 @@ dropping the expensive one — see §8.
 > exact commitment is correct for the integer operands only; everything
 > float-contaminated needs Tier A.
 
-## 5. Settlement: verify before pay
+## 5. The offchain system: settlement, transport, gateways
 
 **No capital is posted.** A non-yielding performance bond is not staking — it earns
 no yield, carries no fork-choice weight, and does not become the security budget.
@@ -349,6 +350,74 @@ a theorem, and it is a measurement gate (§7).
 Note the monotonicity: the more inference pays over mining, the less detection is
 needed. The mechanism gets safer as the market gets more valuable.
 
+### Gateways, and the trust they re-centralize
+
+Most demand will not arrive from users running a libp2p client, holding `$NOCK`,
+managing standing escrows, and verifying fingerprints. It will arrive at a website
+with an OpenAI-compatible HTTP API, and that operator will talk to miners. The design
+should expect this rather than treat it as a degradation — a gateway is exactly where
+the machinery consumer users cannot run was always going to live: fiat handling,
+demand aggregation, standing escrows that solve the 150 s settlement cadence, and
+persistent sessions that make discovery amortize.
+
+But it must be said plainly what a gateway does to the guarantee.
+
+**Verification protects the gateway from miners. It does not protect the user from
+the gateway.** A gateway that serves a cheaper model itself, pockets the difference,
+and claims it used the network is doing precisely what TOPLOC's own motivation
+identifies as the problem — a provider that may not be using the model configuration
+it claims. Every mechanism in this document sits *below* the gateway and none of it
+points at the gateway.
+
+**The fix is that the gateway passes the evidence through rather than absorbing it.**
+Every API response carries a receipt:
+
+- the miner's **signed TOPLOC fingerprint** of that response,
+- the **model manifest digest**,
+- the **serving identity** that produced it, and
+- the **settlement reference**.
+
+The gateway cannot forge this. The fingerprint is signed by a work-backed serving
+identity and is bound to *these* output tokens, so an old receipt cannot be replayed
+against a new response. In an OpenAI-compatible shape it is an added response field
+or header — inert for clients that ignore it, available to clients that do not.
+
+That converts "trust the operator" into "the operator hands you evidence it did not
+author," which is a materially different claim from what an ordinary inference API
+can make.
+
+**Being precise about who can check it.** TOPLOC verification requires a prefill of
+the claimed output, so it requires the weights and a GPU. **A typical end user cannot
+verify their own receipt.** The mechanism is not self-verification; it is that a
+receipt is checkable *by anyone* — a competing gateway, a watchtower service, a
+researcher, the user's own infrastructure if they have it — so a gateway that
+fabricates receipts is discoverable by whoever does check, and its identity is
+public. Fraud has to be detectable, not detected by everyone. That is the same shape
+as the miner-level argument in §5, one layer up.
+
+**What a gateway still absorbs, and cannot be designed away:**
+
+- **The prompt.** The user sends it to the gateway in the clear, and the gateway
+  forwards it to a miner. Two parties now see it instead of one; §8's privacy limit
+  gets worse, not better, under the deployment model users will actually use.
+- **Selection.** The gateway chooses miners and could route to its own. The burn
+  still prices that — routing to itself pays `β` like any other trade — but selection
+  opacity remains its own.
+- **Availability.** A gateway can refuse a user. The mitigation is that gateways are
+  commodity and the protocol beneath them is open, which is real only if running one
+  stays cheap.
+
+**The property to protect is that gateways stay thin and replaceable.** A user of an
+ordinary inference API cannot audit their provider at all, so they cannot compare
+providers on honesty. A user holding receipts can — and can switch. Anything that
+makes gateways sticky in ways receipts cannot audit erodes the only structural
+advantage this design has over a conventional provider.
+
+Sophisticated clients keep the direct path: run a client, hold an escrow, verify
+locally, skip the gateway entirely. **The guarantee is available to everyone and the
+gateway is a convenience** — which is the right ordering, and the opposite of the one
+that emerges if receipts are omitted.
+
 ## 6. The consensus route: none at first, `%aip` later
 
 An earlier version of this section proposed a new lock primitive as *the* route and
@@ -444,10 +513,15 @@ inference, and nothing about this design requires a fork to start.
 
 ## 8. Limits
 
-**No prompt privacy.** Miners see prompts and activations; mid-stack activations are
-substantially invertible. The proof layer establishes correctness, not
-confidentiality — the client's input is an input to the prover, not a secret from
-it. Keeping first and last layers client-side narrows but does not close this.
+**No prompt privacy, and it is worse under the deployment model users will actually
+use.** Miners see prompts and activations; mid-stack activations are substantially
+invertible. The proof layer establishes correctness, not confidentiality — the
+client's input is an input to the prover, not a secret from it. Through a gateway
+(§5) both the operator and the miner see it.
+
+**A typical user cannot verify their own receipt.** TOPLOC verification needs the
+weights and a GPU. The guarantee is that receipts are checkable by anyone and forgery
+is publicly discoverable, not that each user checks their own. Keeping first and last layers client-side narrows but does not close this.
 
 **Only one verification layer is sound.** Tier B's cryptographic guarantee covers
 INT7 group_1 linears. Attention, normalization, sampling, and FP8 are covered by

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -123,7 +123,8 @@ creates the spare compute that pays for verification.
 
 | Gap | Severity | Note |
 |---|---|---|
-| **Coverage.** PoW proves one tile (`h·w ≤ 256`) out of a 4096×14336 = 58.7M-element output — a ~4×10⁻⁶ sample | Fundamental | Full-forward-pass ZK for 8B is out of reach; consensus caps Layer-0 trace at 2¹⁹ (`AI_POW_MAX_TRACE_HEIGHT`) |
+| **Coverage.** PoW proves one tile (`h·w ≤ 256`) out of a 4096×14336 = 58.7M-element output — a ~4×10⁻⁶ sample | Fundamental | Full-forward-pass ZK for 8B is out of reach; consensus caps Layer-0 trace at 2¹⁹ (`AI_POW_MAX_TRACE_HEIGHT`). Mitigated in breadth by Tier 0 (§5) |
+| **FP nondeterminism.** Norms, attention, dequant, and FP8 layers are not bit-reproducible across a heterogeneous fleet | Blocking | Bit-exact replay fails on honest miners; needs a tolerance-bearing commitment |
 | **Noise.** The puzzle proves `(A+E)(B+F)`, with commitment-keyed low-rank noise for anti-reuse | Design | Inference needs clean `A·B`; needs a domain-separated statement |
 | **Provenance.** `HASH_B` binds *some* weights, not *the certified model's* | Blocking | Needs a published model manifest |
 | **Addressing.** No request mempool, matching, or escrow | Blocking | Service layer, not protocol |
@@ -137,69 +138,128 @@ argument, with cryptography used to make sampling unforgeable rather than to mak
 verification exhaustive.** That is the honest framing, and the rest of this
 document takes it as the premise.
 
-## 5. The mechanism: commit, sample, dispute
+## 5. The mechanism: fingerprint, commit, sample, dispute
 
-Three tiers. Each is cheap where it is common and expensive only where it is
-rare.
+Four tiers. Each is cheap where it is common and expensive only where it is rare.
 
-### Tier 1 — Commitment (every request, effectively free)
+The tiers exist because **no single check has both breadth and soundness.** A
+locality-sensitive activation fingerprint covers the whole forward pass but is
+statistical; a STARK is cryptographically sound but covers one tile of one GEMM.
+Layering them is not redundancy — each covers precisely the other's blind spot.
 
-The miner returns the output tokens together with a signed commitment to the
-whole computation:
+### Tier 0 — TOPLOC fingerprint (every response, ~free)
+
+Every response carries a TOPLOC commitment: a locality-sensitive hash of the
+top-`k` values of the **last hidden state**, polynomial-encoded [1]. Because the
+final layer depends on every prior computation, a fingerprint of it is sensitive
+to the entire stack — attention, normalization, activation functions, dequant
+scales, and the FP8 layers the STARK cannot reach.
+
+The reported properties are an unusually good fit here:
+
+- **258 bytes per 32 new tokens** on Llama-3.1-8B-Instruct — a ~1000× reduction
+  versus recording activations. Against the ~512 KiB/token of raw per-layer
+  activations considered below, this is not an optimization, it is a different
+  order of thing.
+- **Detects modified model, prompt, or precision** at 100% accuracy with no false
+  positives or negatives in the paper's evaluation.
+- **Robust across GPU types, attention implementations, tensor-parallel layouts,
+  and algebraic reorderings** — thresholds are set on mantissa deviation where
+  exponents agree, chosen empirically to survive reordering.
+- **Verification up to 100× faster than generation**, because a validator passes
+  all committed tokens through a *single prefill* instead of decoding them
+  autoregressively.
+
+The evaluation model is Llama-3.1-8B-Instruct — the same family as the AI-PoW
+production model — and the cost profile lands on the right side of §3's roofline:
+a top-`k` reduction over a 4,096-wide hidden state is negligible compute, and its
+bandwidth cost (~8 KiB/token read) is nothing against the ~17 GB moved per decode
+step. Taken as an asynchronous tee off the serving path, it should cost neither
+TTFT nor throughput. That claim still belongs in the measurement gate (§9), not
+in the assumptions.
+
+### Tier 1 — Commitment (every request, ~free)
+
+The miner signs, and publishes, a commitment binding:
 
 - the model manifest digest (§6),
-- the request digest — prompt, sampling parameters, and an explicit seed, so the
-  forward pass is deterministic and independently replayable,
-- a Merkle root over the **per-layer activation stream**, and
+- the request digest — prompt, sampling parameters, explicit seed,
+- the Tier-0 fingerprint, extended to a **per-layer fingerprint chain** so
+  disputes can bisect (32 layers × 258 B/32 tokens ≈ 8 KiB per 32 tokens — still
+  negligible),
+- the BLAKE3 roots of the **integer GEMM operands** for the provable layers, and
 - the miner's staked identity.
 
-Per-layer activations are small: 4,096 dims × 4 bytes ≈ 16 KiB per token per
-layer, ~512 KiB per token across 32 layers. Hashing that is microseconds and does
-not perturb the decode roofline in §3. Committing at layer boundaries — rather
-than to every intermediate GEMM output — is what keeps Tier 1 free.
+The purpose is to **pin the computation before any challenge is issued.** After
+Tier 1 the miner has no remaining freedom to choose what it "computed."
 
-The purpose is to **pin every intermediate value before any challenge is
-issued**. After Tier 1 the miner has no remaining freedom to choose what it
-"computed."
+> **Correction to an earlier draft of this design.** A previous version committed
+> to a bit-exact Merkle root over the per-layer activation stream and asserted
+> that "execution is deterministic given the manifest and the seed." That is false
+> for a heterogeneous consumer fleet, and the error is not cosmetic: different GPU
+> architectures, attention kernels, and — critically — *different batch
+> compositions* produce different floating-point reduction orders. Since §3 shows
+> batch composition varies continuously under a KV-capped scheduler, two honest
+> miners would routinely produce different roots, and the dispute tier would fire
+> on honest disagreement.
+>
+> The precise statement is narrower and survives: **the INT7/INT8 GEMM accumulate
+> is integer and therefore exactly reproducible** — this is why the roofline can
+> rely on `mma.sync.satfinite` matching wrapping scalar accumulation, and why `Q`
+> can be bit-lossless. Bit-exact commitment is correct *for the integer operands*.
+> Everything float-contaminated — norms, softmax, attention, dequant scales, the
+> FP8 `down_proj` — needs a tolerance-bearing commitment, which is exactly what
+> Tier 0 supplies.
 
 ### Tier 2 — Sampled spot proofs (rare, expensive)
 
-Once the commitment is published, a public beacon the miner could not predict —
-the next block hash is already available and already unpredictable to it —
-selects a `(layer ℓ, tile i, j)`. The miner must produce the existing compact
-recursive certificate for exactly that tile:
+A public beacon the miner could not predict — the next block hash — selects a
+`(layer ℓ, tile i, j)`. The miner must produce the compact recursive certificate
+for exactly that tile:
 
 - `B` (weights) opened against the model manifest,
-- `A` (activations) opened against the Tier-1 activation root for layer ℓ,
+- `A` (activations) opened against the Tier-1 integer-operand root for layer ℓ,
 - the schedule from `StripIndexSchedule::from_tile`,
 - the claimed output tile.
 
-This is the current `ai-pow-zk` statement with the jackpot/target comparison
-removed and the noise zeroed. It proves: *the certified weights, times the
-activations this miner already committed to, produce the tile it claims.*
-Chained through the per-layer activation roots, a miner that fabricated any layer
-is caught whenever the beacon lands on it.
+This is the current `ai-pow-zk` statement with the jackpot comparison removed and
+the noise zeroed. It proves: *the certified weights, times the activations this
+miner already committed to, produce the tile it claims.*
 
 Commit-then-challenge is what makes a 4×10⁻⁶ tile sample meaningful. The sample
-is tiny, but the miner must be correct *everywhere* to survive a uniformly random
+is tiny, but the miner must be correct everywhere to survive a uniformly random
 draw it cannot anticipate.
 
 ### Tier 3 — Dispute by bisection (very rare)
 
-Execution is deterministic given the manifest and the seed, so any second miner,
-client, or watchtower can replay a request for roughly one forward pass of
-consumer GPU time and compare Tier-1 roots. On disagreement it opens a challenge.
+Any second miner, client, or watchtower re-runs the request as a **single prefill
+of the claimed output** and compares Tier-0 fingerprints under the published
+tolerance. At up to 100× cheaper than generation, this is affordable enough that
+a client can verify *its own* traffic in full rather than relying on sampling.
 
-Because Tier 1 already commits per layer, the parties bisect over the 32-layer
-chain to the first divergent layer in ~5 rounds, then over tiles within that
-layer. The terminal step of the bisection is exactly a Tier-2 proof. One proof
-system serves both tiers; the dispute game adds no new cryptography.
+On mismatch, the parties bisect the per-layer fingerprint chain to the first
+divergent layer in ~5 rounds, then to tiles within it. The terminal step is
+exactly a Tier-2 proof: one proof system serves both, and the dispute game adds
+no new cryptography.
 
-Failure to answer within the timeout, or an answer that verifies against a
-different value, slashes the stake.
+**A fingerprint mismatch escalates; it never slashes directly.** Tier 0 is a
+trigger, not a verdict — see §10.5. Slashing follows only from a failed or
+contradicted Tier-2 certificate, or from a timeout.
 
-The three tiers compose into: cheap always, cryptographic sometimes, adversarial
-rarely — with cost concentrated where dishonesty is, not where throughput is.
+### Why both, and not either alone
+
+| | Tier 0 — TOPLOC | Tier 2 — STARK |
+|---|---|---|
+| Cost | ~free, every response | expensive, sampled |
+| Coverage | whole forward pass, incl. attention, norms, FP8 | one tile of one INT7 GEMM |
+| Robust to FP nondeterminism | yes, by construction | n/a — integer path |
+| Guarantee | statistical | cryptographic |
+| Detection latency for precision/model swap | **1 request** | ~`1/p` requests |
+
+**TOPLOC gives breadth without soundness; the STARK gives soundness without
+breadth.** Dropping either is the failure mode to guard against — and the
+temptation runs toward dropping the expensive one, which is why §10.5 states the
+argument against it explicitly.
 
 ## 6. Model provenance
 
@@ -391,9 +451,41 @@ the value of a *single proof* — not of a request, and independent of request s
 That mildness is why this can work with consumer-scale operators rather than only
 well-capitalized ones.
 
-Systematic cheating is bounded far more tightly than one-shot cheating, because
-Tier-3 replay is cheap and available to anyone: a miner that cheats repeatedly
-faces detection probability approaching 1.
+**Tier 0 changes what `p` has to buy, and this is its largest economic effect.**
+
+The most profitable cheat in a consumer GPU cloud is not fabricating outputs —
+those have to look plausible, which is hard. It is **serving a cheaper precision
+or a smaller model than was paid for**: a 2–4× cost saving on *every* request,
+indefinitely, with outputs that read as fine. Under ZK sampling alone that is
+caught at rate `p`, so the cheat earns roughly `1/p` requests of free margin
+before detection. TOPLOC detects precision and model substitution on **every**
+request, collapsing detection latency from `~1/p` requests to one.
+
+So `p` no longer has to deter the cheap, high-volume cheats. It only has to deter
+the residual adversary who constructs activations that spoof top-`k` under the
+published tolerance while actually running a cheaper computation — a far narrower
+and far more expensive attack. **The same security is bought at a materially lower
+`p`**, which lowers verification overhead and, through `S > value(C_p) / β_v`, the
+stake floor with it.
+
+That feeds back into §8.5: a cheaper verification layer makes the onchain rail
+cheaper overall, which widens the headroom between `β` and the off-chain escape
+hatch.
+
+Two second-order effects, both favorable:
+
+- **Challenger economics.** §8.6 needs a bounty large enough to pay someone to
+  catch a cheat. At up to 100× cheaper than generation, a challenge costs ~1% of
+  serving, so the bounty can be small — which also shrinks the griefing incentive
+  that an oversized bounty would create.
+- **Client-side verification becomes the default posture.** At that cost a client
+  can verify *all* of its own traffic rather than trusting a sampled deterrent.
+  The trust model shifts from "sampled deterrence" to "client-verified by default,
+  with the STARK as the escalation path when a client and miner disagree."
+
+Systematic cheating is bounded far more tightly than one-shot cheating: replay is
+cheap and available to anyone, so a repeat cheat faces detection probability
+approaching 1.
 
 ## 9. What must be measured first
 
@@ -419,7 +511,17 @@ Required before any of this is committed to:
    here too).
 4. **Cost of the zero-noise inference statement**, and confirmation that
    domain-separating it cannot weaken the PoW anti-reuse invariant.
-5. **Off-chain defection rate** once a market exists. This is the only honest way
+5. **TOPLOC threshold calibration for the Pearl quantization.** The published
+   thresholds were established for Llama-3.1-8B-Instruct; the Pearl variant's
+   INT7 group_1 / FP8 group_0 mix is a *different* quantization, so the mantissa
+   thresholds must be re-derived against it rather than inherited. Calibrate
+   across the fleet's real hardware distribution, including its long tail — a
+   false positive on an honest miner with unusual hardware is far more damaging
+   than a missed detection, because Tier 2 catches the latter and nothing repairs
+   the former.
+6. **Tier-0 overhead on the serving path**: confirm the async tee costs neither
+   TTFT nor throughput, rather than assuming it from the bandwidth arithmetic.
+7. **Off-chain defection rate** once a market exists. This is the only honest way
    to bound `β` (§8.5), and unlike the others it cannot be measured before
    launch — which is the argument for shipping a deliberately low constant `β`
    and raising it against evidence, rather than starting high.
@@ -458,11 +560,41 @@ about inference beyond what it already verifies. Only the model manifest registr
 plausibly belongs onchain, and even that could start as a NockApp with a
 well-known root.
 
-**Verification is partial by construction.** Tier 2 covers INT7 group_1 linears.
-Attention, normalization, activation functions, sampling, and the FP8 layers are
-covered by Tier-1 commitment and Tier-3 replay determinism, not by proof. This is
-a real and permanent limit at this model scale, and the service must market
-itself accordingly.
+**Verification is layered, and only one layer is sound.** Tier 2's *cryptographic*
+guarantee covers INT7 group_1 linears and nothing else. Attention, normalization,
+activation functions, sampling, and the FP8 layers are covered by Tier 0's
+fingerprint and Tier 3's replay — real coverage, and far broader than proof
+coverage, but **statistical rather than sound.** The service must state both
+halves: soundly proven on a sampled tile of the integer linear path, empirically
+fingerprinted end to end. No amount of layering turns the second into the first at
+this model scale.
+
+**Tier 0 must not be allowed to displace Tier 2**, and this is the most likely way
+the design degrades in practice — it will arrive looking like a cost optimization.
+
+TOPLOC reports 100% detection with no false positives, but that is an *empirical*
+result against the modifications its authors tested, not a proof against an
+adversary who knows the scheme and optimizes against it. In a research evaluation
+that distinction is academic. Here, real money would reward finding a cheaper
+computation whose top-`k` last-hidden-state values survive the published
+tolerance, and nobody has yet had that incentive. Locality-sensitive hashing is
+built for robustness to *incidental* perturbation; robustness to *adversarial*
+perturbation is a strictly stronger property and is not established.
+
+Three consequences:
+
+- **Tier 0 escalates; it never slashes.** A fingerprint mismatch opens a Tier-2
+  challenge. Money moves on a failed or contradicted certificate, or on a timeout,
+  never on a fingerprint alone. This also contains the false-positive risk from
+  §9.5 — an honest miner on unusual hardware gets challenged, not slashed, and the
+  certificate exonerates it.
+- **Keep `p` strictly positive** however good Tier 0 looks in production. Its whole
+  job is deterring the adversary Tier 0 cannot bound, and that adversary's absence
+  from the logs is not evidence of their impossibility: a cheat designed to pass
+  Tier 0 is, by construction, invisible to Tier 0.
+- **Thresholds are consensus-visible parameters**, versioned and changed
+  deliberately. A silently loosened tolerance weakens the entire scheme with no
+  outward sign.
 
 ## 11. Staged plan
 
@@ -482,12 +614,12 @@ that the measurement gate precedes the design commitments that depend on it.
 6. **Burn-split settlement** over the existing `%brn` primitive: per-MAC bid
    escrow, `(1−β)/β` split on success, refund on failed proof. No price
    controller; `β` fixed for the first deployment.
-7. **Tier-3 bisection game** as a NockApp, with slashing and the challenger
+8. **Tier-3 bisection game** as a NockApp, with slashing and the challenger
    bounty; consensus untouched.
-8. **Scheduler and interleaving**, including PoW/inference preemption at the
+9. **Scheduler and interleaving**, including PoW/inference preemption at the
    existing cancellation granularity.
 
-Stages 2–6 are additive and carry no consensus risk. Stage 7 is where the real
+Stages 2–7 are additive and carry no consensus risk. Stage 8 is where the real
 design review is owed, and it should be reviewed against the existing dual-puzzle
 audit findings rather than in isolation. A moving `β` (§8.4) is explicitly *not*
 in this plan: ship a constant, observe the market, and only then decide whether a
@@ -515,8 +647,17 @@ funds long-run security. Price should be set by auction rather than by a protoco
 controller: supply is self-reported and therefore a cartel lever, so the protocol
 should fix the split and let the market fix the price.
 
-The honest limits are that proof coverage is a sample over the INT7 linear layers
-rather than the whole forward pass, that miners see prompts, that `β` is bounded by
+The honest limits are that only one verification layer is cryptographically sound
+and it samples the INT7 linear path, that end-to-end coverage is statistical and
+rests on adversarial robustness nobody has yet stress-tested with money on the
+line, that miners see prompts, that `β` is bounded by
 an off-chain escape hatch nobody can measure before launch, and that the dispute
 game is the one genuinely risky addition — which is why it belongs in a NockApp
 and not in the consensus kernel.
+
+## References
+
+[1] Jack Min Ong, Matthew Di Ferrante, Aaron Pazdera, Ryan Garner, Sami Jaghouar,
+Manveer Basra, Max Ryabinin, Johannes Hagemann. *TOPLOC: A Locality Sensitive
+Hashing Scheme for Trustless Verifiable Inference.* arXiv:2501.16007, January 2025
+(rev. May 2025); ICML 2025. <https://arxiv.org/abs/2501.16007>

--- a/docs/ai-pow-integration/verifiable-inference-cloud.md
+++ b/docs/ai-pow-integration/verifiable-inference-cloud.md
@@ -7,829 +7,376 @@ Canonical/Legacy: Legacy (design exploration; no protocol authority)
 
 ## Scope
 
-This document considers a mechanism for aggregating Nockchain's AI-PoW miner
-fleet into a consumer-GPU cloud that sells *verifiable inference*: a client pays
-for tokens from a named model and receives a settlement-grade guarantee that the
-tokens came from that model's real weights.
+A mechanism for aggregating Nockchain's AI-PoW miner fleet into a consumer-GPU
+cloud that sells verifiable inference. One mechanism is chosen per purpose;
+rejected alternatives are named once and not revisited. There is a single route
+into consensus, and it is one new lock primitive.
 
-It is a design exploration, not a protocol proposal. It does not change
-`PROTOCOL.md`, consensus activation, ASERT, fork choice, or block validity, and
-it deliberately stops short of code because the sampling rates it recommends
-depend on one quantity nobody in this repository has measured yet (§9). It does
-assume the burn primitive (`%brn`) and the fixed-percentage-split precedent that
-Aletheia already established, rather than proposing new consensus machinery for
-either.
+This is a design exploration. It does not change `PROTOCOL.md`, activation, ASERT,
+fork choice, or block validity, and it stops short of code because the sampling
+policy depends on a quantity nobody in this repository has measured (§7).
 
 ## 1. The claim
 
-Nockchain is already most of the way to a verifiable inference network, and
-almost none of the remaining distance is cryptography.
+Nockchain is already most of the way to a verifiable inference network, and almost
+none of the remaining distance is cryptography.
 
-The AI-PoW puzzle does not mine a synthetic matmul that merely *resembles*
-inference. Per [`crates/ai-pow/src/quant.rs`](../../crates/ai-pow/src/quant.rs),
-the production model is `pearl-ai/Llama-3.1-8B-Instruct-pearl`, served through a
-vLLM mining plugin, and the quant-extraction contract `Q` is documented as
-**bit-lossless**: a pure reindex of the operands vLLM already computed into
-`ai-pow`'s `(A, B)` layout, with no requantization. The mined integers *are* the
-inference integers.
+Per [`crates/ai-pow/src/quant.rs`](../../crates/ai-pow/src/quant.rs), the production
+model is `pearl-ai/Llama-3.1-8B-Instruct-pearl`, served through a vLLM mining
+plugin, and the quant-extraction contract `Q` is documented as **bit-lossless**: a
+pure reindex of the operands vLLM already computed, no requantization. The mined
+integers *are* the inference integers.
 
-So the primitive on offer is not "a chain that could someday host inference." It
-is a fleet of consumer GPUs already executing real Llama-3.1-8B GEMMs, already
-committing to their operands, and already able to produce a compact recursive
-STARK certificate that a named tile of a named committed matmul was computed
-correctly. What is missing is the *service layer*: provenance, addressing,
-sampling, dispute, and settlement.
+What is missing is the service layer: provenance, addressing, verification policy,
+and settlement.
 
-## 2. What the repository already provides
-
-| Capability | Where | Why it matters here |
-|---|---|---|
-| Real-model INT7/INT8 GEMM as the mined unit | `ai-pow/src/quant.rs`, `params.rs::LLAMA_3_1_8B_GATE_UP` | The work is inference, not an inference-shaped mimic |
-| Merkle commitments over operand matrices | `ai-pow/src/commit.rs` (`matrix_commitment`, `a_row_leaf_hash`, `b_col_leaf_hash`) | Weights and activations can both be pinned before challenge |
-| **Proof of an arbitrary named tile** | `ai_pow_zk::canonical::StripIndexSchedule::from_tile(zk_params, tile_i, tile_j)` | Verification can target a tile *chosen after the fact*, not just a lottery winner |
-| Compact recursive certificate | `ai-pow-zk` Layers 0/1/2, `zk_bridge` | Small, verifier-owned-setup proof suitable for onchain settlement |
-| Verifier-owned setup, prover supplies none | `ai-pow-zk/docs/ARCHITECTURE.md` | A dishonest server cannot substitute its own public parameters |
-| Grouped-GEMM / MoE routing binding | `ai-pow/src/pearl_moe_routing.rs` | Extends to MoE models without a new proof system |
-| Production consumer-GPU throughput | `docs/ai-pow-integration/pearl-v3-rtx5090-roofline.md`; commits `c8d6b13`, `330bece` | ~335–348 TMAC/s sustained on a single RTX 5090 |
-
-`StripIndexSchedule::from_tile` is the load-bearing one. The PoW path proves
-whichever tile happened to win the jackpot; that same constructor will prove a
-tile that someone else names. Every verification scheme below is built on that,
-and it already exists.
-
-The repository is also explicit that it does *not* supply what a service layer
-needs. `synth.rs` states outright that "model provenance, economic usefulness,
-and uniqueness are network policy concerns outside this deterministic generator,"
-and `ai-pow-zk/docs/SECURITY.md` disclaims "model provenance, economic
-usefulness, confidentiality, or uniqueness." Those disclaimers are precisely the
-gap this design fills — and they are policy gaps, not cryptographic ones.
-
-## 3. The load-bearing observation: decode leaves the tensor cores idle
-
-This is the fact that makes a *consumer* GPU cloud coherent rather than a
-worse-priced imitation of a datacenter one. It comes out of the roofline.
-
-An RTX 5090 has 32 GiB of GDDR7 at 1,792 GB/s and sustains ~335 TMAC/s on the
-real mining transcript. Llama-3.1-8B is ~8.03B parameters, ~8.5 GB at the shipped
-quantization, and costs ~8.03 GMAC per token.
-
-**Weights fit on one card.** No tensor parallelism, no NVLink, no collectives,
-no interconnect-sensitive placement. Each miner holds a whole model replica and
-the cloud is embarrassingly parallel at the *request* level. This is the single
-biggest reason the aggregation is tractable here and is not tractable for a
-400B-class model on the same hardware.
-
-**KV cache, not weights, caps the batch.** With ~23 GB free after weights and
-GQA KV at ~128 KiB per token across all 32 layers, the card holds ~175k KV
-tokens: roughly 20 concurrent sequences at 8k context, ~85 at 2k. That ceiling
-sits *below* the compute/bandwidth crossover, which the same roofline puts near
-batch ~198. Consumer decode is therefore permanently memory-bound.
-
-Work the consequence through at batch 32, 2k context:
-
-| Quantity | Value |
+| Already in the repository | Where |
 |---|---|
-| Weight traffic per decode step | ~8.5 GB |
-| KV traffic per decode step | ~8.6 GB |
+| Real-model INT7/INT8 GEMM as the mined unit | `ai-pow/src/quant.rs`, `params.rs::LLAMA_3_1_8B_GATE_UP` |
+| Merkle commitments over operand matrices | `ai-pow/src/commit.rs` |
+| **Proof of an arbitrary named tile** | `StripIndexSchedule::from_tile` |
+| Compact recursive certificate | `ai-pow-zk` Layers 0/1/2 |
+| **A resident certificate verifier** | `ai-pow-jets::ai_pow_verify_jet`; nodes build the full setup table at boot |
+| Burn as a lock primitive | `LockPrimitive::Burn` / `%brn` |
+| Fixed-percentage split precedent | Aletheia's 80/20 miner/fund split |
+| ~335–348 TMAC/s on one RTX 5090 | `pearl-v3-rtx5090-roofline.md` |
+
+Two of these do more work than the rest. `from_tile` proves a tile *someone else
+names*, not just a jackpot winner. And the certificate verifier is **already
+resident on every node** — which is what makes §6's consensus route small.
+
+## 2. Why consumer GPUs
+
+The argument is arithmetic. An RTX 5090 has 32 GiB at 1,792 GB/s and sustains ~335
+TMAC/s. Llama-3.1-8B is ~8.03B params, ~8.5 GB quantized, ~8.03 GMAC/token.
+
+**Weights fit on one card.** No tensor parallelism, no collectives, no
+interconnect-sensitive placement. Each miner holds a whole replica; the cloud is
+parallel at the request level. This is why aggregation is tractable here and is not
+tractable for a 400B model on the same hardware.
+
+**KV cache caps the batch below the compute crossover.** ~23 GB free after weights,
+GQA KV ~128 KiB/token across 32 layers → ~175k KV tokens: ~20 sequences at 8k
+context, ~85 at 2k. The compute/bandwidth crossover is near batch ~198. Consumer
+decode is therefore permanently memory-bound:
+
+| Decode step · batch 32 · 2k context | |
+|---|---:|
+| Weight traffic | ~8.5 GB |
+| KV traffic | ~8.6 GB |
 | Step time at 1,792 GB/s | ~9.5 ms |
 | Throughput | ~3.4k tok/s |
-| Tensor-core time actually used | 32 × 24 µs ≈ 0.77 ms |
-| **INT8 tensor-core utilization** | **~8%** |
+| Tensor-core time used | ~0.77 ms |
+| **INT8 utilization** | **~8%** |
 
-During decode a consumer GPU is using something like a twelfth of its INT8
-compute. The remaining ~92% is not merely idle — it is idle *in exactly the units
-AI-PoW consumes*, with a tiny working set that does not contend for the bandwidth
-decode is starving on.
+The other ~92% is idle *in exactly the units AI-PoW consumes*, with a working set
+too small to contend for the bandwidth decode is starving on.
 
-Prefill is the mirror image: it is compute-bound and shaped like the puzzle
-already. `LLAMA_3_1_8B_GATE_UP` is `m=4096, k=4096, n=14336` — and in the `Q`
-convention `A` is the *activation* matrix with `m` tokens of rows. The mined work
-unit is literally a 4,096-token prefill batch. A 1,000-token prompt's prefill is
-~8.03 TMAC, ~24 ms at 335 TMAC/s.
+Prefill is the mirror image and is already the mined shape: `LLAMA_3_1_8B_GATE_UP`
+is `m=4096, k=4096, n=14336`, and in the `Q` convention `A` is the activation
+matrix — so the mined unit is a 4,096-token prefill batch. Serving prefill and
+mining it are nearly the same act; decode leaves the compute free for both mining
+and proving.
 
-So the two workloads are complements, not competitors:
+A datacenter operator cannot exploit this as cleanly: their economics assume
+high-batch decode on HBM parts where the idle fraction is much smaller. The
+consumer fleet's structural weakness is what funds its verification.
 
-- **Prefill** is compute-bound and is *already the mined shape* — serving it and
-  mining it are close to the same act.
-- **Decode** is bandwidth-bound and leaves ~92% of the tensor cores free for PoW
-  mining and for proof generation.
+## 3. Decisions
 
-A datacenter operator cannot exploit this as cleanly, because their economics
-assume high-batch decode on HBM parts where the idle fraction is much smaller.
-The consumer fleet's structural weakness — small memory, capped batch — is what
-creates the spare compute that pays for verification.
+One mechanism per purpose. Alternatives are named here and not carried further.
 
-## 4. What is missing
-
-| Gap | Severity | Note |
+| Purpose | Chosen | Not chosen, and why |
 |---|---|---|
-| **Coverage.** PoW proves one tile (`h·w ≤ 256`) out of a 4096×14336 = 58.7M-element output — a ~4×10⁻⁶ sample | Fundamental | Full-forward-pass ZK for 8B is out of reach; consensus caps Layer-0 trace at 2¹⁹ (`AI_POW_MAX_TRACE_HEIGHT`). Mitigated in breadth by Tier 0 (§5) |
-| **FP nondeterminism.** Norms, attention, dequant, and FP8 layers are not bit-reproducible across a heterogeneous fleet | Blocking | Bit-exact replay fails on honest miners; needs a tolerance-bearing commitment |
-| **Noise.** The puzzle proves `(A+E)(B+F)`, with commitment-keyed low-rank noise for anti-reuse | Design | Inference needs clean `A·B`; needs a domain-separated statement |
-| **Provenance.** `HASH_B` binds *some* weights, not *the certified model's* | Blocking | Needs a published model manifest |
-| **Addressing.** No request mempool, matching, or escrow | Blocking | Service layer, not protocol |
-| **Privacy.** Miners see prompts and activations in the clear | Honest limit | See §10 |
+| Detect wrong model / precision / prompt | **TOPLOC fingerprint on every response** [1] | Bit-exact activation hashing — fails on honest miners (§4) |
+| Bind the claim | **The signed fingerprint is the commitment** | A separate commitment tier — it was the same data twice |
+| Resolve a disagreement | **Compact recursive certificate on a named tile** | Majority re-execution — pays N× for a sampled guarantee |
+| Choose which tile | **Challenger names it; block hash breaks ties** | Interactive bisection — unnecessary (§5) |
+| Make cheating unprofitable | **Forfeiture: never pay before verify** | Bonds — redundant once detection is near-certain (§5) |
+| Sybil / claim-abandon resistance | **One PoW admission ticket per claim** | Reputation, capital deposits, whitelists |
+| Set the price | **Auction, per MAC-equivalent** | Protocol price controller — supply is self-reported, so it is a cartel lever |
+| Accrue value, price fake demand | **Fixed burn fraction `β`** | Moving `β` — damps the supply response exactly when it should attract capacity |
+| Weight authenticity | **Onchain model manifest** | Trusting `HASH_B` alone — it binds *some* weights, not the certified model's |
+| Consensus integration | **One lock primitive (§6)** | A dispute-game NockApp, kernel changes, a second puzzle |
 
-The coverage gap is the central one, and it does not have a cryptographic
-solution at this model scale. Proving every GEMM in a 32-layer forward pass is
-not within a factor of a few of the 2¹⁹-row Layer-0 budget; it is off by orders
-of magnitude. **The mechanism must therefore rest on a detection-and-forfeiture
-argument, with cryptography used to make detection unforgeable rather than to make
-verification exhaustive.** That is the honest framing, and the rest of this
-document takes it as the premise.
+Cut entirely: the challenger bounty (the client is the challenger, motivated by its
+own refund), the optional bonded assurance tier, per-layer bisection, and separate
+identity-activation and challenge tickets.
 
-## 5. The mechanism: fingerprint, commit, sample, dispute
+## 4. Verification: two layers, chosen for opposite blind spots
 
-Four tiers. Each is cheap where it is common and expensive only where it is rare.
+**Tier A — TOPLOC fingerprint. Every response, ~free.**
 
-The tiers exist because **no single check has both breadth and soundness.** A
-locality-sensitive activation fingerprint covers the whole forward pass but is
-statistical; a STARK is cryptographically sound but covers one tile of one GEMM.
-Layering them is not redundancy — each covers precisely the other's blind spot.
+A locality-sensitive hash of the top-`k` values of the last hidden state,
+polynomial-encoded [1]. Because the final layer depends on every prior computation,
+it is sensitive to the entire stack — attention, normalization, dequant scales, and
+the FP8 layers the certificate cannot reach.
 
-### Tier 0 — TOPLOC fingerprint (every response, ~free)
-
-Every response carries a TOPLOC commitment: a locality-sensitive hash of the
-top-`k` values of the **last hidden state**, polynomial-encoded [1]. Because the
-final layer depends on every prior computation, a fingerprint of it is sensitive
-to the entire stack — attention, normalization, activation functions, dequant
-scales, and the FP8 layers the STARK cannot reach.
-
-The reported properties are an unusually good fit here:
-
-- **258 bytes per 32 new tokens** on Llama-3.1-8B-Instruct — a ~1000× reduction
-  versus recording activations. Against the ~512 KiB/token of raw per-layer
-  activations considered below, this is not an optimization, it is a different
-  order of thing.
+- **258 bytes per 32 tokens** on Llama-3.1-8B — ~1000× less than recording
+  activations.
 - **Detects modified model, prompt, or precision** at 100% accuracy with no false
-  positives or negatives in the paper's evaluation.
-- **Robust across GPU types, attention implementations, tensor-parallel layouts,
-  and algebraic reorderings** — thresholds are set on mantissa deviation where
-  exponents agree, chosen empirically to survive reordering.
-- **Verification up to 100× faster than generation**, because a validator passes
-  all committed tokens through a *single prefill* instead of decoding them
-  autoregressively.
+  positives in the paper's evaluation.
+- **Robust across GPU types, attention kernels, tensor-parallel layouts, and
+  algebraic reorderings.**
+- **Verification up to 100× faster than generation** — one prefill of the claimed
+  output instead of autoregressive decode.
 
-The evaluation model is Llama-3.1-8B-Instruct — the same family as the AI-PoW
-production model — and the cost profile lands on the right side of §3's roofline:
-a top-`k` reduction over a 4,096-wide hidden state is negligible compute, and its
-bandwidth cost (~8 KiB/token read) is nothing against the ~17 GB moved per decode
-step. Taken as an asynchronous tee off the serving path, it should cost neither
-TTFT nor throughput. That claim still belongs in the measurement gate (§9), not
-in the assumptions.
+The evaluation model is Llama-3.1-8B-Instruct, the same family AI-PoW mines. Cost
+lands on the right side of §2: a top-`k` reduction over a 4,096-wide state is
+negligible compute and ~8 KiB/token of reads against ~17 GB per step. As an async
+tee it should cost neither TTFT nor throughput — a claim that belongs in §7, not in
+the assumptions.
 
-### Tier 1 — Commitment (every request, ~free)
+**Tier B — Compact recursive certificate. Only on dispute.**
 
-The miner signs, and publishes, a commitment binding:
+The current `ai-pow-zk` statement with the jackpot comparison removed and the noise
+zeroed, over a named tile: weights opened against the manifest, activations against
+the committed integer-operand root, schedule from `from_tile`. It proves the
+certified weights times the committed activations produce the claimed tile.
 
-- the model manifest digest (§6),
-- the request digest — prompt, sampling parameters, explicit seed,
-- the Tier-0 fingerprint, extended to a **per-layer fingerprint chain** so
-  disputes can bisect (32 layers × 258 B/32 tokens ≈ 8 KiB per 32 tokens — still
-  negligible),
-- the BLAKE3 roots of the **integer GEMM operands** for the provable layers, and
-- the miner's **work-backed serving identity** (§8.6).
+**Why both.** TOPLOC gives breadth without soundness; the certificate gives
+soundness without breadth. Neither alone is adequate, and the temptation runs toward
+dropping the expensive one — see §8.
 
-The purpose is to **pin the computation before any challenge is issued.** After
-Tier 1 the miner has no remaining freedom to choose what it "computed."
-
-> **Correction to an earlier draft of this design.** A previous version committed
-> to a bit-exact Merkle root over the per-layer activation stream and asserted
-> that "execution is deterministic given the manifest and the seed." That is false
-> for a heterogeneous consumer fleet, and the error is not cosmetic: different GPU
-> architectures, attention kernels, and — critically — *different batch
-> compositions* produce different floating-point reduction orders. Since §3 shows
-> batch composition varies continuously under a KV-capped scheduler, two honest
-> miners would routinely produce different roots, and the dispute tier would fire
-> on honest disagreement.
->
-> The precise statement is narrower and survives: **the INT7/INT8 GEMM accumulate
-> is integer and therefore exactly reproducible** — this is why the roofline can
-> rely on `mma.sync.satfinite` matching wrapping scalar accumulation, and why `Q`
-> can be bit-lossless. Bit-exact commitment is correct *for the integer operands*.
-> Everything float-contaminated — norms, softmax, attention, dequant scales, the
-> FP8 `down_proj` — needs a tolerance-bearing commitment, which is exactly what
-> Tier 0 supplies.
-
-### Tier 2 — Sampled spot proofs (rare, expensive)
-
-A public beacon the miner could not predict — the next block hash — selects a
-`(layer ℓ, tile i, j)`. The miner must produce the compact recursive certificate
-for exactly that tile:
-
-- `B` (weights) opened against the model manifest,
-- `A` (activations) opened against the Tier-1 integer-operand root for layer ℓ,
-- the schedule from `StripIndexSchedule::from_tile`,
-- the claimed output tile.
-
-This is the current `ai-pow-zk` statement with the jackpot comparison removed and
-the noise zeroed. It proves: *the certified weights, times the activations this
-miner already committed to, produce the tile it claims.*
-
-Commit-then-challenge is what makes a 4×10⁻⁶ tile sample meaningful. The sample
-is tiny, but the miner must be correct everywhere to survive a uniformly random
-draw it cannot anticipate.
-
-### Tier 3 — Dispute by bisection (very rare)
-
-Any second miner, client, or watchtower re-runs the request as a **single prefill
-of the claimed output** and compares Tier-0 fingerprints under the published
-tolerance. At up to 100× cheaper than generation, this is affordable enough that
-a client can verify *its own* traffic in full rather than relying on sampling.
-
-On mismatch, the parties bisect the per-layer fingerprint chain to the first
-divergent layer in ~5 rounds, then to tiles within it. The terminal step is
-exactly a Tier-2 proof: one proof system serves both, and the dispute game adds
-no new cryptography.
-
-**A fingerprint mismatch escalates; it is never itself an adverse finding.** Tier 0
-is a trigger, not a verdict — see §10.5. Consequences follow only from a failed or
-contradicted Tier-2 certificate, or from a timeout, and they are forfeiture of
-payment plus retirement of the serving identity — never seizure of posted capital
-(§8.6).
-
-### Why both, and not either alone
-
-| | Tier 0 — TOPLOC | Tier 2 — STARK |
+| | Tier A | Tier B |
 |---|---|---|
-| Cost | ~free, every response | expensive, sampled |
-| Coverage | whole forward pass, incl. attention, norms, FP8 | one tile of one INT7 GEMM |
+| Cost | ~free, every response | expensive, on dispute only |
+| Coverage | whole forward pass incl. attention, norms, FP8 | one tile of one INT7 GEMM |
 | Robust to FP nondeterminism | yes, by construction | n/a — integer path |
 | Guarantee | statistical | cryptographic |
-| Detection latency for precision/model swap | **1 request** | ~`1/p` requests |
 
-**TOPLOC gives breadth without soundness; the STARK gives soundness without
-breadth.** Dropping either is the failure mode to guard against — and the
-temptation runs toward dropping the expensive one, which is why §10.5 states the
-argument against it explicitly.
+> **Correction carried forward.** An earlier draft committed to a *bit-exact* Merkle
+> root over per-layer activations and claimed execution is deterministic given
+> manifest and seed. That is false for a heterogeneous fleet: architectures,
+> attention kernels, and above all varying batch composition change float reduction
+> order, and §2 shows batch composition varies continuously. Two honest miners would
+> disagree. The surviving statement is narrower — **the INT7/INT8 accumulate is
+> integer and exactly reproducible**, which is why the roofline can rely on
+> `mma.sync.satfinite` matching scalar accumulation and why `Q` is bit-lossless. Bit-
+> exact commitment is correct for the integer operands only; everything
+> float-contaminated needs Tier A.
 
-## 6. Model provenance
+## 5. Settlement: verify before pay
 
-Tier 2 is worthless if `HASH_B` can bind arbitrary weights. The network needs a
-**model manifest**: for each certified model, the per-tensor BLAKE3 Merkle roots
-in the exact layout `commit.rs` uses, plus shape, quantization group, and the
-`MatmulParams` profile per layer.
+**No capital is posted.** A non-yielding performance bond is not staking — it earns
+no yield, carries no fork-choice weight, and does not become the security budget.
+The case against requiring one is not principle but **redundancy**: once detection
+is near-certain, forfeited payment already exceeds any profitable cheat's gain, so
+bonded collateral secures a loss the miner is already fully exposed to. It is also a
+capital barrier against the one-GPU participation thesis, and locked `$NOCK` is
+genuinely expensive to hold precisely because it does not yield.
 
-Publishing the manifest onchain makes "this certificate is for the real
-Llama-3.1-8B-Instruct-pearl" a checkable statement rather than a claim. This is
-the concrete discharge of the provenance concern `synth.rs` explicitly routes to
-network policy.
+The protocol's own analogy: **an invalid block seizes nothing. It wastes the work.**
 
-Note the INT-only production scoping already encoded in `params.rs`: `down_proj`
-is group_0 FP8 and is guarded off as non-mineable (`Fp8LayerNotMineable`). A
-manifest must record which layers are provable and which are attested only by
-Tier-1 commitment and Tier-3 replay. **Verifiable inference on this model is
-therefore verifiable over its INT7 group_1 linear layers, not over every FLOP in
-the forward pass** — and the service must say so plainly rather than imply
-end-to-end proof coverage.
+**The flow.** Client escrows payment with a signed request (manifest digest, prompt
+digest, max tokens, sampling params, seed, bid per MAC-equivalent, deadline). Miner
+claims it with a PoW admission ticket signed by its serving identity — a keypair
+whose standing comes from work, not deposit. Miner serves and publishes tokens plus
+fingerprint. Client verifies at ~1% of serving cost and signs; escrow releases
+`(1−β)` to the miner and `β` to a `%brn` output. If the client disputes, it names a
+tile and the miner must answer with a certificate: verifying releases to the miner,
+failing or timing out refunds the client and retires the identity.
 
-## 7. Aggregation and scheduling
+**No bisection.** Both parties hold the full fingerprint chain, so the challenger
+*names* the first divergent layer directly. The interactive multi-round game was
+solving a problem that does not exist, and it was the largest consensus surface in
+the design.
 
-- **Unit of supply:** one miner = one whole-model replica on one GPU. Request-level
-  parallelism only.
-- **Matching:** clients post signed requests (manifest digest, prompt digest, max
-  tokens, sampling params, seed, bid per MAC-equivalent, deadline) to an offchain
-  mempool; miners claim them with an admission ticket signed by a work-backed
-  serving identity (§8.7). Payment escrows in `$NOCK` through the existing UTXO and
-  wallet crates and settles only *after* verification, splitting `(1−β)` to the
-  miner and `β` to a `%brn` output (§8). Miners post no capital at any point.
-- **Interleaving:** the miner serves inference when paid demand exists and falls
-  back to PoW otherwise — and per §3 it can do *both at once* during decode,
-  because decode leaves the tensor cores mostly free.
-- **Preemption granularity:** the CUDA miner already runs 3–50 ms batched launches
-  with cancellation on candidate replacement (`ai-pow-miner`'s stale-work path).
-  That is finer than a typical 20–50 ms per-token budget, so mining can yield to
-  inference without violating interactive latency.
+**Price per MAC-equivalent.** `DIFFICULTY.md` already prices the target `T` per
+MAC-equivalent, so mining EV and inference bids share a unit and a miner's
+allocation decision is a scalar comparison. The manifest fixes every shape, so a
+request's MAC count is deterministic from `(manifest, prompt length, max tokens)` and
+computable by both parties **before** execution — no metering to trust, no billing
+dispute surface. Quantity is objective; only price is negotiated, by auction.
 
-## 8. Settlement: burn-denominated inference
+**Why burn.** Not primarily deflation. Two stronger reasons:
 
-### 8.1 The reserve price already exists
+*It is the only self-dealing-proof rail.* Verification secures correctness and does
+nothing about **fake demand** — a miner paying itself to manufacture volume, which
+round-trips at zero cost under a fee that goes entirely to the miner. Under a burn
+every washed `$NOCK` costs `β`. That, not a fairness intuition, is what sets `β`.
 
-Nockchain already runs a spot market for exactly this hardware doing exactly
-these GEMMs. Block-reward EV per GPU-second is measurable from sustained TMAC/s
-and the current AI target — and `DIFFICULTY.md` is explicit that the target `T`
-prices *one MAC-equivalent of matmul work*, not one attempt, which is precisely
-the denomination needed.
+*It is the only way to raise miner revenue against a hard cap.* Aletheia sustains a
+64-NOCK floor for ~68 years because the old schedule was "forcing the network onto
+fee revenue earlier than the application ecosystem can sustain." That floor is
+denominated in NOCK, so its real value is what a burn improves, and issuance cannot
+improve it against 2³².
 
-That gives a floor: inference must outbid mining EV per GPU-second, or the miner
-keeps mining. No token subsidy is required to price the fleet, and supply is
-elastic in both directions.
+`β` is bounded not by fairness but by the **off-chain escape hatch**: miner and
+client can always settle privately, so `β` must stay under what the onchain rail is
+worth — escrow, the tie-break beacon, adjudication. Ship a low constant (10–30%) and
+raise it against observed defection.
 
-### 8.2 Price per MAC-equivalent, quantity fixed by the manifest
-
-Denominate inference in the same unit the puzzle already uses: **`$NOCK` per
-MAC-equivalent**. Two properties follow, and both remove trust rather than add it.
-
-A miner's allocation decision becomes a scalar comparison in one unit — mining EV
-per MAC-equivalent against the inference bid per MAC-equivalent — with no
-conversion and no oracle.
-
-And because the model manifest (§6) fixes every layer's shape, the MAC count of a
-request is **deterministic from `(manifest, prompt length, max tokens)` and
-computable by both parties before execution.** There is no metering to trust, no
-usage counter to falsify, and no billing dispute surface: the quantity is
-objective and known in advance, so only the price is negotiated.
-
-### 8.3 Burn is the right rail, and not primarily for deflation
-
-Payment should be a burn split: the client's payment settles as `(1−β)` to the
-serving miner and `β` to a provably unspendable output.
-
-The mechanism needs no new consensus primitive. `%brn` is already a first-class
-lock primitive in the v1 tx engine (`LockPrimitive::Burn` in
-`crates/nockchain-types/src/tx_engine/v1/tx.rs`, `%brn` in
-`hoon/common/tx-engine-1.hoon`), and Aletheia already established the precedent
-for splitting value by fixed percentage to a well-known destination — its 80/20
-miner/protocol-fund split of new issuance.
-
-The usual argument for a burn is deflation. That is real here given the 2³² hard
-cap, but it is the weaker reason. Two stronger ones:
-
-**Burn is the only self-dealing-proof payment rail.** The Tier-1/2/3 design in §5
-secures *correctness* — that a miner computed what it claimed — through detection
-and forfeiture. It does nothing whatsoever about **fake demand**: a miner paying itself
-to manufacture the appearance of volume. That matters wherever serving volume
-becomes visible and valuable — advertising utilization to attract real clients,
-reputation weighting in the scheduler, or any future rule that lets volume
-influence anything consensus-visible. Under a 100%-to-miner fee, a self-deal
-round-trips at *zero cost* and wash volume is free. Under a burn, every washed
-`$NOCK` costs exactly `β`.
-
-**This is the correct criterion for setting `β`**: not a revenue-split intuition
-about what feels fair to miners, but the price at which faking demand stops being
-profitable relative to the largest plausible benefit of faking it.
-
-**Burn is the only way to raise miner revenue against a hard cap.** Aletheia
-deliberately sustains a 64-NOCK floor for ~68 years to extend the chain's revenue
-tail, because the original schedule "front-loads ~99% of emissions into the
-chain's first thirty years… forcing the network onto fee revenue earlier than the
-application ecosystem can sustain." That floor is denominated in NOCK, so its
-*real* value is exactly what a burn improves — and improving it by issuance is
-impossible against a fixed cap. The loop closes:
-
-```text
-inference demand -> burn -> scarcer $NOCK -> higher real value of the
-64-NOCK floor -> more hashrate -> more serving capacity -> inference demand
-```
-
-A burn converts inference demand into security budget for the whole network
-rather than private revenue for whichever miner happened to serve. Given that
-Aletheia's stated motivation is precisely the long-run security-budget
-transition, the fit is unusually good.
-
-### 8.4 Modulate the market, not the price
-
-"Adjust the rate with supply and demand" is right as an objective and dangerous
-as an implementation, and the distinction is where this design most needs care.
-
-**A protocol-set price requires observing supply, and supply is not observable.**
-Settled demand is onchain and honest. Total idle GPU capacity across the fleet is
-not: it is self-reported. An EIP-1559-style controller works because block space
-is a hard cap the protocol *knows*; here the protocol has no idea what the fleet
-can do. A controller keyed on self-reported capacity is a cartel lever —
-under-report capacity, utilization appears high, the protocol raises the price —
-and it pays out precisely to coordinated under-reporting. The fewer large
-operators, the cheaper that attack.
-
-**So let the auction set the price and keep the protocol to the split.** Clients
-bid, miners accept, and the protocol burns `β` of whatever cleared. Price then
-modulates with supply and demand *automatically*, through a real two-sided market
-rather than an oracle reading, and there is nothing to manipulate: a miner that
-misrepresents its capacity moves no protocol variable, it just fails to win work.
-The burn *throughput* still rises and falls with real demand, which is the
-deflationary behavior the mechanism is meant to produce.
-
-**If `β` itself moves, key it to the security budget, not the demand cycle.**
-There is a defensible moving `β`, but the intuitive version is backwards. Burning
-a larger share when demand is high damps the miner-revenue signal exactly when
-that signal should be attracting capacity; the supply response is the one thing
-that must not be damped. The version that earns its complexity instead lets `β`
-*fall* as the block subsidy decays, shifting revenue toward miners as direct
-security funding is most needed — a slow monetary dial on a multi-month EMA,
-bounded within `[β_min, β_max]`, with hysteresis, and keyed on realized burn
-against subsidy rather than on anything a participant self-reports.
-
-### 8.5 What actually bounds `β`
-
-Not fairness, and not revenue maximization: **the off-chain escape hatch.**
-
-A miner and client can always settle privately and never touch the chain. The
-burn is a tax on using the onchain rail, so `β` must stay below what that rail is
-worth to the marginal client — escrow, the unpredictable beacon that makes Tier-2
-sampling unforgeable, and dispute adjudication. Sophisticated repeat
-counterparties who already trust each other will defect off-chain at *any* `β`;
-the rail's real market is strangers and one-shot interactions, which is also
-exactly where verifiability is worth paying for.
-
-That caps `β` well below a naive revenue-maximizing choice — my instinct is a
-10–30% band rather than 50%+ — and it should be set against *observed* off-chain
-defection once there is a market to observe, not guessed in advance.
-
-One consequence: keep the split two-way. Adding the Aletheia protocol fund as a
-third claimant on inference revenue raises the tax on the rail without a clear
-need, and the fund is already financed from issuance. Cheap rail, narrow split.
-
-### 8.6 Forfeiture, and why it makes bonds redundant rather than forbidden
-
-First, a distinction this document previously elided. **A non-yielding performance
-bond is not staking**, and it is worth being precise about why, because the
-imprecise version ("a bond you can seize is stake under another name") is
-rhetorically convenient and analytically wrong.
-
-What makes staking *staking*, in the sense a proof-of-work chain should refuse, is
-three properties together:
-
-1. the bonded capital **earns yield** proportional to itself, so money begets money
-   without work;
-2. it confers **consensus weight** — capital buys the right to produce blocks or
-   order transactions; and
-3. it becomes **the security budget**, displacing work as the thing that secures
-   the chain.
-
-A performance bond that pays no yield, carries no fork-choice weight, and secures
-an application-layer service agreement has none of those. It is a surety deposit,
-closer to an escrowed damages cap than to a validator stake. Someone objecting to
-it on PoS grounds is objecting to the wrong thing.
-
-**So the argument against requiring one has to be made on its merits, and it is a
-different argument: with detection near-certain, a bond buys nothing.**
-
-The analogy is already in the protocol: **an invalid block does not seize anything
-from the miner who produced it. It simply wastes the work.** Orphaning is a
-complete deterrent with no capital at risk, because the miner has already spent the
-electricity. Serving can work the same way — and §8.8 shows that once Tier 0 pushes
-detection probability near 1, forfeited payment plus forgone mining EV *already*
-exceeds what any profitable cheat could gain. A bond stacked on top of that is
-redundant collateral against a loss the miner is already fully exposed to.
-
-Redundant is a weaker claim than forbidden, and it is the one that survives
-scrutiny. Two costs then decide it, and both argue for keeping the base path
-bondless:
-
-- **A bond is a capital barrier to entry.** §3's entire thesis is that one person
-  with one consumer card can join. Any mandatory locked balance sets a floor on
-  participation that has nothing to do with whether that person's GPU computes
-  correctly.
-- **Locked `$NOCK` has a real opportunity cost precisely because it does not
-  yield.** Against a hard-capped asset this design is deliberately making scarcer
-  (§8.3), capital that cannot be sold, spent, or moved is genuinely expensive to
-  post — which is a point in favour of the user's framing (no rentier dynamic,
-  no yield) and simultaneously a reason not to demand it of everyone.
-
-**Verify before pay, never pay before verify.** Restructure so a miner is never
-paid ahead of verification. Then there is nothing to claw back and nothing to
-seize, because the escrow simply never releases. What a cheating miner loses is:
-
-- the payment, which returns to the client;
-- the GPU-seconds it already spent, which are sunk; and
-- the **mining EV it forwent** by serving instead of mining that window.
-
-That third term is the collateral, and it is denominated in proof-of-work. The
-miner posted nothing — it *spent* something, which is the only currency a PoW
-chain should ask for.
-
-**Ordering.** Client escrows payment with the request; miner claims with an
-admission ticket (below) signed by its serving identity; miner serves and publishes
-tokens, fingerprint, and commitment; client verifies at ~1% of serving cost, or
-accepts; escrow releases `(1−β)/β` on pass. On failure the beacon selects a tile
-and the miner must answer with a Tier-2 certificate. A verifying certificate
-releases the escrow to the miner — a spurious challenge does not win. A failed or
-absent certificate refunds the client and retires the identity.
-
-### 8.7 Work-backed serving identity
-
-Independently of whether anyone posts a bond, the base path needs an identity that
-is expensive to create and worth keeping. A serving identity is a keypair whose
-standing comes from work rather than from a deposit — which is what lets the
-default path require no capital at all:
-
-- **Admission costs work.** Activating an identity requires a PoW ticket — the same
-  puzzle at lower difficulty, priced in the same MAC-equivalents as everything else
-  (§8.2). This is what makes identities Sybil-resistant without capital.
-- **Claiming a request costs a ticket too.** A miner that claims work and abandons
-  it has burned real compute for nothing, which is the bondless answer to
-  claim-and-abandon griefing.
-- **Challenging costs a ticket, symmetrically.** This is what stops a client from
-  disputing every request to avoid paying; the certificate resolves who was right,
-  and the challenger's ticket is spent either way.
-- **History accrues to the identity.** Verified served requests earn scheduler
-  preference and access to higher-value work.
-- **A proven failure retires the identity** rather than seizing anything. The cost
-  of misbehavior is having to redo the admission work and rebuild the history —
-  exactly the cost structure of losing a block to a reorg.
-
-No capital is locked at any point, so there is no minimum-capital barrier to a
-consumer operator joining, and no capital-seizure logic anywhere in the protocol.
-
-### 8.8 What forfeiture alone actually buys
-
-Let `M` be mining EV per GPU-second (§8.1), `C_r` the GPU-seconds to serve
-honestly, `γ > 1` the cheat's compute advantage (so cheating costs `C_r/γ` and the
-remainder can be spent mining), `P` the payment, and `q` the probability of
-detection *before escrow releases*. Write `ρ = P / (M·C_r)` for the premium
-inference pays over simply mining — necessarily `ρ > 1`, or nobody serves.
-
-Over a window of `C_r` GPU-seconds, honest serving earns `P`, while cheating earns
-`(1−q)P + M·C_r(1 − 1/γ)`. Cheating fails to pay when:
+**Deterrence.** Let `M` = mining EV per GPU-second, `C_r` = GPU-seconds to serve,
+`γ > 1` the cheat's compute advantage, `P` the payment, `q` the detection
+probability before release, and `ρ = P/(M·C_r) > 1` the premium inference pays over
+mining. Honest serving earns `P`; cheating earns `(1−q)P + M·C_r(1 − 1/γ)`. Cheating
+fails to pay when:
 
 ```text
 q  >  (1 − 1/γ) / ρ
 ```
 
-| `γ` (cheat advantage) | `ρ = 1` | `ρ = 1.5` | `ρ = 2` | `ρ = 3` |
-|---|---:|---:|---:|---:|
-| 1.5 | 0.333 | 0.222 | 0.167 | 0.111 |
-| 2 | 0.500 | 0.333 | 0.250 | 0.167 |
-| 4 (INT4 for INT7) | 0.750 | 0.500 | 0.375 | 0.250 |
-| 8 | 0.875 | 0.583 | 0.438 | 0.292 |
+| `γ` | `ρ = 1` | `ρ = 2` | `ρ = 3` |
+|---|---:|---:|---:|
+| 2 | 0.500 | 0.250 | 0.167 |
+| 4 (INT4 served for INT7) | 0.750 | 0.375 | 0.250 |
+| 8 | 0.875 | 0.438 | 0.292 |
 
-Two readings, and the second is why this design can drop bonds at all.
+**Without Tier A this is unreachable** — certificate sampling alone gives `q ≈
+0.01–0.05` and misses every row. That is exactly why earlier drafts needed capital:
+it was substituting for a detection probability the verification layer could not
+deliver. **With Tier A, `q ≈ 1`** on the high-`γ` substitution cheats that dominate
+the economics — serving cheaper precision or a smaller model, a 2–4× saving on every
+request with plausible outputs. Every row clears with margin.
 
-**Without Tier 0, bondless enforcement is hopeless.** ZK sampling gives `q = p ≈
-0.01–0.05`. Every row of that table is out of reach. This is precisely why the
-earlier drafts needed stake: capital was substituting for a detection probability
-the verification layer could not deliver.
+The residual attack closes it: spoofing top-`k` under tolerance plausibly requires
+the honest result to aim at, so `γ ≤ 1` and the threshold goes non-positive. **An
+attack costing more than honest work needs no deterrent.** That is an argument, not
+a theorem, and it is a measurement gate (§7).
 
-**With Tier 0, `q ≈ 1` for exactly the cheats that have favourable `γ`.** Precision
-and model substitution — the high-`γ`, high-volume cheats that dominate the
-economics (§8.9) — are caught on every response, and cheaply enough that clients
-verify their own traffic in full. Every row is satisfied with enormous margin.
+Note the monotonicity: the more inference pays over mining, the less detection is
+needed. The mechanism gets safer as the market gets more valuable.
 
-Note also the reassuring monotonicity: **the more inference pays over mining, the
-less detection is needed**, because forfeiting a larger premium hurts more. The
-mechanism gets safer exactly as the market gets more valuable.
+## 6. The consensus route: one lock primitive
 
-**The residual adversary closes the argument.** For the attack Tier 0 cannot bound
-— constructing activations that spoof top-`k` under tolerance — the attacker
-plausibly needs the honest result to aim at, so `γ ≤ 1` and the right-hand side
-goes non-positive: **an attack that costs more than honest work needs no deterrent
-at all.** The gap between "cheats TOPLOC catches" and "cheats worth attempting" is
-what makes the bondless construction close. That is an argument, not a theorem, and
-`γ` for adversarial spoofing is a measurement gate (§9), not an assumption.
+Everything above composes from primitives the chain already has, except one thing.
 
-### 8.9 Which cheat the economics are actually about
+The escrow output is spendable three ways:
 
-The dominant cheat in a consumer GPU cloud is not fabricating outputs — those must
-look plausible, which is hard. It is **serving a cheaper precision or a smaller
-model than was paid for**: a 2–4× saving on *every* request, indefinitely, with
-outputs that read as fine. That is the `γ = 2…4` row above, and it is the case
-Tier 0 detects on every response at essentially no cost.
+1. **Happy path** — miner signature + client signature. Plain multisig, already
+   expressible.
+2. **Miner never delivered** — client alone after timeout. Plain timelock, already
+   expressible.
+3. **Client disputes but the miner was honest** — miner alone, by presenting a
+   certificate that verifies against the committed statement digest.
 
-Under ZK sampling alone that cheat earns roughly `1/p` requests of free margin
-before detection. Under Tier 0 it earns none.
+Only path 3 needs anything new: **one lock primitive, `%aip`, satisfied by an
+AI-PoW certificate verifying against a statement digest committed in the output.**
 
-### 8.10 Funding the challenge on the bondless path
+This is small because the work is already done. `ai_pow_verify_jet` exists, and
+production nodes "build and validate the complete setup table at boot" for every
+reachable trace height — the verifier and its setup are **already resident for block
+acceptance**. The primitive exposes a check the node already performs.
 
-An earlier draft paid challengers out of seized collateral. With no bond on the
-base path, the burn leg funds it instead: **on a proven failure, the `β` that would have burned pays the
-challenger instead**, and the client is refunded in full. No new money, no bond,
-and the burn simply does not happen in the case where verification had to be paid
-for.
+Everything else stays off the consensus path: matching and the request mempool are
+offchain, the manifest registry is a NockApp with a well-known root, the burn leg is
+an existing `%brn` output, and identities are ordinary keypairs. The kernel learns
+nothing about inference, prompts, models, or fingerprints. There is no dispute game
+in consensus, no seizure logic, and no second puzzle.
 
-This matters much less than it would have. At ~100× cheaper verification the
-natural challenger is the *client itself*, already motivated by its own refund, so
-third-party watchtowers are a supplement rather than the load-bearing role. And
-because challenging costs an admission ticket (§8.7), the griefing incentive an
-oversized bounty would create is bounded by work rather than by policy.
+**The one real risk of this route** is transaction-validation cost: a spend that
+forces certificate verification is far more expensive to validate than a signature
+check, so `%aip` spends need fee pricing that reflects it, and the bounded-verify
+discipline that already protects block acceptance has to extend to the mempool.
+That is a contained, well-understood problem, and it is the whole of the new
+consensus surface.
 
-Two invariants survive from the bonded design:
+## 7. What must be measured first
 
-- **The client's payment is refunded, never burned, on a failed proof.** If clients
-  bore the cost of miner misbehavior the service would be unusable.
-- **A certificate, not an assertion, decides.** Escrow releases on cryptography, so
-  neither party can win a dispute by insisting.
+1. **Wall-clock cost of one compact certificate** at trace buckets 2¹³…2¹⁹.
+   `zk_bridge` already instruments `l1_circuit_build_ms`, `l1_in_circuit_verify_ms`,
+   and `l1_outer_cert_ms`. Nothing downstream is well-posed without it.
+2. **`γ` for adversarial top-`k` spoofing.** The bondless construction closes on the
+   claim that spoofing costs more than serving honestly. It is load-bearing now that
+   no capital backstops a mistake. Attack it directly.
+3. **TOPLOC thresholds for the Pearl quantization.** Published thresholds are for
+   stock Llama-3.1-8B-Instruct; the INT7 group_1 / FP8 group_0 mix is a different
+   quantization. Calibrate across the fleet's real hardware tail — a false positive
+   on an honest miner is worse than a missed detection, since Tier B catches the
+   latter and nothing repairs the former.
+4. **Tier-A overhead on the serving path** — confirm the async tee is free rather
+   than assuming it from bandwidth arithmetic.
+5. **`%aip` verification cost** per spend, for mempool fee pricing.
+6. **Off-chain defection rate**, once a market exists. The only honest way to bound
+   `β`, and the only gate that cannot be run before launch.
 
-### 8.11 Where a bond does real work: an optional assurance tier
+## 8. Limits
 
-Forfeiture caps the miner's exposure at the fee. That is sufficient for deterrence
-(§8.8) and insufficient for **compensation** whenever a client's downside exceeds
-what it paid — inference costing a fraction of a cent feeding a decision worth far
-more. No detection probability fixes that; the gap is between deterrence and
-indemnity, and only capital closes it.
+**No prompt privacy.** Miners see prompts and activations; mid-stack activations are
+substantially invertible. The proof layer establishes correctness, not
+confidentiality — the client's input is an input to the prover, not a secret from
+it. Keeping first and last layers client-side narrows but does not close this.
 
-So the useful form of the bond idea is **optional and market-priced, never
-protocol-mandated**:
+**Only one verification layer is sound.** Tier B's cryptographic guarantee covers
+INT7 group_1 linears. Attention, normalization, sampling, and FP8 are covered by
+Tier A and replay — real coverage, far broader than proof coverage, but statistical.
+The service must state both halves.
 
-- A miner *may* post a non-yielding performance bond against its serving identity
-  to become eligible for higher-assurance work.
-- Clients needing recourse beyond fee forfeiture route to bonded miners and pay a
-  premium for it.
-- On a proven failure the bond compensates the client up to the posted amount, on
-  top of the refund.
-- The protocol pays no yield on it, grants it no fork-choice weight, and never
-  requires it.
+**Tier A must not displace Tier B.** This is the likeliest way the design degrades,
+and it will arrive as a cost optimization. TOPLOC's reported 100% detection is
+empirical against the modifications its authors tested, not a proof against an
+adversary who knows the scheme and is paid to defeat it. LSH is built for robustness
+to *incidental* perturbation; *adversarial* robustness is strictly stronger and is
+not established. So: a fingerprint mismatch **escalates, and is never itself a
+verdict** — payment moves only on a certificate or a timeout, which also means an
+honest miner on unusual hardware gets challenged and then exonerated. And thresholds
+are versioned, consensus-visible parameters; a silently loosened tolerance weakens
+everything with no outward sign.
 
-This keeps the base path pure proof-of-work and open to anyone with one GPU, while
-letting a market — rather than a protocol parameter — decide how much indemnity a
-given workload is worth. It is the same posture §8.4 takes on price: fix the
-structure, let the market set the level.
+**Forfeiture prices griefing rather than preventing it.** §5 shows cheating does not
+pay; it does not constrain an attacker indifferent to profit. No bond would fix that
+either. The protection is the per-claim admission ticket, and whether its difficulty
+is high enough is a policy question this document does not settle.
 
-## 9. What must be measured first
+**Statement separation is a security requirement.** An inference certificate must
+never be replayable as a PoW certificate or vice versa. Zeroing the noise removes the
+anti-reuse property the puzzle depends on — finding F01 of the dual-puzzle audit was
+exactly that cached nonce-independent state let a miner grind without fresh
+inference. Domain-separate at the statement level and test adversarially in both
+directions.
 
-**The sampling rates above are unresolved until `C_p` is measured, and I have not
-found a measurement of it in this repository.** Everything else in this design is
-grounded in code or in the existing roofline; this one number is not, and I have
-deliberately not invented a value for it.
+## 9. Plan
 
-Required before any of this is committed to:
+Each stage is independently checkable. The measurement gate precedes the design
+commitments that depend on it.
 
-1. **Wall-clock cost of one compact recursive certificate** at each production
-   trace bucket 2¹³…2¹⁹ — Layer 0 + Layer 1 recursion + Layer 2 — on the target
-   consumer GPU and on CPU. `zk_bridge` already instruments `l1_circuit_build_ms`,
-   `l1_in_circuit_verify_ms`, and `l1_outer_cert_ms`, so the harness largely
-   exists. This sets `p`, and therefore the entire security/overhead trade.
-2. **Whether proving can overlap decode** without disturbing the §3 roofline, or
-   whether it contends for bandwidth after all. The 92% headroom claim is an
-   arithmetic upper bound, not a measurement.
-3. **Real served throughput** at realistic context lengths, against the roofline's
-   ~3.4k tok/s estimate, following the same measurement discipline as the RTX 5090
-   roofline (sustained clocks, real data, median of repeated runs — the roofline
-   doc's warning that synthetic all-ones inputs inflate results by 22–30% applies
-   here too).
-4. **Cost of the zero-noise inference statement**, and confirmation that
-   domain-separating it cannot weaken the PoW anti-reuse invariant.
-5. **TOPLOC threshold calibration for the Pearl quantization.** The published
-   thresholds were established for Llama-3.1-8B-Instruct; the Pearl variant's
-   INT7 group_1 / FP8 group_0 mix is a *different* quantization, so the mantissa
-   thresholds must be re-derived against it rather than inherited. Calibrate
-   across the fleet's real hardware distribution, including its long tail — a
-   false positive on an honest miner with unusual hardware is far more damaging
-   than a missed detection, because Tier 2 catches the latter and nothing repairs
-   the former.
-6. **Tier-0 overhead on the serving path**: confirm the async tee costs neither
-   TTFT nor throughput, rather than assuming it from the bandwidth arithmetic.
-7. **`γ` for adversarial top-`k` spoofing** (§8.8). The bondless construction closes
-   on the claim that spoofing the fingerprint costs *more* than serving honestly.
-   That is an argument, not a theorem, and it is the load-bearing one now that no
-   capital backstops a mistake. Attack it directly: try to produce a materially
-   cheaper computation whose top-`k` last-hidden-state values survive tolerance.
-8. **Off-chain defection rate** once a market exists. This is the only honest way
-   to bound `β` (§8.5), and unlike the others it cannot be measured before
-   launch — which is the argument for shipping a deliberately low constant `β`
-   and raising it against evidence, rather than starting high.
+1. **Measure** certificate cost and adversarial `γ` (§7.1, §7.2).
+2. **Model manifest** — per-tensor roots in `commit.rs` layout, provable/attested
+   classification per layer, conformance KAT against the shipped model.
+3. **Zero-noise inference statement** in `ai-pow`, domain-separated, with cross-replay
+   rejection tests in both directions.
+4. **Tier A** as an async tee in the vLLM plugin boundary, thresholds recalibrated
+   for the Pearl quantization. Highest value per unit effort in the plan: nearly
+   free, no consensus involvement, and it closes the substitution cheat that
+   dominates the economics.
+5. **Tier B** on a named tile via `from_tile`, verified offchain end to end.
+6. **`%aip` lock primitive** with mempool fee pricing — the only consensus change,
+   and the only stage owed a full protocol review.
+7. **Settlement and scheduler** — escrow, auction, burn split, admission tickets,
+   PoW/inference interleaving at the existing cancellation granularity.
 
-## 10. Risks and honest limits
+Stages 2–5 carry no consensus risk and can proceed in parallel once stage 1 lands.
+Stage 6 is the review gate.
 
-**No prompt privacy.** The miner sees prompts and activations in the clear, and
-mid-stack activations are substantially invertible. The ZK layer here proves
-*correctness*, not confidentiality — the client's input is not a secret from the
-prover, it is an input to it. Any claim otherwise would be false. Realistic
-options are to scope the service to non-sensitive workloads, or to keep the first
-and last layers client-side so miners see only mid-stack activations, which
-narrows but does not close the exposure.
+## 10. Summary
 
-**Statement separation is a security requirement, not hygiene.** An inference
-certificate must never be replayable as a PoW certificate or vice versa. Zeroing
-the noise removes the anti-reuse property the puzzle depends on
-(`ai-pow/docs/2026-07-17_DUAL_PUZZLE_CONSENSUS_AUDIT.md`, finding F01: cached
-nonce-independent state let a miner grind without fresh inference). Domain
-separation must be enforced at the statement level and tested adversarially in
-both directions.
+The cryptography largely exists; the missing pieces are provenance, addressing,
+verification policy, and settlement. Two verification layers with opposite blind
+spots — a near-free fingerprint covering the whole forward pass statistically, and a
+sound certificate covering one tile on dispute. Payment escrows and releases only
+after verification, so collateral is work rather than capital and no bond is
+required. Price by auction per MAC-equivalent, with a fixed burn fraction that makes
+fake demand cost something and converts inference demand into security budget
+against a hard cap.
 
-**Consensus surface growth is the main systemic risk.** This repository's own
-audit record — the dual-puzzle consensus audit and
-`2026-07-29_TIME_BANKED_FORK_EXPLOIT.md` — shows how readily dual-puzzle
-economics produce exploits that are invisible in the component crates. A dispute
-game with timeouts added to the consensus kernel is a large new attack surface
-against a chain whose fork choice is already carrying two puzzles. Dropping bonds
-helps here as well as economically: with no capital to seize, the kernel never
-needs seizure logic, and the worst outcome of a dispute bug is a misrouted payment
-rather than a confiscation.
+The structural argument for consumer GPUs is that an 8B model fits on one card, so
+the fleet needs no interconnect, and that KV-capped decode leaves ~92% of the INT8
+tensor cores idle in exactly the units AI-PoW consumes. Verification is paid for out
+of compute the serving workload cannot use.
 
-The mitigation follows the repository's own stated architecture rather than
-fighting it. `README.md`: "Applications execute offchain as sovereign NockApps and
-can settle verifiable results to the shared chain." **The inference cloud should
-be a NockApp** — mempool, matching, escrow, and the bisection game all offchain,
-settling only outcomes to the chain. The consensus kernel should learn nothing
-about inference beyond what it already verifies. Only the model manifest registry
-plausibly belongs onchain, and even that could start as a NockApp with a
-well-known root.
+The route into consensus is one lock primitive exposing a verifier every node
+already runs at boot. Everything else — matching, manifest, disputes, identities —
+stays offchain.
 
-**Verification is layered, and only one layer is sound.** Tier 2's *cryptographic*
-guarantee covers INT7 group_1 linears and nothing else. Attention, normalization,
-activation functions, sampling, and the FP8 layers are covered by Tier 0's
-fingerprint and Tier 3's replay — real coverage, and far broader than proof
-coverage, but **statistical rather than sound.** The service must state both
-halves: soundly proven on a sampled tile of the integer linear path, empirically
-fingerprinted end to end. No amount of layering turns the second into the first at
-this model scale.
-
-**Forfeiture does not deter a griefer.** The §8.8 argument shows cheating does not
-*pay*; it does not show that an attacker indifferent to profit will not serve
-garbage to degrade the network. No bond fixes this either — a well-funded griefer
-posts and forfeits capital just as readily — but the honest statement is that the
-bondless design's protection here is the per-claim admission ticket (§8.7), which
-prices griefing in work rather than preventing it. Whether that price is high
-enough is a live question and depends on ticket difficulty, which is a policy dial
-this document does not set.
-
-**Tier 0 must not be allowed to displace Tier 2**, and this is the most likely way
-the design degrades in practice — it will arrive looking like a cost optimization.
-
-TOPLOC reports 100% detection with no false positives, but that is an *empirical*
-result against the modifications its authors tested, not a proof against an
-adversary who knows the scheme and optimizes against it. In a research evaluation
-that distinction is academic. Here, real money would reward finding a cheaper
-computation whose top-`k` last-hidden-state values survive the published
-tolerance, and nobody has yet had that incentive. Locality-sensitive hashing is
-built for robustness to *incidental* perturbation; robustness to *adversarial*
-perturbation is a strictly stronger property and is not established.
-
-Three consequences:
-
-- **Tier 0 escalates; it is never itself a verdict.** A fingerprint mismatch opens
-  a Tier-2 challenge. Payment is withheld only on a failed or contradicted
-  certificate, or on a timeout, never on a fingerprint alone. This also contains the
-  false-positive risk from §9.5 — an honest miner on unusual hardware gets
-  challenged, and the certificate exonerates it and releases its payment.
-- **Keep `p` strictly positive** however good Tier 0 looks in production. Its whole
-  job is deterring the adversary Tier 0 cannot bound, and that adversary's absence
-  from the logs is not evidence of their impossibility: a cheat designed to pass
-  Tier 0 is, by construction, invisible to Tier 0.
-- **Thresholds are consensus-visible parameters**, versioned and changed
-  deliberately. A silently loosened tolerance weakens the entire scheme with no
-  outward sign.
-
-## 11. Staged plan
-
-Ordered so that each stage produces something independently checkable, and so
-that the measurement gate precedes the design commitments that depend on it.
-
-1. **Measure `C_p`** (§9). Nothing downstream is well-posed without it.
-2. **Model manifest format and registry**, offline first: per-tensor roots in
-   `commit.rs` layout, per-layer provable/attested classification, conformance KAT
-   against the shipped model.
-3. **Zero-noise inference statement** in `ai-pow`, domain-separated from the PoW
-   statement, with cross-replay rejection tests in both directions.
-4. **Tier-1 commitment path** in the vLLM plugin boundary: per-layer activation
-   roots emitted on the serving path, with the overhead measured against §9.2.
-5. **Tier-2 spot proof**, driven by block-hash beacon selection through
-   `StripIndexSchedule::from_tile`.
-6. **Burn-split settlement** over the existing `%brn` primitive: per-MAC bid
-   escrow, `(1−β)/β` split on success, refund on failed proof. No price
-   controller; `β` fixed for the first deployment.
-8. **Tier-3 bisection game** as a NockApp: challenge, certificate, forfeiture, and
-   identity retirement. No capital-seizure path anywhere; consensus untouched.
-9. **Scheduler and interleaving**, including PoW/inference preemption at the
-   existing cancellation granularity.
-
-Stages 2–7 are additive and carry no consensus risk. Stage 8 is where the real
-design review is owed, and it should be reviewed against the existing dual-puzzle
-audit findings rather than in isolation. A moving `β` (§8.4) is explicitly *not*
-in this plan: ship a constant, observe the market, and only then decide whether a
-dial is worth its attack surface.
-
-## 12. Summary
-
-The cryptography for verifiable inference on Nockchain largely exists; the missing
-pieces are provenance, addressing, verification policy, and settlement. The
-mechanism that fits the hardware is layered commit-then-challenge with
-forfeiture-based dispute: a near-free locality-sensitive activation fingerprint on
-every response, unforgeable random STARK spot proofs, and cheap replay as the
-backstop. The two verification layers are chosen for complementary blind spots —
-the fingerprint covers the whole forward pass but is statistical, the STARK is
-sound but covers one tile — and neither suffices alone.
-
-The structural argument for consumer GPUs specifically is that an 8B model fits on
-one card — so the fleet needs no interconnect — and that KV-capped decode leaves
-~92% of the INT8 tensor cores idle in exactly the units AI-PoW consumes. The
-verification is paid for out of compute that the serving workload cannot use.
-
-**Nothing in it requires posting capital**, though nothing forbids it either. A
-non-yielding performance bond is not staking — it earns no yield, carries no
-fork-choice weight, and does not become the security budget — so the case against
-*requiring* one rests on redundancy rather than principle: because the miner is
-never paid before a cheat forfeits the payment, the compute it already spent, and the
-mining EV it gave up to serve — collateral denominated in work, not capital, which
-is what a proof-of-work chain should be asking for. Identities are backed by
-admission tickets rather than bonds, and a proven failure retires an identity
-instead of seizing anything, exactly as an orphaned block wastes work without
-confiscating it. That construction closes only because Tier 0 pushes detection
-probability near 1 on the cheats worth attempting; with STARK sampling alone the
-required detection rates are unreachable and capital would have to substitute for
-them.
-
-Settlement should be a burn split, denominated per MAC-equivalent so the manifest
-makes every request's quantity objective in advance. The burn's primary job is not
-deflation but making fake demand cost something — it is the only rail on which a
-miner cannot wash its own volume for free — and, against a hard supply cap, the
-only way inference demand can raise the real value of the 64-NOCK floor that funds
-long-run security. Price should come from auction rather than a protocol
-controller: supply is self-reported and therefore a cartel lever, so the protocol
-fixes the split and the market fixes the price.
-
-The honest limits are that only one verification layer is cryptographically sound
-and it samples the INT7 linear path, that end-to-end coverage is statistical and
-rests on adversarial robustness nobody has yet stress-tested with money on the
-line, that miners see prompts, that forfeiture deters profit-seeking cheats but
-only prices griefing rather than preventing it, that `β` is bounded by an
-off-chain escape hatch nobody can measure before launch, and that the dispute game
-is the one genuinely risky addition — which is why it belongs in a NockApp and not
-in the consensus kernel.
+The honest limits are that only one layer is sound and it samples the integer linear
+path, that end-to-end coverage rests on adversarial robustness nobody has tested with
+money on the line, that miners see prompts, and that forfeiture deters profit-seeking
+cheats without preventing griefing.
 
 ## References
 
 [1] Jack Min Ong, Matthew Di Ferrante, Aaron Pazdera, Ryan Garner, Sami Jaghouar,
-Manveer Basra, Max Ryabinin, Johannes Hagemann. *TOPLOC: A Locality Sensitive
-Hashing Scheme for Trustless Verifiable Inference.* arXiv:2501.16007, January 2025
-(rev. May 2025); ICML 2025. <https://arxiv.org/abs/2501.16007>
+Manveer Basra, Max Ryabinin, Johannes Hagemann. *TOPLOC: A Locality Sensitive Hashing
+Scheme for Trustless Verifiable Inference.* arXiv:2501.16007, January 2025 (rev. May
+2025); ICML 2025. <https://arxiv.org/abs/2501.16007>


### PR DESCRIPTION
Adds one document, `docs/ai-pow-integration/verifiable-inference-cloud.md`. No code, no protocol change. It considers a mechanism for aggregating the AI-PoW miner fleet into a consumer-GPU cloud selling verifiable inference, and decides one mechanism per purpose rather than surveying options.

## Why the starting point is closer than it looks

`crates/ai-pow/src/quant.rs` documents the quant-extraction contract `Q` as **bit-lossless** — a pure reindex of the operands vLLM already computed, no requantization. The mined integers *are* the inference integers on `pearl-ai/Llama-3.1-8B-Instruct-pearl`. So the gap to a service is provenance, addressing, verification policy, and settlement — the things `synth.rs` and `ai-pow-zk/docs/SECURITY.md` both explicitly route to network policy.

Two existing pieces do most of the work:

- `StripIndexSchedule::from_tile` proves a tile *someone else names*, not just a jackpot winner.
- `ai_pow_verify_jet` already exists, and production nodes build the complete verifier setup table at boot for every reachable trace height.

## The design as decided

**Two verification layers, chosen for opposite blind spots.** Tier A is a TOPLOC locality-sensitive fingerprint (arXiv:2501.16007) on every response — ~free, covers the whole forward pass including attention, norms, and the FP8 layers proof cannot reach, but statistical. Tier B is the existing compact recursive certificate over a named tile, on dispute only — cryptographic, but one tile of one INT7 GEMM. Neither is adequate alone.

**Settlement is verify-before-pay, with no capital posted.** Escrow releases only after verification, so a cheat forfeits the payment, the compute it spent, and the mining EV it gave up by serving instead of mining. Collateral is denominated in work. The deterrence condition is `q > (1 − 1/γ) / ρ`; with certificate sampling alone (`q ≈ 0.01–0.05`) it is unreachable, which is why bonds looked necessary — with Tier A at `q ≈ 1` on the substitution cheats that dominate the economics, it clears with margin.

**Price by auction per MAC-equivalent, with a fixed burn fraction.** `DIFFICULTY.md` already prices the target per MAC-equivalent, so mining EV and inference bids share a unit and the manifest makes each request's quantity computable in advance. The burn's primary job is not deflation but pricing fake demand — under a fee that goes entirely to the miner, self-dealing round-trips at zero cost.

## The consensus surface: one lock primitive

This is the part worth reviewing closely. The escrow output is spendable three ways:

1. Miner sig + client sig — plain multisig, already expressible
2. Client alone after timeout — plain timelock, already expressible
3. Miner alone, presenting a certificate that verifies against a committed statement digest

Only path 3 needs anything new: **one lock primitive, `%aip`**, exposing a verifier every node already runs at boot. The expensive path is also the rare path — normally the client verifies at ~1% of serving cost and signs, so consensus sees a certificate only on real disagreement.

Everything else stays offchain: matching, manifest registry, disputes, identities. No dispute game in consensus, no seizure logic, no second puzzle.

The one real risk of this route is recorded in the doc: a spend forcing certificate verification costs far more to validate than a signature check, so `%aip` needs mempool fee pricing and the bounded-verify discipline protecting block acceptance has to extend to the mempool.

## Two corrections made during the branch

Worth flagging because both changed the design rather than the wording:

- **The bit-exact determinism claim was wrong.** An early draft committed to a bit-exact Merkle root over per-layer activations and asserted execution is deterministic given manifest and seed. False for a heterogeneous fleet — varying batch composition changes float reduction order, and the KV-capped scheduler varies it continuously, so honest miners would disagree and the dispute path would fire on honest divergence. The surviving claim is narrower: the INT7/INT8 accumulate is integer and exactly reproducible, so bit-exact commitment is correct for the integer operands only.
- **"A bond that can be seized is stake under another name" was an overclaim.** A non-yielding performance bond earns no yield, carries no fork-choice weight, and does not become the security budget. The case for a bondless base path rests on redundancy — once detection is near-certain, forfeited payment already exceeds any profitable cheat's gain — not on principle.

## Not settled, and gated on measurement

Nothing here should be implemented before these land. Two are load-bearing:

1. **Wall-clock cost of one compact certificate** at buckets 2^13…2^19. `zk_bridge` already instruments the Layer-1 timings. Nothing downstream is well-posed without it.
2. **`γ` for adversarial top-`k` spoofing.** The bondless construction closes on the claim that spoofing costs more than serving honestly — load-bearing now that no capital backstops a mistake.
3. TOPLOC threshold recalibration for the Pearl INT7/FP8 quantization, across the fleet's real hardware tail.
4. Tier-A overhead on the serving path.
5. `%aip` verification cost per spend.
6. Off-chain defection rate — the only honest bound on the burn fraction, and the only gate that cannot run before launch.

## Limits stated in the doc

No prompt privacy — the proof layer establishes correctness, not confidentiality. Only one verification layer is sound, and it samples the integer linear path. Forfeiture deters profit-seeking cheats but prices griefing rather than preventing it. Zeroing the noise for the inference statement removes the anti-reuse property the puzzle depends on, so statement separation must be tested adversarially in both directions against finding F01 of the dual-puzzle audit.

## Review notes

Docs-only; no build or test impact. The roofline figures derive from `pearl-v3-rtx5090-roofline.md` and are arithmetic, not measurements — the doc labels them as such. Commits are individually readable and the last one is a full rewrite that cut 835 lines to 382, so reviewing the final state is more useful than the diff series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKpwPad2xwe1dKMGnhv1ny