### PR TITLE
fix(consensus): schedule spend replay guard with Logos

### DIFF
--- a/changelog/protocol/016-logos.md
+++ b/changelog/protocol/016-logos.md
@@ -65,6 +65,10 @@ Logos activates AI-PoW at height 126,000 (`ai-pow-activation-height`) as an
    existing protocol fund (`protocol-fund-address`). AI-PoW changes the puzzle
    and per-puzzle retargeting, not the coinbase recipient.
 
+5. **Spend parent binding.** At and after `ai-pow-activation-height`, every seed
+   in a v1 `%1` spend must contain the hash of its input note. Pre-activation
+   pages use the transaction validation rules that produced the existing chain.
+
 This upgrade does **not** change the ZK-PoW puzzle, the emissions schedule, the
 80/20 split *ratio*, transaction formats, or any pre-activation behaviour. It
 adds a puzzle; it does not replace one.
@@ -396,6 +400,9 @@ the protocol-fund recipient.
 - **ZK re-anchor**: block 125,999 is the anchor for the new
   `zk-asert-post-ai` 214 s regime. Target computation switches for candidate
   height 126,000; block 125,999 itself remains in the pre-activation 150 s regime.
+- **Spend parent binding**: v1 `%1` seed parent hashes become mandatory at
+  `ai-pow-activation-height`. The configured activation height controls this
+  boundary on mainnet and fakenets.
 - **Verifier setup**: every validating node must have the AI-PoW verifier setup
   installed before it needs to validate an `%ai-pow` block (first boot generates
   it, ~15 min; subsequent boots load the cache). A node without it shuts down on

--- a/hoon/common/tx-engine-1.hoon
+++ b/hoon/common/tx-engine-1.hoon
@@ -1229,6 +1229,8 @@
             page-num=page-number
             max-size=@
             bythos-phase=page-number
+            ::  first page whose %1 spends bind seeds to their input note
+            parent-hash-phase=page-number
         ==
     ^-  (reason ~)
     ?:  (note-data-exceeds-max sps max-size)
@@ -1255,7 +1257,9 @@
       ::  v1 note must back a %1 spend
       ?:  ?=(^ -.note)  [%.n %v1-spend-version-mismatch]
       ?:  !=(%1 version.note)  [%.n %v1-note-version-mismatch]
-      ?.  (verify-parent-hashes:spend-1 +.sp note)
+      ?.  ?|  (lth page-num parent-hash-phase)
+              (verify-parent-hashes:spend-1 +.sp note)
+          ==
         [%.n %v1-spend-1-parent-hash-failed]
       =/  ctx=check-context
         :*  page-num

--- a/hoon/common/tx-engine.hoon
+++ b/hoon/common/tx-engine.hoon
@@ -970,6 +970,23 @@
   =+  spends:v1
   |%
   +$  form  $|(^form |=(* %&))
+  ++  validate-with-context
+    |=  $:  balance=(h-map nname nnote)
+            sps=form
+            page-num=page-number
+            max-size=@
+            bythos-phase=page-number
+        ==
+    ^-  (reason ~)
+    %-  validate-with-context:spends:v1
+    :*  balance
+        sps
+        page-num
+        max-size
+        bythos-phase
+        ai-pow-activation-height
+    ==
+  ::
   ::  count note-data words as stored on output notes (outputs are built by
   ::  grouping all seeds across the tx by lock-root)
   ++  note-data-by-lock-root

--- a/hoon/tests/dumb/mod/unit/transact-v1.hoon
+++ b/hoon/tests/dumb/mod/unit/transact-v1.hoon
@@ -12,6 +12,35 @@
     h  ~(. helpers constants)
 ::  +der: pre-activation derived-state (read-only extra arg for consensus/miner doors)
 ++  der  ^-  derived-state  *derived-state
+++  test-v1-spend-1-parent-hash-binding
+  =/  note=nnote:t
+    (make-simple-note:v1:h p:default-keys-1:h 100.000)
+  =/  other-note=nnote:t
+    (make-simple-note:v1:h p:default-keys-2:h 100.000)
+  =/  parent-hash=hash:t  (hash:nnote:t note)
+  =/  other-parent-hash=hash:t  (hash:nnote:t other-note)
+  ?.  !=(parent-hash other-parent-hash)
+    (expect !>(%.n))
+  =/  pk=schnorr-pubkey:t
+    (head ~(tap z-in pubkeys.p:default-keys-1:h))
+  =/  [root=hash:t *]  (make-pkh-lock:v1:h 1 ~[pk])
+  =/  matching-seed=seed:v1:t
+    (make-seed:v1:h root 90.000 parent-hash)
+  =/  mismatched-seed=seed:v1:t
+    (make-seed:v1:h root 90.000 other-parent-hash)
+  =/  matching-spend=spend-1:v1:t
+    %*  .  *spend-1:v1:t
+      seeds  (~(put z-in *seeds:v1:t) matching-seed)
+      fee    10.000
+    ==
+  =/  mismatched-spend=spend-1:v1:t
+    matching-spend(seeds (~(put z-in *seeds:v1:t) mismatched-seed))
+  %+  expect-eq
+    !>([%.y %.n])
+  !>  :*  (verify-parent-hashes:spend-1:v1:t matching-spend note)
+          (verify-parent-hashes:spend-1:v1:t mismatched-spend note)
+      ==
+::
 ++  test-process-v0-into-v1
   =/  con=consensus-state  initial-consensus-state:h
   =^  par=page:t  con  (add-n-pages:h 1 con default-retain:h)

--- a/hoon/tests/dumb/mod/unit/transact-v1.hoon
+++ b/hoon/tests/dumb/mod/unit/transact-v1.hoon
@@ -41,6 +41,68 @@
           (verify-parent-hashes:spend-1:v1:t mismatched-spend note)
       ==
 ::
+++  replay-guard-validation
+  |=  [activation=page-number:t page-num=page-number:t parent-match=?]
+  =/  bc=blockchain-constants:t
+    constants(ai-pow-activation-height activation)
+  =/  et  ~(. tx-engine bc)
+  =/  pk=schnorr-pubkey:t
+    (head ~(tap z-in pubkeys.p:default-keys-1:h))
+  =/  [root=hash:t sc=spend-condition:v1:t *]
+    (make-pkh-lock:v1:h 1 ~[pk])
+  =/  note=nnote-1:v1:t
+    %*  .  *nnote-1:v1:t
+      version      %1
+      origin-page  0
+      name         (new-v1:nname:t root [*hash:t %.n])
+      note-data    *(z-map @tas *)
+      assets       100.000
+    ==
+  =/  other-note=nnote-1:v1:t  note(origin-page 1)
+  =/  parent-hash=hash:t
+    ?:(parent-match (hash:nnote:t note) (hash:nnote:t other-note))
+  =/  seed=seed:v1:t
+    (make-seed:v1:h root 90.000 parent-hash)
+  =/  spend=spend-1:v1:t
+    %*  .  *spend-1:v1:t
+      seeds  (~(put z-in *seeds:v1:t) seed)
+      fee    10.000
+    ==
+  =/  sig-hash=hash:t  (sig-hash:spend-1:v1:t spend)
+  =/  witness=witness:t
+    (make-pkh-witness:v1:h root sc sig-hash ~[[s:default-keys-1:h pk]])
+  =.  spend  spend(witness witness)
+  =/  name=nname:t  ~(name get:nnote:t note)
+  =/  balance=(h-map nname:t nnote:t)
+    (~(put h-by *(h-map nname:t nnote:t)) name note)
+  =/  spends=spends:v1:t
+    (~(put z-by *spends:v1:t) name [%1 spend])
+  %-  validate-with-context:spends:et
+  :*  balance
+      spends
+      page-num
+      max-size.data.bc
+      bythos-phase.bc
+  ==
+::
+++  test-v1-spend-1-parent-hash-legacy-before-ai-activation
+  =/  activation=page-number:t  50
+  %+  expect-eq
+    !>([%.y ~])
+  !>((replay-guard-validation [activation (dec activation) %.n]))
+::
+++  test-v1-spend-1-parent-hash-rejected-at-ai-activation
+  =/  activation=page-number:t  50
+  %+  expect-eq
+    !>([%.n %v1-spend-1-parent-hash-failed])
+  !>((replay-guard-validation [activation activation %.n]))
+::
+++  test-v1-spend-1-matching-parent-hash-accepted-at-ai-activation
+  =/  activation=page-number:t  50
+  %+  expect-eq
+    !>([%.y ~])
+  !>((replay-guard-validation [activation activation %.y]))
+::
 ++  test-process-v0-into-v1
   =/  con=consensus-state  initial-consensus-state:h
   =^  par=page:t  con  (add-n-pages:h 1 con default-retain:h)


### PR DESCRIPTION
## Problem

The v1 spend seed-to-parent binding was applied to every block. A historical pre-Logos transaction does not satisfy that rule, so a node that replays mainnet from genesis stops after height 41,111 with `v1-spend-1-parent-hash-failed`. Consensus rules must not invalidate the existing chain retroactively.

## Decision

- Keep the parent-hash verifier as the replay guard.
- Apply it only at and after `ai-pow-activation-height`.
- Read the activation height from `blockchain-constants`, including fakenet overrides.
- Preserve the existing `validate-with-context` adapter interface for consensus, mempool, and wallet callers.
- Document the transaction-rule boundary in the Logos protocol changelog.

## Verification

- `make build-hoon`
- `RUSTFLAGS="-C target-cpu=native" cargo build --release --bin roswell`
- `target/release/roswell --new --ephemeral test test-v1-spend-1`
- `target/release/roswell --new --ephemeral test-dumb`
- `cargo fmt --all --check`
- `git diff --check`

The boundary tests use activation height 50. They accept a mismatched parent hash at height 49, reject it at height 50, and accept a matching parent hash at height 50.