### PR TITLE
fix(bridge): add fail-closed node withdrawal pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6628,7 +6628,6 @@ dependencies = [
  "tokio",
  "tonic 0.14.6",
  "tracy-client",
- "zkvm-jetpack",
 ]
 
 [[package]]
@@ -6644,7 +6643,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracy-client",
- "zkvm-jetpack",
 ]
 
 [[package]]

--- a/crates/bridge-dev/src/main.rs
+++ b/crates/bridge-dev/src/main.rs
@@ -2865,6 +2865,7 @@ fn write_bridge_configs(
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
+            withdrawal_processing_enabled: true,
             withdrawal_activation_nock_next_height: Some(nock_activation_height),
             ingress_listen_address: Some(format!("127.0.0.1:{}", ingress_ports[node_id])),
             nodes: (0..5usize)
@@ -4387,6 +4388,7 @@ mod tests {
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
+            withdrawal_processing_enabled: false,
             withdrawal_activation_nock_next_height: Some(1),
             ingress_listen_address: None,
             nodes: Vec::new(),
@@ -4416,6 +4418,7 @@ mod tests {
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
+            withdrawal_processing_enabled: false,
             withdrawal_activation_nock_next_height: Some(1),
             ingress_listen_address: None,
             nodes: Vec::new(),

--- a/crates/bridge/bridge-conf.example.toml
+++ b/crates/bridge/bridge-conf.example.toml
@@ -49,6 +49,10 @@ deposit_nonce_epoch_start_height = 50009
 # Set it to the tx_id corresponding to the last successful deposit
 deposit_nonce_epoch_start_tx_id_base58 = "2uYre9HXRP8X6BD7w3GvgfUAU47RSmZDGkz9uJgJmD9CxN7JA69k6MF"
 
+# Withdrawal processing is fail-closed. Base withdrawal events remain tracked,
+# but nodes do not assemble, sign, exchange, or submit proposals while false.
+withdrawal_processing_enabled = false
+
 # Withdrawal activation cutoff.
 # This is a bridge-kernel Nock next height, not an RPC chain tip. Fresh
 # withdrawal projections wait until this frontier is reached, then initialize at

--- a/crates/bridge/docs/bridge-withdrawals.md
+++ b/crates/bridge/docs/bridge-withdrawals.md
@@ -127,6 +127,9 @@ This spec focuses on:
      an interval in which withdrawals are disabled; it replaces the stored
      value with the connected node's value and verifies that the kernel
      persisted it before continuing
+   - `withdrawal_processing_enabled` defaults to false. When false, nodes track
+     and acknowledge Base withdrawal events but do not assemble, sign, exchange,
+     or submit withdrawal proposals
    - the ingress-side withdrawal proposal transport remains in the main bridge
      process, while the sequencer gRPC surface is now hosted on the Nockchain
      API node process

--- a/crates/bridge/docs/release-punchlist.md
+++ b/crates/bridge/docs/release-punchlist.md
@@ -28,8 +28,10 @@ when moving from fakenet to mainnet.
    - Mainnet Base must be chain id `8453`.
    - Fakenet / VNET / Base Sepolia configs must not be accepted as mainnet.
 5. Confirm withdrawal launch toggles.
-   - `withdrawalsEnabled()` may be false pre-launch.
-   - Production readiness validation should fail until withdrawals are enabled.
+   - `MessageInbox.withdrawalsEnabled()` controls whether Base accepts new burns.
+   - `withdrawal_processing_enabled` controls whether bridge nodes assemble,
+     sign, exchange, and submit withdrawal proposals.
+   - Production readiness requires both controls to be enabled.
 
 ## Rendered Production Config
 
@@ -42,6 +44,7 @@ when moving from fakenet to mainnet.
    - `nock_contract_address`
    - `base_confirmation_depth`
    - `nockchain_confirmation_depth`
+   - `withdrawal_processing_enabled`
    - `withdrawal_activation_nock_next_height`
    - all five `[[nodes]]` entries
 3. Confirm production values are not inherited from fakenet / bridge-dev.

--- a/crates/bridge/src/main.rs
+++ b/crates/bridge/src/main.rs
@@ -763,6 +763,7 @@ async fn main() -> Result<(), BridgeError> {
 
     let nonce_epoch = build_deposit_nonce_epoch_config(&config_toml)?;
     let withdrawal_activation_cutoff = config_toml.withdrawal_activation_cutoff()?;
+    let withdrawal_processing_enabled = config_toml.withdrawal_processing_enabled;
     info!(
         "driver finality: base_confirmation_depth={}, nockchain_confirmation_depth={}",
         base_confirmation_depth, nockchain_confirmation_depth
@@ -954,7 +955,8 @@ async fn main() -> Result<(), BridgeError> {
     let ingress_status_state = status_state.clone();
     let ingress_deposit_log = deposit_log.clone();
     let ingress_nonce_epoch = nonce_epoch.clone();
-    let ingress_withdrawal_transport = Some(withdrawal_transport.clone());
+    let ingress_withdrawal_transport =
+        withdrawal_processing_enabled.then(|| withdrawal_transport.clone());
     let ingress_withdrawal_tui_source = Some(WithdrawalTuiSource {
         registry: withdrawal_registry.clone(),
         sequencer: Some(withdrawal_sequencer_client.clone()),
@@ -1011,6 +1013,7 @@ async fn main() -> Result<(), BridgeError> {
             stop_controller: stop_controller.clone(),
             bridge_status: bridge_status.clone(),
             stop: stop_handle.clone(),
+            processing_enabled: withdrawal_processing_enabled,
             proposal_registry: withdrawal_registry.clone(),
             withdrawal_transport: withdrawal_transport.clone(),
             peers: peers.clone(),
@@ -1176,8 +1179,17 @@ async fn main() -> Result<(), BridgeError> {
         signing_policy: Default::default(),
         submission_policy: Default::default(),
     };
-    let _withdrawal_runtime_handles = spawn_withdrawal_runtime_loops(withdrawal_runtime);
-    info!("Spawned withdrawal runtime loops");
+    let _withdrawal_runtime_handles = if withdrawal_processing_enabled {
+        let handles = spawn_withdrawal_runtime_loops(withdrawal_runtime);
+        info!(target: "bridge.withdrawal", "spawned withdrawal runtime loops");
+        Some(handles)
+    } else {
+        info!(
+            target: "bridge.withdrawal",
+            "withdrawal processing paused; Base events remain tracked and proposal assembly, signing, peer exchange, and submission are disabled"
+        );
+        None
+    };
 
     let ack_handle = spawn_base_observer(base_bridge.clone(), bridge_status.clone());
 

--- a/crates/bridge/src/main.rs
+++ b/crates/bridge/src/main.rs
@@ -1331,6 +1331,7 @@ mod tests {
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
+            withdrawal_processing_enabled: false,
             withdrawal_activation_nock_next_height: Some(200),
             ingress_listen_address: None,
             nodes: vec![

--- a/crates/bridge/src/shared/config.rs
+++ b/crates/bridge/src/shared/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use alloy::primitives::Address;
 use nockchain_math::belt::{Belt, PRIME};
-use nockchain_types::tx_engine::common::Hash as NockPkh;
+use nockchain_types::tx_engine::common::{Hash as NockPkh, SchnorrPubkey};
 use nockchain_types::v1::{Lock, LockPrimitive, Pkh, SpendCondition};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -64,6 +64,11 @@ pub struct BridgeConfigToml {
     /// Required when deposit_nonce_epoch_base is non-zero.
     #[serde(default, alias = "nonce_epoch_start_tx_id_base58")]
     pub deposit_nonce_epoch_start_tx_id_base58: Option<String>,
+    /// Enables withdrawal proposal assembly, signing, peer exchange, and submission.
+    ///
+    /// Base withdrawal events remain tracked while this is false.
+    #[serde(default)]
+    pub withdrawal_processing_enabled: bool,
     /// Nock hashchain next height that must be reached before withdrawal
     /// processing activates.
     #[serde(default)]
@@ -393,12 +398,47 @@ impl BridgeConfigToml {
             }
         }
 
+        let local_node_index = usize::try_from(self.node_id).map_err(|_| {
+            BridgeError::Config(format!("node_id {} does not fit in usize", self.node_id))
+        })?;
+        let local_node = nodes.get(local_node_index).ok_or_else(|| {
+            BridgeError::Config(format!(
+                "node_id {} does not identify one of the {} configured nodes",
+                self.node_id,
+                nodes.len()
+            ))
+        })?;
+        let my_nock_key = SchnorrSecretKey::from(my_nock_key_limbs);
+        if self.withdrawal_processing_enabled {
+            let signer_pubkey = SchnorrPubkey::from_secret_scalar_biguint(
+                &my_nock_key.to_big_uint(),
+            )
+            .map_err(|err| {
+                BridgeError::Config(format!(
+                    "failed to derive nockchain public key from my_nock_key: {err}"
+                ))
+            })?;
+            let signer_pkh = signer_pubkey.pkh_hash().map_err(|err| {
+                BridgeError::Config(format!(
+                    "failed to derive nockchain pkh from my_nock_key: {err}"
+                ))
+            })?;
+            if signer_pkh != local_node.nock_pkh {
+                return Err(BridgeError::Config(format!(
+                    "my_nock_key does not derive the configured nock_pkh for node_id {}: derived {}, configured {}",
+                    self.node_id,
+                    signer_pkh.to_base58(),
+                    local_node.nock_pkh.to_base58()
+                )));
+            }
+        }
+
         Ok(NodeConfig {
             node_id: self.node_id,
             nodes,
             bridge_lock_root,
             my_eth_key: AtomBytes::from(my_eth_key),
-            my_nock_key: SchnorrSecretKey::from(my_nock_key_limbs),
+            my_nock_key,
         })
     }
 

--- a/crates/bridge/src/withdrawal/assembly.rs
+++ b/crates/bridge/src/withdrawal/assembly.rs
@@ -220,6 +220,17 @@ fn classify_withdrawal_execution_effect(
     }
 }
 
+fn should_process_withdrawal_execution_effect(
+    processing_enabled: bool,
+    effect: WithdrawalExecutionEffect,
+) -> bool {
+    processing_enabled
+        || matches!(
+            effect,
+            WithdrawalExecutionEffect::BaseBlockWithdrawalsPending
+        )
+}
+
 /// Orders withdrawal requests deterministically by the canonical Base request
 /// ordering used for local nonce assignment.
 fn sort_withdrawal_requests(requests: &mut [NockWithdrawalRequestKernelData]) {
@@ -532,6 +543,7 @@ pub struct WithdrawalExecutionDriverContext {
     pub stop_controller: StopController,
     pub bridge_status: BridgeStatus,
     pub stop: StopHandle,
+    pub processing_enabled: bool,
     pub proposal_registry: Arc<WithdrawalProposalRegistry>,
     pub withdrawal_transport: Arc<WithdrawalProposalTransport>,
     pub peers: Vec<PeerEndpoint>,
@@ -551,6 +563,7 @@ pub fn create_withdrawal_execution_driver(
         let stop_controller = context.stop_controller.clone();
         let bridge_status = context.bridge_status.clone();
         let stop = context.stop.clone();
+        let processing_enabled = context.processing_enabled;
         let proposal_registry = context.proposal_registry.clone();
         let withdrawal_transport = context.withdrawal_transport.clone();
         let peers = context.peers.clone();
@@ -580,8 +593,23 @@ pub fn create_withdrawal_execution_driver(
                     }
                 };
 
-                let outcome = match classify_withdrawal_execution_effect(&bridge_effect.variant) {
-                    Some(WithdrawalExecutionEffect::BaseBlockWithdrawalsPending) => {
+                let Some(execution_effect) =
+                    classify_withdrawal_execution_effect(&bridge_effect.variant)
+                else {
+                    continue;
+                };
+                if !should_process_withdrawal_execution_effect(processing_enabled, execution_effect)
+                {
+                    warn!(
+                        target: "bridge.withdrawal",
+                        effect = ?execution_effect,
+                        "ignored withdrawal lifecycle effect while processing is paused",
+                    );
+                    continue;
+                }
+
+                let outcome = match execution_effect {
+                    WithdrawalExecutionEffect::BaseBlockWithdrawalsPending => {
                         let BridgeEffectVariant::BaseBlockWithdrawalsPending(pending) =
                             bridge_effect.variant
                         else {
@@ -606,7 +634,7 @@ pub fn create_withdrawal_execution_driver(
                             );
                         })
                     }
-                    Some(WithdrawalExecutionEffect::WithdrawalProposalBuilt) => {
+                    WithdrawalExecutionEffect::WithdrawalProposalBuilt => {
                         let BridgeEffectVariant::WithdrawalProposalBuilt(proposal) =
                             bridge_effect.variant
                         else {
@@ -682,7 +710,7 @@ pub fn create_withdrawal_execution_driver(
                             },
                         }
                     }
-                    Some(WithdrawalExecutionEffect::WithdrawalTxSigned) => {
+                    WithdrawalExecutionEffect::WithdrawalTxSigned => {
                         let BridgeEffectVariant::WithdrawalTxSigned(proposal) =
                             bridge_effect.variant
                         else {
@@ -765,7 +793,6 @@ pub fn create_withdrawal_execution_driver(
                             }
                         }
                     }
-                    None => continue,
                 };
 
                 if let Err(err) = outcome {
@@ -2371,6 +2398,30 @@ mod tests {
             ),
             Some(WithdrawalExecutionEffect::BaseBlockWithdrawalsPending)
         );
+    }
+
+    #[test]
+    fn paused_execution_only_tracks_base_withdrawal_events() {
+        assert!(should_process_withdrawal_execution_effect(
+            false,
+            WithdrawalExecutionEffect::BaseBlockWithdrawalsPending
+        ));
+        assert!(!should_process_withdrawal_execution_effect(
+            false,
+            WithdrawalExecutionEffect::WithdrawalProposalBuilt
+        ));
+        assert!(!should_process_withdrawal_execution_effect(
+            false,
+            WithdrawalExecutionEffect::WithdrawalTxSigned
+        ));
+
+        for effect in [
+            WithdrawalExecutionEffect::BaseBlockWithdrawalsPending,
+            WithdrawalExecutionEffect::WithdrawalProposalBuilt,
+            WithdrawalExecutionEffect::WithdrawalTxSigned,
+        ] {
+            assert!(should_process_withdrawal_execution_effect(true, effect));
+        }
     }
 
     fn sample_name(seed: u64) -> Name {

--- a/crates/bridge/tests/config_tests.rs
+++ b/crates/bridge/tests/config_tests.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use alloy::primitives::Address;
 use bridge::shared::config::{
-    BridgeConfigToml, SequencerConfigToml, CANONICAL_TESTING_BRIDGE_LOCK_ROOT_B58,
+    BridgeConfigToml, NodeInfoToml, SequencerConfigToml, CANONICAL_TESTING_BRIDGE_LOCK_ROOT_B58,
     CANONICAL_TESTING_BRIDGE_NODE_PKHS_B58,
 };
 use nockchain_math::belt::{Belt, PRIME};
@@ -83,6 +83,27 @@ fn derive_runtime_signer_pkh_b58(sk: &bridge::shared::types::SchnorrSecretKey) -
     let scalar: BigUint = sk.to_big_uint();
     let pubkey = SchnorrPubkey::from_secret_scalar_biguint(&scalar).expect("derive signer pubkey");
     pubkey.pkh_hash().expect("hash signer pubkey").to_base58()
+}
+
+#[test]
+fn withdrawal_processing_defaults_to_paused() {
+    let config_without_gate = include_str!("../bridge-conf.example.toml")
+        .replacen("withdrawal_processing_enabled = false\n", "", 1);
+    let config: BridgeConfigToml =
+        toml::from_str(&config_without_gate).expect("parse config without withdrawal gate");
+
+    assert!(!config.withdrawal_processing_enabled);
+}
+
+#[test]
+fn withdrawal_processing_requires_explicit_enable() {
+    let enabled_config = include_str!("../bridge-conf.example.toml").replacen(
+        "withdrawal_processing_enabled = false", "withdrawal_processing_enabled = true", 1,
+    );
+    let config: BridgeConfigToml =
+        toml::from_str(&enabled_config).expect("parse config with withdrawals enabled");
+
+    assert!(config.withdrawal_processing_enabled);
 }
 
 #[test]
@@ -449,6 +470,51 @@ nockchain_start_height = 1
             "parsed my_nock_key for node {node_id} should derive the configured node PKH"
         );
     }
+}
+
+#[test]
+fn node_config_requires_matching_nock_signer_before_enabling_withdrawals() {
+    let mut config = BridgeConfigToml {
+        node_id: 1,
+        base_ws_url: "wss://example.invalid".to_string(),
+        bridge_lock_root: CANONICAL_TESTING_BRIDGE_LOCK_ROOT_B58.to_string(),
+        inbox_contract_address: None,
+        nock_contract_address: None,
+        my_eth_key: "0x6c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f36231a"
+            .to_string(),
+        my_nock_key: "5KZuFKrctV5iUburT54Z9fhpf3V3hv2sPf9GRQnjFR8T".to_string(),
+        grpc_address: "http://127.0.0.1:5002".to_string(),
+        nockchain_sequencer_api_address: None,
+        base_confirmation_depth: 0,
+        nockchain_confirmation_depth: 0,
+        deposit_nonce_epoch_base: None,
+        deposit_nonce_epoch_start_height: None,
+        deposit_nonce_epoch_start_tx_id_base58: None,
+        withdrawal_processing_enabled: false,
+        withdrawal_activation_nock_next_height: Some(1),
+        ingress_listen_address: None,
+        nodes: CANONICAL_TESTING_BRIDGE_NODE_PKHS_B58
+            .iter()
+            .enumerate()
+            .map(|(index, pkh)| NodeInfoToml {
+                ip: format!("127.0.0.1:{}", 8_001 + index),
+                eth_pubkey: format!("0x{:040x}", index + 1),
+                nock_pkh: (*pkh).to_string(),
+            })
+            .collect(),
+        constants: None,
+    };
+
+    config
+        .to_node_config()
+        .expect("paused withdrawals must not require a usable withdrawal signer");
+    config.withdrawal_processing_enabled = true;
+
+    let error = config
+        .to_node_config()
+        .expect_err("node 1 must not accept node 0's nock signer key");
+    assert!(error.to_string().contains("my_nock_key"));
+    assert!(error.to_string().contains("node_id 1"));
 }
 
 #[test]

--- a/crates/nockchain-api/BUILD.bazel
+++ b/crates/nockchain-api/BUILD.bazel
@@ -19,7 +19,6 @@ rust_binary(
         "//crates/nockapp",
         "//crates/nockchain:nockchain-lib",
         "//crates/nockvm/rust/nockvm",
-        "//crates/zkvm-jetpack",
     ] + all_crate_deps(),
 )
 

--- a/crates/nockchain-api/Cargo.toml
+++ b/crates/nockchain-api/Cargo.toml
@@ -25,7 +25,6 @@ nockchain.workspace = true
 nockvm.workspace = true
 tokio.workspace = true
 tracy-client = { workspace = true, optional = true }
-zkvm-jetpack.workspace = true
 
 [dev-dependencies]
 nockapp-grpc-proto = { workspace = true }

--- a/crates/nockchain-api/src/main.rs
+++ b/crates/nockchain-api/src/main.rs
@@ -4,7 +4,6 @@ use chaff::Chaff;
 use kernels_open_dumb::KERNEL;
 use nockapp::kernel::boot;
 use nockchain::NockchainAPIConfig;
-use zkvm_jetpack::hot::produce_prover_hot_state;
 
 // Disable jemalloc when we're running Miri
 #[cfg(all(not(miri), not(feature = "tracing-heap"), not(feature = "malloc")))]
@@ -29,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     cli.nockapp_cli.color = clap::ColorChoice::Never;
     boot::init_default_tracing(&cli.nockapp_cli);
 
-    let prover_hot_state = produce_prover_hot_state();
+    let prover_hot_state = nockchain::consensus::prepare_consensus_runtime(&mut cli)?;
 
     let api_config = if let Some(addr) = cli.bind_public_grpc_addr {
         NockchainAPIConfig::EnablePublicServer(addr)

--- a/crates/nockchain-bridge-sequencer/BUILD.bazel
+++ b/crates/nockchain-bridge-sequencer/BUILD.bazel
@@ -17,7 +17,6 @@ SEQUENCER_DAEMON_DEPS = [
     "//crates/nockapp",
     "//crates/nockchain:nockchain-lib",
     "//crates/nockvm/rust/nockvm",
-    "//crates/zkvm-jetpack",
 ]
 
 SEQUENCER_CTL_DEPS = [

--- a/crates/nockchain-bridge-sequencer/Cargo.toml
+++ b/crates/nockchain-bridge-sequencer/Cargo.toml
@@ -6,8 +6,8 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+jemalloc = []
 tracing-heap = ["tracy-client"]
-jemalloc = ["tikv-jemallocator"]
 
 [dependencies]
 bridge = { path = "../bridge" }
@@ -15,11 +15,10 @@ clap.workspace = true
 nockapp.workspace = true
 nockchain.workspace = true
 nockvm.workspace = true
-tikv-jemallocator = { workspace = true, optional = true }
+tikv-jemallocator.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracy-client = { workspace = true, optional = true }
-zkvm-jetpack.workspace = true
 
 [lints]
 workspace = true

--- a/crates/nockchain-bridge-sequencer/src/main.rs
+++ b/crates/nockchain-bridge-sequencer/src/main.rs
@@ -9,7 +9,6 @@ use bridge::core::loop_policy::BaseObserverLoopPolicy;
 use clap::Parser;
 use nockapp::kernel::boot;
 use tracing::{error, info};
-use zkvm_jetpack::hot::produce_prover_hot_state;
 
 type SequencerJournalHandle = bridge::withdrawal::sequencer::journal::SequencerJournalHandle;
 type SequencerJournalRecoveryReport =
@@ -47,8 +46,8 @@ fn withdrawal_sequencer_data_dir() -> PathBuf {
     nockapp::system_data_dir().join("nockchain")
 }
 
-// When enabled, use jemalloc for more stable memory allocation.
-#[cfg(all(feature = "jemalloc", not(feature = "tracing-heap")))]
+// The verifier setup releases multi-gigabyte contexts through jemalloc.
+#[cfg(not(feature = "tracing-heap"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
@@ -430,10 +429,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let base_height_tracker =
         Arc::new(bridge::withdrawal::sequencer::base_height::SequencerBaseHeightTracker::default());
-    let nockchain_cli = cli.nockchain.clone();
+    let mut nockchain_cli = cli.nockchain.clone();
     let public_addr = nockchain_cli
         .bind_public_grpc_addr
         .ok_or("nockchain-bridge-sequencer requires --bind-public-grpc-addr to be set")?;
+    let prover_hot_state = nockchain::consensus::prepare_consensus_runtime(&mut nockchain_cli)?;
 
     let base_ws_url = cli.base_ws_url.clone();
     let verifier_base_ws_url = base_ws_url.clone();
@@ -532,7 +532,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     .await?;
 
     let api_config = nockchain::NockchainAPIConfig::EnablePublicServer(public_addr);
-    let prover_hot_state = produce_prover_hot_state();
     let nockchain_app =
         nockchain::run_nockchain_app(nockchain_cli, prover_hot_state.as_slice(), api_config);
     tokio::pin!(nockchain_app);

--- a/crates/nockchain/src/consensus.rs
+++ b/crates/nockchain/src/consensus.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use nockvm::jets::hot::HotEntry;
+use zkvm_jetpack::hot::produce_prover_hot_state;
+
+use crate::NockchainCli;
+
+/// Prepares every consensus jet and verifier artifact before node networking starts.
+pub fn prepare_consensus_runtime(cli: &mut NockchainCli) -> Result<Vec<HotEntry>, Box<dyn Error>> {
+    if let Err(err) = cli.validate() {
+        return Err(err.into());
+    }
+
+    let data_dir = configure_ai_pow_data_dir(cli);
+
+    if let Some(cap) = cli.ai_pow_verifier_cache_cap {
+        std::env::set_var(
+            ai_pow_jets::setup::AI_POW_VERIFIER_CACHE_CAP_ENV,
+            cap.to_string(),
+        );
+    }
+
+    let buckets = ai_pow_jets::setup::production_verifier_setup_buckets();
+    ai_pow_jets::setup::install_or_build_verifier_setup(&data_dir, &buckets)?;
+
+    Ok(consensus_hot_state())
+}
+
+fn configure_ai_pow_data_dir(cli: &mut NockchainCli) -> PathBuf {
+    let data_dir = cli
+        .nockapp_cli
+        .data_dir
+        .clone()
+        .unwrap_or_else(|| nockapp::default_data_dir("nockchain"));
+
+    if !cli
+        .nockapp_cli
+        .new_data_dir_allowlist
+        .iter()
+        .any(|path| path == Path::new("ai-pow"))
+    {
+        cli.nockapp_cli.new_data_dir_allowlist.push("ai-pow".into());
+    }
+
+    data_dir
+}
+
+fn consensus_hot_state() -> Vec<HotEntry> {
+    let mut hot_state = produce_prover_hot_state();
+    hot_state.extend(ai_pow_jets::produce_ai_pow_hot_state());
+    hot_state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consensus_hot_state_contains_stark_and_ai_pow_jets() {
+        let stark_jet_count = produce_prover_hot_state().len();
+        let ai_pow_jet_count = ai_pow_jets::produce_ai_pow_hot_state().len();
+
+        assert_eq!(
+            consensus_hot_state().len(),
+            stark_jet_count + ai_pow_jet_count
+        );
+        assert!(ai_pow_jet_count > 0);
+    }
+}

--- a/crates/nockchain/src/lib.rs
+++ b/crates/nockchain/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod backbone;
 pub mod config;
+pub mod consensus;
 pub mod setup;
 pub mod traces;
 

--- a/crates/nockchain/src/main.rs
+++ b/crates/nockchain/src/main.rs
@@ -4,7 +4,6 @@ use chaff::Chaff;
 use kernels_open_dumb::KERNEL;
 use nockapp::kernel::boot;
 use nockchain::NockchainAPIConfig;
-use zkvm_jetpack::hot::produce_prover_hot_state;
 
 // jemalloc is REQUIRED (not optional): the AI-PoW verifier-setup table pages large
 // contexts in/out of memory, and returning that freed memory to the OS relies on
@@ -26,49 +25,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         nockchain::NockchainCli::parse_with_default_stack_size(boot::NockStackSize::Large);
     boot::init_default_tracing(&cli.nockapp_cli);
 
-    // Fail fast on invalid CLI config (e.g. a malformed --fakenet-*-asert-* combo)
-    // before the multi-minute AI-PoW verifier-setup generation below.
-    if let Err(e) = cli.validate() {
-        return Err(e.into());
-    }
-
-    // Shared jet registry: the STARK prover jets + the AI-PoW consensus verify
-    // jet. roswell must extend the identical set (crates/roswell) so `check-pow`'s
-    // `~/ %ai-pow-verify` matches in both binaries.
-    let mut prover_hot_state = produce_prover_hot_state();
-    prover_hot_state.extend(ai_pow_jets::produce_ai_pow_hot_state());
+    let prover_hot_state = nockchain::consensus::prepare_consensus_runtime(&mut cli)?;
 
     let api_config = if let Some(addr) = cli.bind_public_grpc_addr {
         NockchainAPIConfig::EnablePublicServer(addr)
     } else {
         NockchainAPIConfig::DisablePublicServer
     };
-
-    // Resolve the node data dir the same way `boot::setup` does (explicit
-    // --data-dir, else `./.data.nockchain`) BEFORE `cli` is moved into
-    // `init_with_kernel`, so we can load the AI-PoW verifier-setup cache from it.
-    let data_dir = cli
-        .nockapp_cli
-        .data_dir
-        .clone()
-        .unwrap_or_else(|| nockapp::default_data_dir("nockchain"));
-    cli.nockapp_cli.new_data_dir_allowlist.push("ai-pow".into());
-
-    // CLI takes precedence over the environment. Lower caps are an explicit
-    // memory-for-latency tradeoff; the default keeps all 14 shape keys resident after
-    // first use.
-    if let Some(cap) = cli.ai_pow_verifier_cache_cap {
-        std::env::set_var(
-            ai_pow_jets::setup::AI_POW_VERIFIER_CACHE_CAP_ENV,
-            cap.to_string(),
-        );
-    }
-
-    // The installer may prove every production setup bucket. It must complete before
-    // `init_with_kernel` starts I/O drivers, so an unready node cannot accept or dial
-    // network traffic while its consensus verifier is unavailable.
-    let buckets = ai_pow_jets::setup::production_verifier_setup_buckets();
-    ai_pow_jets::setup::install_or_build_verifier_setup(&data_dir, &buckets)?;
 
     let mut nockchain =
         nockchain::init_with_kernel::<Chaff>(cli, KERNEL, prover_hot_state.as_slice(), api_config)


### PR DESCRIPTION
## Summary

- add `withdrawal_processing_enabled`, defaulting to `false`
- require an enabled node's Nock secret key to derive `nodes[node_id].nock_pkh`
- keep tracking and acknowledging Base withdrawal events while processing is paused
- disable proposal assembly, signing, peer exchange, submission, and stale proposal-effect handling while paused
- document the independent Base contract and bridge-node withdrawal gates

## Incident context

Bridge node 2 reached `%create-withdrawal-tx` while withdrawals were intended to be operationally paused. Its configured signing key failed the transaction builder's signer-membership check, causing a kernel `%stop` that propagated to nodes 0 and 1. The Base contract gate did not provide a node-side processing pause.

## Safety properties

Paused nodes preserve Base burn observations for later processing but cannot advance a withdrawal proposal. Signer identity validation is deferred while paused so a node with a broken withdrawal key can still start for deposit and observation duties; explicit enablement fails closed until the key matches the configured node PKH.

## Verification

- `cargo test -p bridge --test config_tests` — 29 passed
- `cargo test -p bridge --bin bridge` — 22 passed
- `cargo test -p bridge` — 725 passed, 8 ignored
- `cargo test -p bridge-dev` — 55 passed, 15 ignored
- `cargo fmt --check`
- `git diff --check`
