### PR TITLE
feat(bridge): define canonical withdrawal protocol

### DIFF
--- a/crates/bridge-dev/src/main.rs
+++ b/crates/bridge-dev/src/main.rs
@@ -31,6 +31,7 @@ use bridge::shared::ingress::proto::withdrawal_sequencer_client::WithdrawalSeque
 use bridge::shared::nockchain::fetch_private_blockchain_constants;
 use bridge::shared::proposer::withdrawal_turn_proposer;
 use bridge::shared::signing::BridgeSigner;
+use bridge::shared::types::WITHDRAWAL_POLICY_V1_ID;
 use bridge::withdrawal::transport::withdrawal_id_from_proto;
 use clap::{Args, Parser, Subcommand};
 use ibig::UBig;
@@ -2151,16 +2152,12 @@ async fn run_deposit(
     Ok(())
 }
 
-fn minimum_event_nocks(config: &BridgeConfigToml) -> u64 {
-    config
-        .constants
-        .clone()
-        .unwrap_or_default()
-        .minimum_event_nocks
+fn minimum_event_nocks(config: &BridgeConfigToml) -> Result<u64> {
+    Ok(config.bridge_constants()?.minimum_event_nocks)
 }
 
 fn minimum_event_nicks(config: &BridgeConfigToml) -> Result<u64> {
-    let minimum_event_nocks = minimum_event_nocks(config);
+    let minimum_event_nocks = minimum_event_nocks(config)?;
     minimum_event_nocks
         .checked_mul(NICKS_PER_NOCK)
         .context("bridge minimum_event_nocks overflowed when converted to nicks")
@@ -2170,13 +2167,14 @@ fn ensure_withdrawal_amount_meets_floor(
     amount_nicks: u64,
     active_bridge_config: &BridgeConfigToml,
 ) -> Result<()> {
+    let minimum_nocks = minimum_event_nocks(active_bridge_config)?;
     let minimum_nicks = minimum_event_nicks(active_bridge_config)?;
-    if amount_nicks <= minimum_nicks {
+    if amount_nicks < minimum_nicks {
         bail!(
-            "withdrawal amount {} nicks must be greater than bridge minimum event size {} nicks (minimum_event_nocks={})",
+            "withdrawal amount {} nicks must be at least bridge minimum event size {} nicks (minimum_event_nocks={})",
             amount_nicks,
             minimum_nicks,
-            minimum_event_nocks(active_bridge_config)
+            minimum_nocks
         );
     }
     Ok(())
@@ -2837,7 +2835,7 @@ fn write_bridge_configs(
     let constants = BridgeConstantsToml {
         min_signers: 3,
         total_signers: 5,
-        minimum_event_nocks: 1000,
+        minimum_event_nocks: 100_000,
         nicks_fee_per_nock: 195,
         base_blocks_chunk: base_blocks_chunk()?,
         base_start_height: vnet.base_start_height,
@@ -2862,6 +2860,7 @@ fn write_bridge_configs(
             nockchain_sequencer_api_address: Some(sequencer_api_address.clone()),
             base_confirmation_depth: profile.cluster.base_confirmation_depth,
             nockchain_confirmation_depth: profile.cluster.nockchain_confirmation_depth,
+            withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
@@ -2885,6 +2884,7 @@ fn write_bridge_configs(
     let sequencer_config = SequencerConfigToml {
         nock_contract_address: vnet.nock_contract_address.clone(),
         nockchain_confirmation_depth: profile.cluster.nockchain_confirmation_depth,
+        withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
         manual_submit_approval: bridge_dev_manual_submit_approval()?,
         manual_submit_approval_dir: None,
         nodes: (0..5usize)
@@ -4385,6 +4385,7 @@ mod tests {
             nockchain_sequencer_api_address: None,
             base_confirmation_depth: 0,
             nockchain_confirmation_depth: 0,
+            withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
@@ -4393,16 +4394,16 @@ mod tests {
             ingress_listen_address: None,
             nodes: Vec::new(),
             constants: Some(BridgeConstantsToml {
-                minimum_event_nocks: 1_000,
+                minimum_event_nocks: 100_000,
                 ..BridgeConstantsToml::default()
             }),
         };
 
-        assert_eq!(minimum_event_nicks(&config).unwrap(), 65_536_000);
+        assert_eq!(minimum_event_nicks(&config).unwrap(), 6_553_600_000);
     }
 
     #[test]
-    fn withdrawal_floor_requires_more_than_minimum_event_nocks() {
+    fn withdrawal_floor_accepts_minimum_event_nocks() {
         let config = BridgeConfigToml {
             node_id: 0,
             base_ws_url: "ws://example".to_string(),
@@ -4415,6 +4416,7 @@ mod tests {
             nockchain_sequencer_api_address: None,
             base_confirmation_depth: 0,
             nockchain_confirmation_depth: 0,
+            withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,
@@ -4423,17 +4425,18 @@ mod tests {
             ingress_listen_address: None,
             nodes: Vec::new(),
             constants: Some(BridgeConstantsToml {
-                minimum_event_nocks: 1_000,
+                minimum_event_nocks: 100_000,
                 ..BridgeConstantsToml::default()
             }),
         };
 
-        let err = ensure_withdrawal_amount_meets_floor(65_536_000, &config).unwrap_err();
+        let minimum_nicks = 6_553_600_000;
+        let err = ensure_withdrawal_amount_meets_floor(minimum_nicks - 1, &config).unwrap_err();
         assert!(err
             .to_string()
-            .contains("must be greater than bridge minimum event size"));
+            .contains("must be at least bridge minimum event size"));
 
-        ensure_withdrawal_amount_meets_floor(65_536_001, &config).unwrap();
+        ensure_withdrawal_amount_meets_floor(minimum_nicks, &config).unwrap();
     }
 
     #[test]

--- a/crates/bridge/bridge-conf.example.toml
+++ b/crates/bridge/bridge-conf.example.toml
@@ -33,6 +33,9 @@ grpc_address = "http://localhost:5555"
 base_confirmation_depth = 300
 nockchain_confirmation_depth = 400
 
+# Versioned withdrawal wire, amount, and fee policy.
+withdrawal_policy = "withdrawal-policy-v1"
+
 # Deposit nonce epoch base.
 # This exists because deposit nonce semantics were corrected by an ad-hoc
 # update about a month after launch. Set it to the last successful deposit

--- a/crates/bridge/contracts/DEPLOYMENT.md
+++ b/crates/bridge/contracts/DEPLOYMENT.md
@@ -2,12 +2,18 @@
 
 Status: Active
 Owner: Nockchain Maintainers
-Last Reviewed: 2026-02-20
+Last Reviewed: 2026-08-24
 Canonical/Legacy: Legacy (bridge contracts deployment guide; canonical docs spine starts at [`START_HERE.md`](../../../START_HERE.md))
 
 This guide covers deploying, upgrading, and managing the bridge contracts
 (`MessageInbox` behind an ERC-1967 proxy plus the `Nock` ERC-20) on Tenderly
 networks (devnets, simulations, or proxied mainnets).
+
+> **Production withdrawal note:** Official Base-to-Nockchain clients must
+> submit the exact 116-byte `WithdrawalWireV1` calldata documented in
+> [`../docs/bridge-withdrawals.md`](../docs/bridge-withdrawals.md). Ordinary
+> generated-ABI `burn(uint256,bytes32)` calls are unsupported and may burn
+> funds without a processable destination.
 
 ## Quick Start
 
@@ -120,7 +126,7 @@ export BRIDGE_NODE_0="0x..."
 Use the bridge provisioning script from the repository root:
 
 ```bash
-cd open/crates/bridge
+cd crates/bridge
 ./scripts/tenderly-vnet-deploy.sh
 ```
 

--- a/crates/bridge/contracts/foundry.toml
+++ b/crates/bridge/contracts/foundry.toml
@@ -27,4 +27,5 @@ cbor_metadata = true
 fs_permissions = [
   { access = "read-write", path = "./" },
   { access = "read-write", path = "./deployments.json" },
+  { access = "read", path = "../test-fixtures" },
 ]

--- a/crates/bridge/contracts/test/MessageInboxBridgeNodeTest.t.sol
+++ b/crates/bridge/contracts/test/MessageInboxBridgeNodeTest.t.sol
@@ -67,6 +67,40 @@ contract MessageInboxBridgeNodeTest is Test {
         for (uint256 i = 0; i < 5; i++) {
             assertEq(inbox.bridgeNodes(i), bridgeNodeAddresses[i]);
         }
+        assertTrue(inbox.withdrawalsEnabled());
+    }
+
+    function test_owner_can_toggle_withdrawals() public {
+        inbox = new MessageInbox();
+        nock = new Nock("Nock", "NOCK", address(inbox));
+
+        address[5] memory nodes;
+        for (uint256 i = 0; i < 5; i++) {
+            nodes[i] = bridgeNodeAddresses[i];
+        }
+        inbox.initialize(nodes, address(nock));
+
+        inbox.setWithdrawalsEnabled(false);
+        assertFalse(inbox.withdrawalsEnabled());
+        inbox.setWithdrawalsEnabled(true);
+        assertTrue(inbox.withdrawalsEnabled());
+    }
+
+    function test_non_owner_cannot_toggle_withdrawals() public {
+        inbox = new MessageInbox();
+        nock = new Nock("Nock", "NOCK", address(inbox));
+
+        address[5] memory nodes;
+        for (uint256 i = 0; i < 5; i++) {
+            nodes[i] = bridgeNodeAddresses[i];
+        }
+        inbox.initialize(nodes, address(nock));
+
+        address nonOwner = vm.addr(uint256(keccak256("non-owner")));
+        vm.prank(nonOwner);
+        vm.expectRevert();
+        inbox.setWithdrawalsEnabled(false);
+        assertTrue(inbox.withdrawalsEnabled());
     }
 
     function test_updateBridgeNode_rejects_duplicate() public {

--- a/crates/bridge/contracts/test/NockWithdrawalTest.t.sol
+++ b/crates/bridge/contracts/test/NockWithdrawalTest.t.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.19;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {stdJson} from "forge-std/StdJson.sol";
 import {Nock} from "../Nock.sol";
 import {BridgeTestBase} from "./BridgeTestBase.t.sol";
 
 contract NockWithdrawalTest is BridgeTestBase {
-    function setUp() public override {
-        super.setUp();
-    }
+    using stdJson for string;
 
     function testBurnEmitsEventAndNotifiesInbox() public {
         address burner = makeAddr("burner");
@@ -26,17 +25,15 @@ contract NockWithdrawalTest is BridgeTestBase {
         assertEq(nock.balanceOf(burner), 0);
     }
 
-    function testBurnAcceptsTrailingCalldata() public {
-        address burner = makeAddr("burner");
-        uint256 amount = nockAmount(25);
-        bytes32 commitment = keccak256("withdrawal-commitment");
-        bytes memory trailer =
-            hex"4e4f434b57443121000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2021222324252627";
+    function testBurnAcceptsCanonicalWithdrawalWireV1Vector() public {
+        string memory fixture = vm.readFile("../test-fixtures/withdrawal_wire_v1_vectors.json");
+        address burner = fixture.readAddress(".valid_vectors[0].burner_address");
+        uint256 amount = vm.parseUint(fixture.readString(".valid_vectors[0].amount_base_units"));
+        bytes32 commitment = fixture.readBytes32(".valid_vectors[0].commitment");
+        bytes memory data = fixture.readBytes(".valid_vectors[0].calldata");
 
-        mintFromInbox(burner, amount);
-
-        bytes memory data = bytes.concat(abi.encodeWithSelector(Nock.burn.selector, amount, commitment), trailer);
         assertEq(data.length, 116);
+        mintFromInbox(burner, amount);
 
         vm.expectEmit(true, true, true, true, address(nock));
         emit Nock.BurnForWithdrawal(burner, amount, commitment);
@@ -44,8 +41,20 @@ contract NockWithdrawalTest is BridgeTestBase {
         vm.prank(burner);
         (bool ok, bytes memory returnData) = address(nock).call(data);
         assertTrue(ok, string(returnData));
-
         assertEq(nock.balanceOf(burner), 0);
+    }
+
+    function testBurnRevertsAtomicallyWhenWithdrawalsDisabled() public {
+        address burner = makeAddr("disabled-burner");
+        uint256 amount = nockAmount(1);
+        mintFromInbox(burner, amount);
+        inbox.setWithdrawalsEnabled(false);
+
+        vm.prank(burner);
+        vm.expectRevert("Withdrawals are disabled");
+        nock.burn(amount, keccak256("disabled-lock"));
+
+        assertEq(nock.balanceOf(burner), amount);
     }
 
     function testBurnRequiresPositiveAmount() public {

--- a/crates/bridge/docs/bridge-withdrawals.md
+++ b/crates/bridge/docs/bridge-withdrawals.md
@@ -1,46 +1,82 @@
 # Bridge Withdrawals
 
-Status: Active
+Status: Backend implemented; public Base-to-Nockchain launch disabled
 Owner: Nockchain Maintainers
-Last Reviewed: 2026-04-01
+Last Reviewed: 2026-08-27
 Canonical/Legacy: Canonical bridge withdrawal protocol and implementation spec
 
 ## Scope
 
-This document specifies the implementation work required to enable bridge withdrawals (Base -> Nockchain) across:
+This document defines the Base-to-Nockchain withdrawal protocol across the
+Rust bridge (`crates/bridge`), the Hoon bridge kernel
+(`hoon/apps/bridge`), the sequencer, public read APIs, recovery state, and
+required verification.
 
-1. Rust bridge crate (`open/crates/bridge`)
-2. Hoon bridge kernel (`open/hoon/apps/bridge/bridge.hoon`, plus `base.hoon`, `nock.hoon`, `types.hoon`)
+It is normative for:
 
-This spec focuses on:
-
-1. The current implemented withdrawal protocol shape
-2. The intended steady-state coordination model
-3. Remaining hardening gaps and policy choices
-4. How to validate correctness
+1. `WithdrawalWireV1` and `withdrawal-policy-v1`;
+2. withdrawal identity, state, authorization, and single-flight ordering;
+3. persistence, reservation, journal, and reorg recovery invariants;
+4. public readiness, history, quote, and browser boundaries;
+5. launch and verification gates.
 
 ## Current Implementation Status
+
+### Launch gate
+
+Public withdrawal launch remains disabled:
+
+1. Rust implements canonical burn decoding, sequencer persistence and replay,
+   authenticated operator RPC, public lookup/history, bounded Base recovery,
+   and Nockchain inclusion recovery.
+2. Rust withholds Base and Nockchain observations until their configured
+   confirmation depths; the production example uses 300 and 400 blocks.
+   Ordinary shallow forks therefore do not reach Hoon. A parent mismatch after
+   that buffer is a finality-assumption violation: Hoon and Rust fail-stop, and
+   launch requires certified depth settings plus a tested operator
+   stop/close-gate/rebuild/replay procedure. Automatic in-place Hoon rewind is
+   an optional resilience improvement, not a launch prerequisite.
+3. Iris SDK `0.3.3` is a local release candidate with the 116-byte codec,
+   amount policy, canonical v1-PKH/direct-lock-root resolver, and a
+   self-contained E2E driver package. NockSwap and the withdrawal harness pin
+   its content-hashed tarball, but the public registry still serves `0.2.0`;
+   `0.3.3` is not yet an immutable public release.
+4. NockSwap keeps Base-to-Nockchain behind a compile-time-disabled launch flag.
+   The disabled path now uses the official SDK calldata, validates the Base
+   receipt and burn log, persists settlement identity and history, polls the
+   sequencer's production `/withdrawal-status` HTTP adapter, displays readiness
+   and fees, and has real-browser nominal and failure coverage against that
+   production adapter.
+5. The pinned Foundry gate runs all 57 contract tests, including the 13
+   withdrawal compatibility and fail-closed initialization tests. Hermetic and
+   Base Sepolia fork browser runs retain redacted terminal evidence. Live
+   production-host authentication, R2 recovery, post-confirmation
+   stop/rebuild/replay drills, immutable SDK publication, and independent
+   certification remain required.
+
+No current UI or CLI should offer an official Base-to-Nockchain withdrawal
+until every remaining gate above is closed at one exact revision.
 
 ### Kernel status (Hoon)
 
 1. Nock-side withdrawal tx detection is now wired (no intentional hard-stop):
-   - `open/hoon/apps/bridge/nock.hoon`
+   - `hoon/apps/bridge/nock.hoon`
    - arm: `++ process-nock-txs`
    - branch: `is-bridge-withdrawal-tx`
    - current behavior: detects packed `%bridge-w` note-data, parses withdrawal metadata, and builds `withdrawal-settlement` entries (non-matching/malformed outputs are skipped, not fatal)
 
 2. Nock-side settlement processing no longer intentionally rejects withdrawals:
-   - `open/hoon/apps/bridge/nock.hoon`
+   - `hoon/apps/bridge/nock.hoon`
    - arm: `++ nockchain-process-withdrawal-settlements`
    - current behavior: reconciles settlements against tracked withdrawals by counterpart identity and destination, enforces `0 < settled_amount < burned_amount`, emits hold when referenced `as_of` base hash is unknown, stops on irreconcilable counterpart issues or out-of-bounds settlement amounts, and clears matched unsettled entries
 
 3. Base-side withdrawal proposal arm is now implemented:
-   - `open/hoon/apps/bridge/base.hoon`
+   - `hoon/apps/bridge/base.hoon`
    - arm: `++ base-propose-withdrawals`
    - current behavior: returns `(list nock-withdrawal-request)` which is included in `%base-block-withdrawals-pending`
 
 4. Withdrawal data/effect surface was updated:
-   - `open/hoon/apps/bridge/types.hoon`
+   - `hoon/apps/bridge/types.hoon`
    - `withdrawal` now uses `dest=nock-lock-root` and no fee field
    - `withdrawal-settlement` now includes `base-batch-end` (including hashable encoding) and no `nock-tx-fee`
    - effects now include `%base-block-withdrawals-pending`,
@@ -62,14 +98,14 @@ This spec focuses on:
 ### Runtime status (Rust)
 
 1. Core runtime now wires both deposit and withdrawal execution:
-   - `open/crates/bridge/src/main.rs`
-   - `open/crates/bridge/src/shared/runtime.rs`
-   - `open/crates/bridge/src/withdrawal/runtime.rs`
+   - `crates/bridge/src/main.rs`
+   - `crates/bridge/src/shared/runtime.rs`
+   - `crates/bridge/src/withdrawal/runtime.rs`
    - active loops now include withdrawal assembly, signing, submission, and
      sequencer confirmation polling alongside the existing deposit path
 
 2. Rust effect surface now decodes the live withdrawal kernel effects:
-   - `open/crates/bridge/src/shared/types.rs`
+   - `crates/bridge/src/shared/types.rs`
    - withdrawal-related variants:
     `BridgeEffectVariant::BaseBlockWithdrawalsPending(PendingBaseBlockCommit)`,
      `BridgeEffectVariant::WithdrawalProposalBuilt(WithdrawalProposalData)`,
@@ -77,41 +113,36 @@ This spec focuses on:
    - legacy `BridgeEffectVariant::CreateWithdrawalTxs(...)` remains decodable but is not live execution work
    - there is no `BridgeEffectVariant::WithdrawalTerminal(...)` today
 
-3. Legacy runtime local effect queue was removed:
-   - `open/crates/bridge/src/shared/runtime.rs`
-   - `BridgeRuntime::process_effect` and `send_effect` no longer exist
-   - effect consumption is now driver-specific (e.g., stop/deposit drivers)
-
-4. Live effect handling now includes the withdrawal execution driver:
-   - `open/crates/bridge/src/deposit/log.rs`
-   - `open/crates/bridge/src/withdrawal/assembly.rs`
-   - `open/crates/bridge/src/main.rs` registers both
+3. Withdrawal effect handling is registered in the live runtime:
+   - `crates/bridge/src/deposit/log.rs`
+   - `crates/bridge/src/withdrawal/assembly.rs`
+   - `crates/bridge/src/main.rs` registers
      `create_commit_nock_deposits_driver` and
      `create_withdrawal_execution_driver`
-   - `open/crates/bridge/src/withdrawal/guard.rs` still exists as historical
-     milestone-1 scaffolding, but it is not the production path
 
-5. Ingress now serves both deposit and withdrawal coordination:
-   - `open/crates/bridge/proto/bridge_ingress.proto`
-   - `open/crates/bridge/src/shared/ingress.rs`
+4. Ingress serves both deposit and withdrawal coordination:
+   - `crates/bridge/proto/bridge_ingress.proto`
+   - `crates/bridge/src/shared/ingress.rs`
    - deposit proposal cache remains deposit-specific, but withdrawals use
      `WithdrawalProposalTransport` and dedicated ingress RPCs for proposal,
      canonicalization, and signed-proposal broadcast
 
-6. Withdrawal proposal validation and tracking belong to Rust:
+5. Withdrawal proposal validation and tracking belong to Rust:
    - there is no kernel proposal-validation cause in the intended design
    - Rust owns proposal-envelope validation against withdrawal identity,
      snapshot/selected-note inputs, epoch legality, replay/equivocation rules,
      and durable per-withdrawal proposal tracking
-7. Base burn events are observed and minimum-gated before they become tracked
-   withdrawals:
-   - `open/crates/bridge/src/ethereum.rs`
-   - `process_nock_log` decodes `BurnForWithdrawal`
-   - generated local `Withdrawal` currently has `dest: None`
-   - `open/hoon/apps/bridge/base.hoon` now rejects burns at or below the
+6. Base burn events are observed, decoded, and policy-gated before they become
+   tracked withdrawals:
+   - `crates/bridge/src/shared/base.rs` decodes the event together with
+     the fetched transaction input
+   - only self-consistent 116-byte calldata yields the five-limb destination
+   - malformed or ordinary 68-byte burns are excluded and classified for
+     incident monitoring rather than converted into destination-less work
+   - `hoon/apps/bridge/base.hoon` rejects burns below the inclusive
      configured minimum before they materialize into withdrawal state
 
-8. Withdrawal-specific coordination state is live:
+7. Withdrawal-specific coordination state is live:
    - a durable withdrawal state-store record of prepared / peer-canonical /
      authorized / submitted / confirmed withdrawals exists in Rust
    - append-only withdrawal lifecycle storage and sequencer-owned reserved-note
@@ -148,21 +179,222 @@ This spec focuses on:
 ### Contracts and dependencies
 
 1. Contracts support burn-side initiation:
-   - `open/crates/bridge/contracts/Nock.sol`: `burn(amount, lockRoot)` emits `BurnForWithdrawal`
-   - `open/crates/bridge/contracts/MessageInbox.sol`: `notifyBurn` + `withdrawalsEnabled` gate
+   - `crates/bridge/contracts/Nock.sol`: `burn(amount, lockRoot)` emits `BurnForWithdrawal`
+   - `crates/bridge/contracts/MessageInbox.sol`: `notifyBurn` + `withdrawalsEnabled` gate
 
-2. No immediate `Cargo.toml` dependency gap identified for baseline implementation:
-   - `open/crates/bridge/Cargo.toml`
-   - nockapp gRPC client dependencies already present
+2. Runtime dependencies are declared in `crates/bridge/Cargo.toml`; Cargo and
+   Bazel lockfiles pin the resolved graph.
+
+## Canonical Base Burn Wire Protocol (`WithdrawalWireV1`)
+
+### Contract Calldata Constraint
+
+`Nock.sol::burn(uint256,bytes32)` accepts ordinary ABI calldata, but the bridge
+cannot recover a five-limb Nockchain destination from that 68-byte call. The
+only supported withdrawal initiation path is therefore the exact 116-byte
+`WithdrawalWireV1` representation below. Official clients must construct it
+through the shared withdrawal SDK rather than a generated contract
+`writeContract` helper.
+
+### Exact Calldata Layout
+
+| Byte range | Size | Encoding | Meaning |
+|---|---:|---|---|
+| `0..4` | 4 | raw bytes | selector for `burn(uint256,bytes32)` |
+| `4..36` | 32 | unsigned big-endian | wrapped-NOCK amount in Base token units |
+| `36..68` | 32 | raw bytes | withdrawal commitment passed as the ABI `lockRoot` argument |
+| `68..76` | 8 | ASCII | literal trailer magic `NOCKWD1!` |
+| `76..116` | 40 | five unsigned 64-bit big-endian limbs | full Tip5 destination lock root |
+
+The total length is exactly 116 bytes. Shorter, longer, or differently ordered
+input is not a supported withdrawal request.
+
+Despite the Solidity parameter and event field name, the 32-byte `lockRoot`
+value is the withdrawal commitment, not the full Nockchain lock root. The full
+root is the final 40 calldata bytes.
+
+### Commitment
+
+The commitment is:
+
+```text
+keccak256(
+  "nock-withdrawal-calldata-v1"
+  || nock_token_address[20]
+  || burner_address[20]
+  || amount_be[32]
+  || lock_root_limbs_be[40]
+)
+```
+
+The input sequence is concatenated without ABI padding between fields:
+
+1. the exact ASCII domain string
+2. the deployed `Nock` token address
+3. the connected Base account that will send the burn
+4. the exact 32-byte amount used in calldata
+5. the five destination limbs in their serialized order
+
+The current commitment does not include Base chain id. Clients must separately
+verify the configured chain id and token deployment before constructing,
+simulating, or submitting the transaction.
+
+### Destination and Amount Invariants
+
+1. The destination is five Tip5 field limbs, not a 32-byte digest.
+2. Each limb is encoded as eight big-endian bytes.
+3. Each limb must be strictly below the Tip5 base-field prime.
+4. A v1 PKH address may be accepted as user input only by deriving its
+   canonical simple-PKH lock root before serialization.
+5. Direct lock-root input must parse to the same canonical five-limb form.
+6. The amount is an unsigned 256-bit Base token-unit integer.
+7. Rust additionally requires exact divisibility by
+   `152,587,890,625` Base token units per nick and conversion to fit `u64`.
+8. Minimum and fee-viability policy is versioned separately from this wire
+   format; an official client must validate the active policy before opening
+   the wallet.
+
+### Mandatory Client Workflow
+
+An official client must:
+
+1. read and validate the connected Base account, chain id, and deployed token
+2. parse the user amount without JavaScript floating-point conversion
+3. parse or derive the canonical five-limb destination
+4. construct the commitment and final 116-byte calldata
+5. decode those final bytes locally through the shared SDK
+6. compare the decoded selector, amount, commitment, magic, destination,
+   burner binding, and token binding with current client state
+7. simulate and estimate gas using those exact bytes
+8. submit those same bytes without rebuilding through a generated ABI helper
+
+A change to account, chain, token, amount, or destination invalidates any
+previously constructed calldata. The client must rebuild and revalidate before
+submission.
+
+### Unsupported Direct Calls and Residual Risk
+
+An ordinary generated-ABI call to `burn(amount, bytes32)` is not a supported
+withdrawal initiation method, even though the contract accepts and
+burns it. It omits the full destination, so the observer returns
+`MissingCalldataTrailer` and cannot reconstruct a normal payout.
+
+This residual risk cannot be removed off-chain. Production readiness therefore
+requires:
+
+1. prominent SDK, DApp, and integration documentation
+2. durable per-event quarantine in `sequencer_base_burn_rejections` without
+   allowing one unsupported burn to stop later canonical indexing
+3. an operator-owned refund or compensation procedure
+4. immutable, coordinate-validated compensation entries rendered identically
+   to all bridge nodes and the sequencer
+5. sequencer persistence and admission checks so a compensated burn can never
+   later settle as a withdrawal
+
+The shared Rust implementation in `src/shared/base.rs` is the executable source
+for selector, commitment, encoding, decoding, and rejection parity. Rust and
+TypeScript implementations must share byte-for-byte positive and mutated-field
+test vectors.
+
+The canonical cross-language fixture is
+`test-fixtures/withdrawal_wire_v1_vectors.json`. It contains versioned
+constants, positive vectors, and malformed-field vectors with stable rejection
+categories. SDK implementations must execute that fixture rather than copy
+example bytes into an independent test corpus.
+
+## Withdrawal Amount Policy (`withdrawal-policy-v1`)
+
+The first production withdrawal policy is `withdrawal-policy-v1`. It
+matches the existing Rust defaults and Hoon boundary behavior rather than the
+older 10,000/1,000,000-NOCK prose and examples.
+
+This value is not inferred from the deposit documentation. The executable
+kernel configuration defines `minimum-event-nocks` as `100.000`, and
+`base.hoon` rejects a burn only when its amount is less than
+`minimum-event-nocks * nicks-per-nock`; equality is admitted. The same
+configuration field currently gates Nockchain deposit events as well. A future
+`10,000 NOCK` withdrawal minimum would therefore require a distinct
+withdrawal-only kernel/config field and a new policy version, not a silent
+reinterpretation of `withdrawal-policy-v1`.
+
+| Field | `withdrawal-policy-v1` value |
+|---|---:|
+| wire format | `WithdrawalWireV1` |
+| wrapped-NOCK base units per NOCK | `10,000,000,000,000,000` |
+| nicks per NOCK | `65,536` |
+| wrapped-NOCK base units per nick | `152,587,890,625` |
+| minimum gross burn | `100,000 NOCK` |
+| minimum boundary | inclusive (`gross_nocks >= 100,000`) |
+| maximum converted amount | `u64::MAX` nicks |
+| bridge fee rate | `195` nicks per started whole NOCK |
+
+The gross minimum is `6,553,600,000` nicks or
+`1,000,000,000,000,000,000,000` wrapped-NOCK base units.
+
+### Admission Rules
+
+An official request is statically admissible only when:
+
+1. the raw amount is positive
+2. the raw amount is exactly divisible by `152,587,890,625`
+3. the converted nick amount fits `u64`
+4. the gross amount is at least `100,000 NOCK`
+5. the deterministic bridge fee is less than the gross amount
+
+The bridge fee is:
+
+```text
+ceil(gross_nicks / 65,536) * 195
+```
+
+The Nockchain transaction fee depends on the selected confirmed bridge inputs
+and transaction shape. The backend planner and proposal validator remain
+authoritative for that exact fee and enforce:
+
+```text
+gross_burn = bridge_fee + transaction_fee + net_payout
+net_payout > 0
+```
+
+The public policy/quote surface must return the active policy version and a
+current payout estimate using safe, unreserved liquidity. The estimate is not a
+guarantee: input reservations and chain state may change before construction.
+The official DApp must refuse submission when the policy is unavailable,
+unknown, stale, or when the quote reports no positive payout.
+
+### Policy Publication and Versioning
+
+The frontend must not hardcode this policy. A frontend-safe endpoint and the
+rendered deployment manifest must publish:
+
+1. policy id and wire-format id
+2. Base chain id and `Nock` token address
+3. effective Base block or deployment activation point
+4. minimum and boundary rule
+5. unit conversion constants and maximum nick amount
+6. bridge fee rate
+7. quote timestamp and readiness status
+
+Every admitted burn must retain the policy id under which it was accepted. A
+policy change requires a new id and explicit effective point; it must not
+reinterpret already observed burns. Clients fail closed on an unsupported
+policy id or a deployment mismatch.
+
+The `Nock` contract does not enforce this policy. Unsupported direct
+callers can bypass client validation and remain covered by malformed-burn
+monitoring and the operator compensation process.
 
 ## Target Withdrawal Flow
 
-1. User burns wrapped NOCK on Base (`Nock.sol::burn`), event emitted with `lockRoot`.
-2. Rust Base observer ingests burn, emits `%base-blocks` cause to kernel.
+1. The official client validates the active policy, constructs
+   `WithdrawalWireV1`, and submits those exact 116 bytes to `Nock.sol::burn`.
+   `BurnForWithdrawal.lockRoot` carries the 32-byte commitment.
+2. The Rust Base observer retrieves the transaction calldata, validates the
+   commitment and full destination, and emits a `%base-blocks` cause to the
+   kernel.
 3. Kernel stores unsettled withdrawals keyed by `(as_of base hash, base_event_id)`.
-   Base-side kernel processing now enforces the withdrawal minimum first; only
-   burns strictly above the configured minimum become withdrawals. We are
-   targetting a minimum of 10,000 NOCKS.
+   Under `withdrawal-policy-v1`, Base-side kernel processing admits burns at or
+   above the inclusive `100,000 NOCK` gross minimum.
 4. Kernel emits `%base-block-withdrawals-pending` with the Base batch identity and derived `nock-withdrawal-request` payloads.
 5. Runtime persists those requests idempotently, sends `%base-block-withdrawals-committed`, and then treats each request as a single-withdrawal coordination unit. `base-batch-end` remains part of withdrawal metadata, but settlement coordination is per-withdrawal rather than multi-withdrawal batching.
 6. For a given withdrawal id `(as_of, base_event_id)`, a deterministic epoch
@@ -254,6 +486,10 @@ This spec focuses on:
 22. The sequencer observes block inclusion directly from the colocated public
     Nockchain API, records confirmation for the authorized withdrawal, and
     clears the matching reserved-input / in-flight state.
+    The sequencer status response publishes the durable confirmation event
+    id, the matching reservation-release event id, and the confirmed
+    height/block only while the current row remains confirmed. Reorg-held or
+    invalidated rows return none of those terminal evidence fields.
 23. Kernel independently reconciles settlement with the counterpart withdrawal
     on the confirmed Nock block stream using counterpart identity, destination
     equality, and the basic bound `0 < settled_amount < burned_amount`, then
@@ -357,6 +593,10 @@ This spec focuses on:
      operator attempt in `Assembling`, `Prepared`, `PeerCanonical`,
      `Authorized`, or `MempoolAccepted`; `Pending` is tracked-but-not-live, and
      `Confirmed` is terminal.
+   - Sequencer ordering is stricter than the bridge-node live-work label:
+     `MempoolAccepted` remains the single nonce frontier. Only durable
+     `Confirmed` releases that nonce and permits the next withdrawal to
+     canonicalize, reserve inputs, authorize, or submit.
    - Tracks the current epoch, the current assembly / prepared / peer-canonical / authorized / submitted / confirmed phase, and the live peer-canonical / authorized candidate hashes when applicable.
    - Also acts as the live local assembly-lock record; there is no separate staged-request queue.
    - Must be rebuildable from the append-only log.
@@ -563,14 +803,20 @@ This spec focuses on:
    sequencer DB should be reconstructable from the remote journal plus Base /
    Nockchain reconciliation, except for explicitly fatal operator-intervention
    cases.
-6. Current implementation status: the sequencer can mirror lifecycle events to
-   remote object storage before local SQLite projection mutation, assign ordered
-   journal sequence numbers from a local SQLite cursor, and list/get ordered
-   R2 / S3-compatible journal objects. Startup verifies that the local cursor
-   names a real remote event, verifies that the cursor event's projection is
-   already present in SQLite, then replays every remote successor into SQLite.
-   Base activity replay and Base / Nockchain reconciliation are still deferred
-   follow-up phases.
+6. Current Rust implementation status:
+   - lifecycle decisions and exact retry artifacts are mirrored before SQLite
+     projection mutation and replayed through an exact remote cursor
+   - the verified Base activity index rebuilds canonical burns, tail-scans the
+     overlap window, recovers unmatched eligible burns, and refuses conflicting
+     chain facts
+   - Nockchain startup reconciliation requires exact authorized raw bytes,
+     confirms buried inclusion, retries only those bytes, filters unsafe-origin
+     liquidity, and blocks while local chain state is behind
+   - bounded Base and Nockchain invalidations are append-only and can regress
+     public lifecycle state while restoring reservations atomically
+   - real R2/chain drills and a tested operator recovery procedure for
+     post-confirmation history divergence remain launch gates; automatic
+     in-place Hoon rewind is an optional resilience improvement
 
 ### Remote Sequencer Journal
 
@@ -933,9 +1179,15 @@ safe_nock_tip = max(0, current_nock_tip - nockchain_confirmation_depth)
    - if not included, leave `MempoolAccepted`; orphan retry can resubmit using
      `authorized_raw_tx`
 4. For each `Confirmed` row:
-   - if the tx is still observable as confirmed, recovery continues
-   - if the tx is not visible, fail closed or alert by default; do not silently
-     roll back confirmed state without an explicit deep-reorg repair mode
+   - matching canonical inclusion keeps the row confirmed and clears any
+     missing-inclusion observation
+   - same-transaction inclusion in a different block appends invalidation and
+     reinclusion facts without changing raw bytes or creating a second payout
+   - absence requires two consecutive persisted observations before regression
+   - a stable snapshot may regress to `MempoolAccepted` or `Authorized`, restore
+     reservations, and resubmit only the exact authorized raw transaction
+   - unsafe input origins, excessive depth, or missing checkpoint evidence enter
+     `reorg_hold` before mutation
 5. Refresh current balance snapshot.
 6. Filter bridge-owned notes to safe-origin notes only.
 7. Verify each active reserved input is either:
@@ -995,254 +1247,306 @@ safe_nock_tip = max(0, current_nock_tip - nockchain_confirmation_depth)
 6. Future replay phases must advance the cursor in the same SQLite transaction
    as the projection writes covered by that cursor.
 
-### Updated Implementation Plan
+### Base and Nockchain Reorg Recovery Policy
 
-1. Terminology and configuration:
-   - rename operator-facing config/docs from S3-specific language to
-     R2 / S3-compatible object-store language
-   - keep R2 as the primary documented target
-   - keep compatibility aliases only where useful for rollout
-   - keep `bridge-dev` explicitly disabled unless local object-store settings
-     are configured
-2. Journal completeness:
-   - extend journal records with `sequence`, `event_id`,
-     `previous_event_id`, `created_at_unix_ms`, deployment-bound
-     `journal_id`, and event context blocks
-   - add missing event types for withdrawal ordering and mempool retry metadata
-   - journal `withdrawal_nonce`, handoff fields, submit-attempt metadata,
-     selected input origins, `transaction_jam`, submitted raw tx id, and
-     `authorized_raw_tx`
-3. R2 / object-store read path:
-   - extend the journal abstraction with append, list, and get
-   - use `aws-sdk-s3` for S3-compatible `ListObjectsV2` pagination and `GET`
-   - validate decoded records before mutating SQLite
-4. Replay projector:
-   - apply journal events to projection state without writing new remote events
-   - keep replay exact-frontier: a cursor event must already be projected, and
-     successors are applied one at a time
-   - reuse the local recovery cursor: last sequence and last event id
-   - fail if local SQLite projection is non-empty with no usable cursor, if the
-     cursor object is absent from the remote stream, or if the projection is
-     detectably ahead of the event being replayed
-5. Base reconciliation:
-   - add `BaseActivityIndex` / `BaseActivityStore`
-   - add local verified Base burn projection, e.g. `sequencer_base_burns`
-   - verify indexed records against Base RPC
-   - scan the recent overlap tail and insert missing burns
-   - recover unmatched burns as pending withdrawals
-6. Nockchain reconciliation:
-   - add startup reconciliation over `Authorized`, `MempoolAccepted`, and
-     `Confirmed` rows
-   - require raw tx bytes for unconfirmed in-flight withdrawals
-   - use tx-included-block lookup plus current tip to mark confirmations
-   - reject or defer currently unsafe-origin selected inputs in proposal
-     validation without advancing lifecycle state
-   - keep assembly pending when safe-origin liquidity is insufficient
-7. Tests:
-   - DB wipe rebuilds sequencer state from remote journal
-   - partial DB catches up from journal cursor
-   - remote append succeeds but local SQLite mutation fails; reboot applies the
-     remote event
-   - replay preserves `authorized_raw_tx` byte-for-byte
-   - replay restores and clears reserved inputs correctly
-   - replay does not re-append remote objects
-   - replay rejects projection/cursor skew instead of skipping over later local
-     lifecycle state
-   - malformed, missing, duplicated, gapped, or hash-discontinuous remote
-     records fail safely
-   - Base activity index verifies exact logs and tail scan finds missing recent
-     burns
-   - Base burn with no sequencer state recovers as pending
-   - journaled sequencer withdrawal with mismatched Base amount, destination, or
-     ordering fails recovery
-   - proposal construction excludes notes with `origin_height > safe_nock_tip`
-   - refund / change note is ignored before confirmation depth and accepted
-     after confirmation depth
-   - incoming proposal with an input that is unsafe at validation height is not
-     persisted, but the same otherwise-valid proposal can be accepted after the
-     local safe tip advances past that input origin
-   - insufficient safe notes leaves withdrawal pending and retries later
-   - incoming proposal using unsafe/recent note is rejected
-   - missing authorized raw tx for unconfirmed in-flight withdrawal fails safe
-   - journal write failure prevents mutation/submission in production mode
+#### Boundaries and checkpoints
 
-## Design Commitments and Remaining Hardening
+1. Both observers derive an eligible height from the latest RPC tip minus the
+   configured confirmation depth; they do not consume an RPC `safe` or
+   `finalized` tag. The buffer prevents ordinary shallow forks from reaching
+   Hoon and lowers the probability of deeper divergence, but a parent mismatch
+   after acceptance remains a fail-stop incident.
+2. For each chain, the maximum automatic rewind is:
 
-### A) Kernel behavior and remaining hardening (Hoon)
+   ```text
+   automatic_rewind_depth =
+     min(configured_confirmation_depth, 64 blocks)
+   ```
 
-1. Keep withdrawal proposal handling out of the kernel.
-   - do not introduce a kernel withdrawal proposal-validation cause
-   - do not persist `withdrawal-proposals` in kernel state
-   - do not validate proposal identity, epoch legality, replay, or
-     equivocation in the kernel
-   - do not validate proposal envelope fields against tracked withdrawal
-     metadata in the kernel
-   - the kernel should remain withdrawal-level only: qualifying burns create
-     live/unconfirmed withdrawals, and confirmed settlements clear them
-2. Harden Base-side proposal generation in `++ base-propose-withdrawals` (already emitting `nock-withdrawal-request`) with queue semantics suitable for single-flight assembly/canonicalization.
-3. Harden withdrawal parsing path in `++ process-nock-txs` (already creating `withdrawal-settlement`) and close remaining schema/validation gaps.
-4. Finalize `++ nockchain-process-withdrawal-settlements` behavior in `open/hoon/apps/bridge/nock.hoon`:
-   - reconcile settlement against tracked unsettled withdrawals
-   - apply hold/stop semantics for out-of-order or inconsistent settlement
-   - tolerate sequencer retries of the same authorized tx without treating them as a second withdrawal
-5. The dedicated `create-withdrawal-tx` poke/cause is the bridge-side tx
-   builder seam.
-   - it includes `epoch` and pinned
-     `withdrawal-snapshot` in addition to explicit withdrawal metadata plus
-     selected inputs
-   - it lets Rust ask the bridge app tx-builder to build one full
-     `withdrawal-proposal`, not just a raw tx
-   - successful construction comes back out via `%withdrawal-proposal-built`,
-     carrying that full proposal
-   - it remains separate from `%base-block-withdrawals-pending`, which stages
-     Base burn withdrawal intent until Rust persists and acks it
-6. `%sign-tx` is the dedicated poke/cause for transaction signing.
-   - input should be the full `withdrawal-proposal`
-   - Rust uses it after proposal construction / authorization, not as part of
-     kernel withdrawal-state transitions
-   - signing remains distinct from tx construction and from confirmed terminal
-     effects
-7. Kernel settlement reconciliation is currently state-only.
-   - on confirmed settlement reconciliation from the confirmed Nock block
-     stream, kernel clears the unsettled withdrawal directly
-   - there is no dedicated `%withdrawal-terminal` effect today
-   - if a future terminal effect is added, it should identify the confirmed
-     withdrawal and settlement outcome only; it must not include local note
-     names
-8. Normalize and finalize withdrawal metadata encoding:
-   - new packed key path: `%bridge-w`
-   - includes `base-block-hash`, `beid`, `base-batch-end`, `lock-root`
-9. Finalize amount semantics in kernel and Rust models now that dedicated
-   withdrawal fee fields were removed from molds.
-   - gross burned amount remains the source-of-truth input from Base
-   - net disbursed amount is the amount actually paid to the Nockchain
-     recipient
-   - kernel settlement reconciliation enforces only
-     `0 < settled_amount < gross_burned_amount`
-  - exact economic correctness
-    (`gross_burned_amount = withdrawal_fee + final_fee + net_disbursed_amount`)
-    belongs in the Rust proposal validation path owned by
-    `WithdrawalProposalRegistry`
-   - do not overload one public planner request type to mean both "gross burn"
-     and "net gift"
+   `64` is a hard protocol safety cap. A zero confirmation depth permits no
+   automatic rewind.
+3. Each observer persists the current confirmed header plus at least
+   `automatic_rewind_depth` predecessors. A checkpoint includes chain,
+   deployment, height, block id, parent id, observation time, and the projection
+   cursor/journal event covered by that header.
+4. The stable rewind anchor is the oldest retained checkpoint in that bounded
+   window. Automatic recovery is allowed only when all affected local
+   projections prove the same canonical common ancestor at or above that
+   anchor.
+5. The Base bridge observer and sequencer Base-activity scanner may be at
+   different tips. Recovery uses the older common ancestor proven by both; no
+   observer may independently resume ahead of the other.
+6. A fork that crosses the configured withdrawal activation block, the
+   `WithdrawalWireV1` rollout block, the withdrawal Nock activation frontier, or
+   a policy/deployment-id boundary is always manual even when it is fewer than
+   64 blocks.
+7. Oscillating shallow forks reuse the same stable anchor. The cumulative
+   rewind may never move below it. Each detected fork gets a distinct recovery
+   generation/event, so an old branch becoming visible again cannot silently
+   reactivate invalidated work.
+8. A mismatch beyond the retained anchor, missing/corrupt checkpoint evidence,
+   or disagreement between projections is a deep reorg. It pauses admission,
+   authorization, submission, confirmation, reservation release, and public
+   terminal-state advancement.
 
-### B) Rust bridge crate shape and remaining hardening
+#### Append-only recovery facts
 
-1. Withdrawal proposal transport and validation live in Rust:
-   - ingress RPC and message types exist for withdrawal proposal, canonical
-     proposal, and signed-proposal broadcast
-   - proposal envelope must include withdrawal id, epoch, pinned snapshot
-     metadata, selected input note names, the built `transaction`, net
-     disbursed amount, and gross burned amount
-   - decode and route directly to Rust withdrawal coordination logic rather
-     than via a kernel cause
-   - validate the proposal envelope in Rust by checking:
-     - whether the withdrawal exists
-     - whether the proposal's `burned_amount`, recipient, and batch metadata
-       match the tracked withdrawal
-     - same-epoch replay vs equivocation
-     - contiguous epoch legality
-     - future exact amount validation before persistence/canonicalization by
-       independently checking
-       `burned_amount = withdrawal_fee + final_fee + amount`
-   - also validate pinned snapshot, selected notes, and transaction identity
-     as part of the Rust-owned proposal envelope checks
-2. The split withdrawal tx-builder seam is live:
-   - Rust selects candidate inputs and pinned snapshot metadata, then pokes the
-     widened `%create-withdrawal-tx`
-   - decode `%withdrawal-proposal-built`, carrying the constructed full
-     `withdrawal-proposal`
-   - keep this builder seam implementable before durable submission is enabled
-   - make the withdrawal builder use a withdrawal-specific planning API that
-     takes gross burned amount as input and computes net disbursed amount plus
-     fee before calling `%create-withdrawal-tx`
-   - keep the existing generic `plan_create_tx` path as the net-gift planner;
-     share the lower-level selection/fee/refund engine rather than forcing one
-     top-level amount field to serve both meanings
-3. The signing seam is live:
-   - Rust pokes `%sign-tx` with the full `withdrawal-proposal`
-   - successful signing should come back out via `%withdrawal-tx-signed`,
-     carrying the proposal envelope with signed transaction data
-   - signing is driven from Rust-side coordination and remains separate from
-     kernel withdrawal-state transitions
-4. The withdrawal sequencing service is live:
-   - implement the durable sequencing service core and schema first
-   - append-only local log of proposal/canonicalization/submission/confirmation lifecycle
-   - authoritative tracking in the withdrawal state store of peer-canonical / authorized /
-     submitted withdrawals
-   - host the sequencer gRPC surface on the Nockchain API node process rather
-     than in a separate bridge-side binary
-   - have that API-node-hosted sequencer poll the colocated public Nockchain
-     API for confirmation and clear the in-flight set there
-   - reserve input notes by note `Name` at peer canonicalization and keep them
-     reserved through authorization / submission until confirmation
-   - drive local tx-status reconciliation using `tx-accepted` as a diagnostic
-     mempool/accepted signal and confirmed settlement observations as the
-     release signal
-   - confirmation and reservation release are sequencer-owned; kernel
-     settlement reconciliation is parallel and does not currently arrive as a
-     dedicated Rust terminal effect
-   - make the sequencer the only submission authority for withdrawals
-   - make bridge nodes ask the sequencer for `authorized` / `submitted` /
-     `confirmed` truth instead of reconstructing that lifecycle locally
-5. The withdrawal execution driver is live:
-   - consume `BridgeEffectVariant::BaseBlockWithdrawalsPending`
-   - allow at most one withdrawal in assembly/canonicalization at a time for the bridge-controlled spend authority / note pool
-   - make the sequencer gRPC service the only component that finalizes and submits an authorized raw tx using nockapp public nockchain gRPC client (`wallet_send_transaction`)
-   - include separate assembly timeout and sequencer submission timeout behavior
-   - if the sequencer is unavailable, stop withdrawal progress rather than failing over to peer submission
-6. Add proposal broadcast/signature workflow keyed off per-withdrawal epochs rather than deposit ids or withdrawal batches, with sequencer authorization required before a peer-canonical candidate becomes submit-ready.
-   - built proposals must be broadcast from the live `%withdrawal-proposal-built`
-     execution path
-   - canonicalization gossip must carry a threshold commit certificate
-   - authorization must reject peer-canonical proposals that lack that
-     certificate
-7. Runtime/main wiring now registers the withdrawal execution driver, ingress
-   transport, and withdrawal runtime loops in `open/crates/bridge/src/main.rs`.
-8. Bridge note snapshot handling should continue to:
-   - use a normalized bridge-note balance snapshot for private-node sync as well as public sync
-   - refresh the confirmed bridge-note snapshot whenever a newly confirmed nockchain block is observed
-   - support on-demand refresh before assembly when the cached snapshot is stale
-   - compute `spendable_notes = confirmed_snapshot(origin_page <= safe_nockchain_tip) - reserved_inputs`
-   - prevent reuse of notes that belong to peer-canonical / authorized /
-     mempool-accepted but unconfirmed withdrawal txs
-9. Durable withdrawal storage must continue to provide:
-   - an append-only withdrawal lifecycle log
-   - the live reserved-note set and current withdrawal state-store projection
-   - startup rebuild of live mutable state from the append-only log
-   - transactional reserved-note writes alongside the corresponding canonical /
-     confirmed lifecycle event append
-10. Optional but recommended:
-   - enrich `process_nock_log` output in `open/crates/bridge/src/ethereum.rs` to propagate destination/lock-root mapping into runtime observability structures, or explicitly document that kernel state is canonical and Rust-side `dest` remains advisory-only.
+Recovery changes mutable projections only by appending facts and rebuilding
+from them. The logical event set is:
 
-### C) Type/protocol shape
+- `reorg_recovery_started`
+- `base_burn_invalidated`
+- `proposal_invalidated`
+- `nock_inclusion_invalidated`
+- `kernel_settlement_invalidated`
+- `reservation_restored`
+- `reorg_recovery_completed`
+- `reorg_recovery_escalated`
 
-1. `open/crates/bridge/proto/bridge_ingress.proto`
-   - includes withdrawal proposal request/response
-   - proposal payload is a full withdrawal proposal envelope, not just a bare
-     transaction body
-   - includes withdrawal id, epoch, proposal hash / transaction name, pinned
-     snapshot metadata, selected input note names, and typed payload
-   - includes sequencer RPCs for register / handoff / canonical / signed /
-     reserved-inputs / authorize / submit / status / confirmed-record updates
-2. `open/crates/bridge/src/shared/types.rs`
-   - keep `NockWithdrawalRequestKernelData` as the kernel-emitted withdrawal intent payload
-   - include `%withdrawal-proposal-built`, carrying a full `withdrawal-proposal`
-   - include `%withdrawal-tx-signed`, carrying a full signed `withdrawal-proposal`
-   - include a separate withdrawal proposal envelope type for peer coordination
-   - there is no terminal withdrawal effect variant today
-   - ensure serialized field order matches Hoon `nock-withdrawal-request` (`base_event_id`, `recipient`, `amount`, `base_batch_end`, `as_of`)
-3. `open/hoon/apps/bridge/types.hoon`
-   - keep withdrawal molds aligned with new shapes (`nock-lock-root`, `base-batch-end`, no dedicated withdrawal fee field)
-   - widen `%create-withdrawal-tx` so bridge-side tx building includes
-     `epoch` and pinned `withdrawal-snapshot`, not just withdrawal metadata and
-     selected inputs
-   - add a `%withdrawal-proposal-built` effect mold carrying a full
-     `withdrawal-proposal`
-   - add a `%withdrawal-tx-signed` effect mold carrying a full signed
-     `withdrawal-proposal`
-   - there is no `%withdrawal-terminal` effect mold today
-   - do not add a withdrawal proposal-validation cause to the kernel molds
+Every invalidation references the original journal event, chain checkpoint,
+recovery generation, withdrawal id, and exact raw transaction id when one
+exists. An old event is never deleted or rewritten. A journal append that raced
+ahead of reorg detection remains in history and is followed by its invalidation.
+SQLite cursors/checkpoint projections may rewind atomically; remote journal
+sequence numbers never do.
+
+Canonical replay may re-admit a burn or inclusion after its invalidation. That
+is a new append-only fact referencing the prior invalidation, not resurrection
+by deleting it.
+
+#### Base reorg response by lifecycle
+
+| Lifecycle when Base burn is orphaned | Automatic response within boundary | Reservations | Public status |
+|---|---|---|---|
+| not admitted / activity index only | invalidate activity row, rewind cursor, rescan canonical logs | none | absent or `invalidated` |
+| `Pending`, `Assembling`, `Prepared` | append burn/proposal invalidation; discard local attempt; canonical rescan may re-admit | release only tentative pre-canonical work | regress to `invalidated` |
+| `PeerCanonical` | append burn and proposal invalidation; fixed proposal becomes permanently unusable | release pinned inputs atomically with invalidation | `invalidated` |
+| `Authorized` but not known in mempool | **manual**: a fully signed raw tx may already have escaped | retain all reservations | `reorg_hold` |
+| `MempoolAccepted` | **manual**: stop resubmission and query exact tx on canonical Nockchain | retain all reservations | `reorg_hold` |
+| Nock-included / sequencer `Confirmed` | **manual conservation incident** | restore/retain reservations; do not pay or refund again | regress to `reorg_hold` |
+| kernel settlement applied | **manual conservation incident**: Base funding is gone while payout may exist | retain incident evidence and safe-origin locks | `reorg_hold` |
+
+Once a proposal is authorized, automatic Base invalidation is prohibited
+because the exact fully signed Nock transaction can be submitted by another
+party. "Not observed" is not proof it cannot execute.
+
+A canonical replacement burn with the same tx/log identity may be re-admitted
+automatically only for rows that had not reached `Authorized`. A replacement at
+another Base identity is a new withdrawal. The system never infers that it is a
+refund or substitutes it for an already-paid orphan.
+
+#### Nockchain reorg response by lifecycle
+
+| Nock-side stage affected by orphaned blocks | Automatic response within boundary | Reservations / raw tx | Public status |
+|---|---|---|---|
+| note snapshot only; no fixed proposal | rewind snapshot/checkpoint and replan from canonical safe notes | discard tentative selection | unchanged or regress to assembling |
+| `PeerCanonical` and any selected input origin is orphaned | invalidate proposal and start a new epoch from a canonical snapshot | release invalid proposal reservations; never mutate its raw tx | regress to pending |
+| `Authorized` and all input origins remain at/below common ancestor | keep exact authorized raw tx; query mempool/inclusion; resubmit only those exact bytes if absent | retain reservations | `authorized` or `mempool_accepted` |
+| `Authorized` and an input/change-note origin is orphaned | **manual**: signed transaction safety cannot be proven | retain reservations and raw bytes | `reorg_hold` |
+| mempool accepted, inclusion not yet terminal | preserve exact raw tx; if still in mempool wait, otherwise resubmit exact bytes | retain reservations | `mempool_accepted` or `authorized` |
+| inclusion orphaned after sequencer `Confirmed` | append inclusion invalidation; if re-included record new block; otherwise regress and retry exact raw tx | atomically restore reservations before retry eligibility | regress from `confirmed` |
+| kernel settlement was applied on orphaned block | restore the last stable kernel checkpoint, append settlement invalidation, replay canonical Nock blocks | restore reservations/unsettled counterpart before any retry | regress from `confirmed` |
+| required kernel checkpoint absent, replay diverges, or descendant change note has been spent | **manual deep-reorg procedure** | freeze affected notes/reservations | `reorg_hold` |
+
+Re-inclusion of the same transaction in another block changes only inclusion
+facts; the transaction id/raw bytes stay identical and no second payout is
+created. If the old transaction remains in the mempool, do not submit a
+replacement. If it disappears and its input origins remain canonical, retry
+only the journaled `authorized_raw_tx`; recovery never reconstructs or
+re-signs it.
+
+Kernel replay is deterministic from the stable checkpoint and canonical block
+pages. It must restore `unsettled-withdrawals` before a previously cleared
+settlement can become retry-eligible. Rust projections advance in the same
+transaction as the replay cursor.
+
+#### Reservation and user-state invariants
+
+1. Pre-canonical invalidation releases reservations only when no authorized raw
+   transaction exists.
+2. `Authorized`, `MempoolAccepted`, and orphaned `Confirmed` rows retain or
+   atomically restore their exact input reservations until canonical inclusion
+   is proven again or an operator resolves a deep incident.
+3. A reservation restored after an orphaned confirmation becomes visible
+   before any planner snapshot can spend that note.
+4. Public state is allowed to regress. `confirmed` is not sticky across a
+   reorg. Responses include the recovery generation, invalidated block
+   reference, prior state, current state, and `reorg_hold`/recovery reason.
+5. Public pagination/readiness snapshots must not mix pre- and post-rewind
+   generations.
+6. No automatic path emits a refund for a burn that may already have produced a
+   Nock payout. No automatic path creates a second payout for one Base event.
+
+#### Recovery examples
+
+1. **Shallow Base fork, pending burn**
+   - retained ancestor: Base 1,000; orphan burn: 1,003; depth: 3
+   - append recovery start and burn invalidation
+   - atomically rewind activity/kernel-derived cursor to 1,001
+   - rescan 1,001..safe tip; re-admit only canonical wire-valid burns
+   - result: zero actionable rows for the orphan, conservation unchanged
+2. **Shallow Base fork, authorized payout**
+   - the same depth is inside the header window, but lifecycle is `Authorized`
+   - append escalation, globally pause submission, keep exact raw tx and
+     reservations
+   - result: no automatic refund, release, replacement, or second payout
+3. **Shallow Nock fork, sequencer confirmed**
+   - exact tx was included at Nock 2,010; common ancestor is 2,008
+   - append inclusion invalidation and restore reservations
+   - if canonical RPC reports the same tx at 2,011, append new inclusion and
+     confirm after depth; otherwise retain/resubmit the same raw bytes
+4. **Kernel-cleared settlement orphaned**
+   - restore kernel checkpoint at the common ancestor
+   - replay canonical pages; absent settlement restores the Base counterpart to
+     unsettled state
+   - public state regresses and reservations are restored before planning
+5. **Both chains reorg**
+   - pause once and assign one recovery generation
+   - reconcile Base funding first, then Nock inclusion/settlement against that
+     result
+   - any authorized Base orphan forces manual handling even if the Nock fork is
+     shallow
+6. **Journal append before detection**
+   - preserve the append, add an invalidation referencing it, rebuild the local
+     projection; journal sequence remains monotonic
+7. **Activation frontier crossed**
+   - append escalation and stop; do not recompute activation from the new fork
+     or admit pre-rollout calldata
+8. **Depth 65 with a 64-block anchor**
+   - no cursor/state mutation occurs
+   - record expected/got parent, newest/oldest checkpoint, candidate ancestor,
+     affected withdrawals/raw tx ids/reservations, and stop for operator repair
+
+#### Fatal deep-reorg procedure
+
+1. Stop all bridge nodes and sequencer mutation loops; keep read APIs in
+   `reorg_hold` readiness.
+2. Snapshot SQLite files and the remote append-only journal. Do not truncate,
+   delete, or rewrite either.
+3. Record both chains' canonical RPC endpoints/tips, expected and observed
+   parent ids, retained checkpoint range, activation/policy boundaries, journal
+   cursor, affected withdrawals, exact raw tx ids, and reservations.
+4. Determine the canonical common ancestor independently on at least two RPC
+   providers per affected chain.
+5. Classify every affected withdrawal for possible Base funding, Nock payout,
+   refund, and raw-tx replay. Preserve exact raw transaction bytes.
+6. Use an explicit audited repair mode to append checkpoint/invalidation facts
+   and rebuild projections. Never hand-edit live tables.
+7. Re-run conservation, reservation, journal-prefix, chain-readiness, and
+   public-status checks at one exact revision before resuming.
+
+The conservation condition is strict: one canonical Base burn funds at most one
+canonical Nock payout, and no refund is allowed while a payout may exist. An
+incident that cannot prove that condition remains paused.
+
+### Recovery implementation and release gates
+
+Rust implements the remote journal, exact replay cursor, Base activity index,
+startup Base/Nockchain reconciliation, safe-origin liquidity filters, exact raw
+transaction retry, bounded chain invalidation, reservation restoration, and
+public lifecycle regression. Tests cover wiped and partial SQLite recovery,
+remote-ahead replay, cursor/projection skew, authorized raw-byte preservation,
+reservation rebuild, Base-tail recovery, unsafe-origin deferral, shallow fork
+replay, and deep-fork holds.
+
+Production launch additionally requires:
+
+1. deployment-locked, nonzero Base and Nockchain confirmation depths with the
+   accepted finality assumptions recorded at the certified revision;
+2. real-kernel proof that post-confirmation parent divergence stops processing
+   without mutating the accepted hashchain, plus Rust mutation refusal and
+   fail-closed readiness;
+3. a tested operator procedure to disable new Base burns, preserve evidence,
+   rebuild or restore Hoon from a certified ancestor, replay canonical history,
+   and reconcile Rust projections before resuming;
+4. credentialed R2 and chain recovery drills;
+5. bridge-dev reorg and restart scenarios using the deployed kernel jams;
+6. conservation, journal-prefix, reservation, public-status, and readiness
+   certification at one exact revision.
+
+Automatic Hoon rewind may implement part of item 3, but is not required when
+the certified manual recovery procedure satisfies the same safety invariant.
+Missing kernel assets, live credentials, or a tested recovery procedure block
+launch. Mocks do not satisfy these gates.
+
+## Component Ownership
+
+### Hoon kernel
+
+The kernel owns withdrawal-level state:
+
+1. qualifying Base burns enter unsettled withdrawal state;
+2. `%base-block-withdrawals-pending` stages admitted withdrawal intent;
+3. `%create-withdrawal-tx` builds a proposal from explicit withdrawal,
+   snapshot, epoch, and selected-input data;
+4. `%withdrawal-proposal-built` returns the complete proposal envelope;
+5. `%sign-tx` signs a complete proposal;
+6. `%withdrawal-tx-signed` returns the signed proposal;
+7. confirmed Nockchain settlement reconciles and clears the matching
+   unsettled withdrawal.
+
+The kernel does not own proposal epochs, replay/equivocation detection,
+peer-canonical certificates, sequencer authorization, raw transaction retry,
+or note reservation projections. Those checks require Rust and durable
+sequencer state.
+
+Withdrawal metadata uses `%bridge-w` and carries `base-block-hash`, `beid`,
+`base-batch-end`, and `lock-root`. Kernel settlement reconciliation enforces
+identity, destination, and `0 < settled_amount < gross_burned_amount`. Rust
+proposal validation enforces the complete economic equation:
+
+```text
+gross_burned_amount = bridge_fee + transaction_fee + net_disbursed_amount
+```
+
+### Rust bridge runtime
+
+Rust owns proposal construction inputs, validation, peer transport, and runtime
+coordination:
+
+1. select a confirmed bridge-note snapshot and candidate inputs;
+2. compute bridge fee, transaction fee, and net payout;
+3. invoke `%create-withdrawal-tx` and decode the returned proposal;
+4. validate withdrawal identity, recipient, amount, Base batch, epoch,
+   snapshot, selected inputs, transaction body, and fee conservation;
+5. broadcast complete proposal envelopes;
+6. verify signed peer commits over the exact proposal hash;
+7. submit peer-canonical work to the sequencer for authorization;
+8. keep peer-canonical, authorized, and mempool-accepted inputs reserved until
+   durable confirmation or explicit recovery.
+
+`crates/bridge/src/main.rs` registers the withdrawal execution driver, ingress
+transport, runtime loops, blockchain-constant handshake, and confirmed-block
+watchers. Sequencer unavailability pauses withdrawal progress; peers do not
+take over submission.
+
+### Sequencer
+
+The API-node-hosted sequencer is the only withdrawal submission authority. It
+durably records ordering, handoff, peer-canonical proposal, authorization, raw
+transaction, submission, confirmation, reservation, incident, and public
+projection facts.
+
+Only one withdrawal may be authorized, submitted, or unconfirmed at a time.
+The next withdrawal cannot reserve or canonicalize until the current
+withdrawal has durable confirmation. Confirmation polling uses the colocated
+public Nockchain API and records the confirmed block plus matching
+reservation-release event before advancing the frontier.
+
+### Protocol types
+
+- `crates/bridge/proto/bridge_ingress.proto` defines proposal transport,
+  private sequencer mutation RPCs, read-only public queries, terminal evidence,
+  readiness, history, and quote messages.
+- `crates/bridge/proto/bridge_tui.proto` defines target-bound kernel
+  observability for terminal evidence.
+- `crates/bridge/src/shared/types.rs` mirrors the Hoon request and effect
+  field order.
+- `hoon/apps/bridge/types.hoon` defines `nock-withdrawal-request`,
+  `withdrawal-proposal`, snapshot, proposal-built, and signed-proposal molds.
+
+Field order and numeric encodings must remain identical across Rust, protobuf,
+Hoon, Iris, and the published test vectors.
 
 ## Invariants and Validation Rules
 
@@ -1293,7 +1597,57 @@ safe_nock_tip = max(0, current_nock_tip - nockchain_confirmation_depth)
 10. At most one withdrawal may hold the assembly/canonicalization lock at a time for the bridge-controlled spend authority / note pool.
 11. At most one withdrawal may be sequencer-authorized / submitted / unconfirmed at a time.
 
-## Testing Plan
+## Executable Bounded Lifecycle Model
+
+The independent Quint model is
+[`spec/bridge-withdrawal.qnt`](../../../spec/bridge-withdrawal.qnt), with
+deterministic happy, restart, Base-reorg, Nock-reinclusion, replacement-epoch,
+stale-kernel, simultaneous-fork, and compensation runs in
+[`spec/bridge-withdrawal-tests.qnt`](../../../spec/bridge-withdrawal-tests.qnt).
+It bounds exploration to three kernel nodes, two selected inputs, two proposal
+epochs, and two journal generations. Amounts are abstract integers that retain
+both conservation equations; process, SQLite, RPC, and cryptographic details
+remain outside the model.
+
+| Production/Rust concept | Quint state or action |
+|---|---|
+| `WithdrawalModelAction::ObserveBurn` | `observeCanonicalBurn` / `canonicalBurn` |
+| prepared and peer-canonical proposal epochs | `assemble`, `prepare`, `replacePrepared`, `canonicalize` |
+| exact authorized transaction name | `rawTxIdentity`, `authorizedTxIdentity`, `authorize` |
+| sequencer restart and journal replay | `journalGeneration`, `restartSequencer`, `restoreReservations`, `replayJournal` |
+| submitted/included/reincluded/confirmed | `submit`, `include`, `reinclusion`, `confirm` |
+| per-kernel settlement proof | `settledNodes`, `settleKernel` |
+| sequencer-owned note exclusion | `reservations`, `releaseReservations` |
+| Base/Nock reorg hold | `HoldKind` and the shallow/deep fork actions |
+| terminal multi-source proof | `publishTerminal` guarded by `terminalProofInv` |
+
+The executable invariant bundle `allSafety` maps to the production requirements
+as follows:
+
+- `onePayoutPerBurnInv` and `compensationExcludesPayoutInv`: one canonical burn
+  funds at most one payout, and compensation permanently excludes payout.
+- `oneReservationOwnerInv` and `activeReservationInv`: every selected input has
+  at most one owner and remains excluded until replay or terminal release.
+- `retryIdentityInv`: authorization, retry, inclusion, and reinclusion retain one
+  exact raw transaction identity.
+- `terminalProofInv`: terminal requires a canonical burn, exact inclusion,
+  every kernel settlement, both conservation equations, one payout, and released
+  reservations.
+- `unsafeForkHoldsInv` and `publicStateInv`: deep/unsafe fork paths enter
+  `PublicReorgHold` before payout mutation and public state cannot outrun the
+  protocol phase.
+
+The temporal properties state their assumptions in code. A continuously enabled
+healthy progress action is weakly fair only while Base, Nockchain, quorum, and
+liquidity remain available. A continuously enabled shallow-fork recovery
+observation is separately weakly fair; deep forks intentionally remain held.
+
+Local verification is pinned explicitly in the command line rather than CI:
+`npx -y @informalsystems/quint@0.32.0 test spec/bridge-withdrawal-tests.qnt`;
+TLC checks `allSafety`, `healthyEventuallyTerminal`, and
+`shallowForkEventuallyResolves`.
+
+## Required Verification
 
 ### Kernel tests
 
@@ -1313,9 +1667,9 @@ safe_nock_tip = max(0, current_nock_tip - nockchain_confirmation_depth)
 1. Ingress decodes withdrawal proposal and hands it directly to Rust
    withdrawal coordination logic.
 2. Rust proposal validation rejects unknown withdrawals, mismatched withdrawal
-   metadata, illegal epochs, replay with mismatched envelope, same-epoch
-   equivocation, and future economically inconsistent fee decomposition.
-3. Rust proposal broadcast driver emits full withdrawal proposal envelopes to peers correctly.
+   metadata, illegal epochs, replay with a mismatched envelope, same-epoch
+   equivocation, and inconsistent fee decomposition.
+3. Rust proposal broadcast carries complete proposal envelopes.
 4. Canonicalization is reached only when threshold peers persist and commit to
    the same proposal hash, and the resulting canonicalized broadcast carries a
    valid threshold commit certificate.
@@ -1354,30 +1708,11 @@ safe_nock_tip = max(0, current_nock_tip - nockchain_confirmation_depth)
 6. Conflicting later proposal for an already authorized withdrawal is treated as an invariant violation / stop.
 7. Simulated out-of-order Base/Nock arrival with hold release.
 
-## Remaining Policy Questions
-
-1. Fee model:
-   - exact formula for withdrawal fee deduction and where it is applied
-2. Hold metadata requirements:
-   - whether base block height must be embedded in tx metadata for deterministic unblock behavior
-3. Whether single-flight policy should remain permanent, or only the current intended design
-
-## Remaining Hardening Themes
-
-1. Kernel hardening
-   - keep kernel settlement reconciliation scoped to identity plus basic amount
-     bounds while moving exact fee validation into Rust proposal acceptance
-   - keep hold/stop behavior deterministic
-2. Runtime and integration hardening
-   - continue exercising multi-node proposal convergence, assembly failover,
-     sequencer restart recovery, and reservation integrity
-   - keep one-withdrawal-at-a-time assembly / submission behavior explicit
-3. Production hardening
-   - metrics, alerts, operational docs, replay abuse tests
 
 ## Acceptance Criteria
 
-1. No `TODO`/hard-stop paths remain for withdrawal causes/effects in kernel.
+1. Every withdrawal cause and effect has implemented runtime behavior;
+   deliberate stop paths are limited to invariant failures.
 2. Bridge nodes can process Base burns into canonicalized, submitted, and finalized per-withdrawal Nock settlements.
 3. If the scheduled assembler is offline before canonicalization, timeout handling is unambiguous:
    - `Assembling` rotates same-epoch pre-canonical handoff

--- a/crates/bridge/docs/release-punchlist.md
+++ b/crates/bridge/docs/release-punchlist.md
@@ -2,7 +2,7 @@
 
 Status: Draft
 Owner: Nockchain Maintainers
-Last Reviewed: 2026-05-06
+Last Reviewed: 2026-08-27
 
 This punchlist tracks release-blocking bridge launch checks that are easy to miss
 when moving from fakenet to mainnet.
@@ -31,7 +31,10 @@ when moving from fakenet to mainnet.
    - `MessageInbox.withdrawalsEnabled()` controls whether Base accepts new burns.
    - `withdrawal_processing_enabled` controls whether bridge nodes assemble,
      sign, exchange, and submit withdrawal proposals.
-   - Production readiness requires both controls to be enabled.
+   - Keep both gates false while recovery, monitoring, SDK, frontend, and
+     certification gates are incomplete.
+   - Enable both only during the controlled cutover after every bridge node and
+     the sequencer report the certified readiness frontier.
 
 ## Rendered Production Config
 
@@ -42,10 +45,12 @@ when moving from fakenet to mainnet.
    - `bridge_lock_root`
    - `inbox_contract_address`
    - `nock_contract_address`
+   - `base_chain_id`
    - `base_confirmation_depth`
    - `nockchain_confirmation_depth`
    - `withdrawal_processing_enabled`
    - `withdrawal_activation_nock_next_height`
+   - `withdrawal_policy = "withdrawal-policy-v1"`
    - all five `[[nodes]]` entries
 3. Confirm production values are not inherited from fakenet / bridge-dev.
    - No Base Sepolia, Tenderly VNET, localhost, or dev-only endpoints unless
@@ -54,6 +59,115 @@ when moving from fakenet to mainnet.
 4. Confirm secrets are injected from secret management.
    - Private keys and object-store credentials must not be committed in rendered
      configs or checked-in vars.
+
+## Withdrawal Contract Compatibility
+
+1. Confirm the production contract identity and configuration.
+   - Record Base chain id, `MessageInbox` proxy, `Nock` token, code hashes,
+     reciprocal pairing, owner, five signers, and threshold.
+2. Confirm the official SDK implements `WithdrawalWireV1`.
+   - Exact calldata length is 116 bytes.
+   - Bytes `68..76` are ASCII `NOCKWD1!`.
+   - Bytes `76..116` are the five unsigned 64-bit big-endian Tip5 limbs.
+   - Commitment vectors match
+     `test-fixtures/withdrawal_wire_v1_vectors.json` byte for byte.
+   - The published SDK version is immutable and installable without Git SSH
+     credentials or a moving branch.
+3. Confirm NockSwap exclusively uses the official codec.
+   - No generated `writeContract` call invokes
+     `burn(uint256,bytes32)`.
+   - The exact same raw calldata is locally decoded, simulated, gas-estimated,
+     and submitted.
+   - Account, chain, token, amount, or destination changes invalidate the
+     previous calldata.
+4. Confirm malformed-burn quarantine is operational.
+   - Every excluded `BurnForWithdrawal` persists one immutable
+     `sequencer_base_burn_rejections` row.
+   - Alerts include chain/deployment, tx hash, log index, `base_event_id`,
+     burner, amount, commitment, rejection code, and detail.
+   - A malformed burn followed by a valid burn must advance the scanner and
+     admit only the valid burn.
+   - Zero unresolved malformed-burn incidents remain at cutover.
+5. Confirm the compensation process is rehearsed.
+   - Ordinary 68-byte burns cannot be replayed because the destination is
+     absent.
+   - Governance and independent-verifier roles are assigned.
+   - Every compensation has an exact coordinate-validated config entry on all
+     bridge nodes and the sequencer.
+   - Sequencer startup persists those entries before Base scanning or RPC.
+   - Public lookup returns `COMPENSATED`; registration and Base recovery reject
+     the same identity before any compensation transfer.
+   - A compensated `base_event_id` cannot later enter withdrawal state.
+
+## NockSwap End-to-End Product Gate
+
+1. Pin NockSwap to one immutable, publicly fetchable Iris SDK release.
+   - The local `0.3.3` candidate is not a release until it is published and a
+     clean install resolves it without a sibling checkout, moving branch, or
+     Git SSH credentials.
+   - Run the published Rust parity vectors from the installed package.
+2. Keep the Base-to-Nockchain route flag disabled until every item in this
+   section passes together.
+   - A direction selector or Base wallet connection is not launch proof.
+   - Runtime/UI state manipulation must not bypass the same flag.
+3. Verify the exact client value boundary.
+   - User amount remains a decimal string plus bigint nicks/Base units.
+   - Unsupported nick precision is rejected before the wallet opens.
+   - Displayed, simulated, and encoded amounts are identical.
+4. Verify the Base transaction lifecycle.
+   - Resolve a v1 PKH or explicit lock root to one normalized five-limb value
+     and show it before confirmation.
+   - Self-validate one 116-byte payload and pass those exact bytes to simulation,
+     gas estimation, and raw submission.
+   - Wait for a successful Base receipt and verify the exact
+     `BurnForWithdrawal` log before entering `withdrawal_pending`.
+   - Persist chain id, tx hash, log index, `base_event_id`, amount, destination,
+     calldata identity, and timestamps before polling.
+5. Verify the public withdrawal lifecycle.
+   - Reload resumes the existing pending record and never offers an automatic
+     second burn.
+   - Poll only the public deployment-bound lookup/history API.
+   - Render success only after confirmed Nockchain settlement evidence.
+   - Delayed, invalidated, reorg-held, corrupt, and unavailable states provide
+     safe next action and support references.
+6. Verify fees against the submitted transaction.
+   - Estimate the exact 116-byte Base request.
+   - Include or explicitly disclose the OP Stack L1 data fee.
+   - Label Nockchain payout as an estimate until confirmed.
+7. Run browser E2E from Base wallet through reload to confirmed settlement.
+   - Assert exactly one burn and one payout.
+   - Assert ordinary/malformed ABI paths cannot be initiated.
+   - Record exact NockSwap, SDK, backend, contracts, policy, and deployment
+     revisions in the result.
+
+## Private Sequencer, Reorg, And Behavioral Gates
+
+1. Run private sequencer smoke from all five intended production bridge hosts.
+   - The intended private network or tunnel path must succeed.
+   - The public listener must not serve private `WithdrawalSequencer` methods.
+2. Certify confirmation assumptions and post-confirmation recovery.
+   - Lock the approved Base and Nockchain confirmation depths in every
+     production node; zero or reduced depths require a new safety review.
+   - Ordinary shallow forks are withheld from Hoon. The real-kernel mismatch
+     tests model history changing only after it crossed that buffer.
+   - A post-confirmation mismatch must stop every bridge, block sequencer
+     mutation/readiness, and trigger closure of the Base burn gate.
+   - Exercise the audited ancestor restore/rebuild, canonical replay, and Rust
+     reconciliation procedure. Automatic Hoon rewind is optional when this
+     procedure satisfies the same safety invariant.
+3. Keep the pinned Forge gate required on contract, decoder, fixture, or
+   withdrawal changes.
+   - The current required suite is 57 tests, including 13 withdrawal
+     compatibility/fail-closed tests and explicit 68-vs-116 behavior.
+   - Forge success does not imply Rust, Hoon, Anvil observer, R2, or browser
+     success.
+4. Run a deterministic nonignored local Anvil smoke using the exact published
+   SDK artifact and production Rust decoder.
+5. Run real-R2, real-chain restart, degraded-quorum, and reorg suites with
+   revision-bound redacted artifacts.
+6. Do not enable the on-chain gate or frontend flag while any P0, unresolved
+   malformed burn, unapproved compensation case, recovery hold, or proof gap
+   remains.
 
 ## R2 / Object-Store Journal Configuration
 
@@ -162,9 +276,12 @@ when moving from fakenet to mainnet.
 2. Confirm planner idle behavior when liquidity is unsafe or insufficient.
    - The bridge should wait and retry later, not construct spends from unsafe
      notes.
-3. Confirm withdrawal burn inputs are validated before users submit.
-   - Destination lock root must fit the Solidity `bytes32` withdrawal field.
-   - Amounts must satisfy minimum event and fee policy expectations.
+3. Confirm official withdrawal input validation before users submit.
+   - Destination parses to five bounded Tip5 limbs and serializes to 40 bytes.
+   - Amount satisfies `withdrawal-policy-v1`, including exact nick divisibility
+     and the inclusive 100,000-NOCK gross minimum.
+   - A current quote reports a positive estimated payout.
+   - Final 116-byte calldata passes local SDK decode/self-validation.
 
 ## Networking And Operations
 

--- a/crates/bridge/docs/withdrawal-dapp.md
+++ b/crates/bridge/docs/withdrawal-dapp.md
@@ -1,467 +1,341 @@
-# Withdrawal DApp Spec
+# Withdrawal DApp
 
-Status: Draft
+Status: Normative for the public withdrawal API
 Owner: Nockchain Maintainers
-Last Reviewed: 2026-03-16
-Canonical/Legacy: DApp-facing product/implementation spec derived from `bridge-withdrawals.md`
+Last Reviewed: 2026-08-28
+Canonical/Legacy: DApp-facing product and API contract derived from `bridge-withdrawals.md`
 
-Source of truth:
-- `open/crates/bridge/docs/bridge-withdrawals.md`
+Source of truth: [`bridge-withdrawals.md`](bridge-withdrawals.md)
 
-## Why This Doc Exists
+## Purpose
 
-`bridge-withdrawals.md` is the canonical protocol and systems spec. It is
-written for people implementing the bridge kernel, runtime, sequencer, and
-storage layers.
+The withdrawal DApp burns wrapped NOCK on Base, requests settlement to a
+Nockchain lock root, and displays authoritative progress until Nockchain
+settlement is confirmed. The DApp owns request preparation, Base transaction
+submission, local recovery, and presentation. The bridge runtime and sequencer
+own proposal construction, authorization, Nockchain submission, reservation,
+and settlement reconciliation.
 
-This document is the DApp/UI translation of that spec. It is meant to answer:
+## Launch Gate
 
-1. What is the withdrawal DApp actually doing for the user?
-2. What backend states matter to the UI?
-3. What should the UI show, and what should it never pretend to control?
-4. What assumptions should you make before wiring screens and
-   API calls?
+Base-to-Nockchain withdrawal remains disabled for users. Enabling the frontend
+flag alone is not a valid launch procedure. Launch requires all of the following
+at one certified revision:
 
-## One-Sentence Product Definition
+1. an immutable public Iris SDK release with the canonical codec and policy;
+2. matching contract, sequencer, signer, protocol, policy, and SDK identities;
+3. enabled operator admission and on-chain `MessageInbox.withdrawalsEnabled`;
+4. fresh Base and Nockchain observations;
+5. positive reservation-aware quotes;
+6. receipt and burn-log verification;
+7. durable browser persistence and authoritative history recovery;
+8. production monitoring, compensation procedures, and recovery drills;
+9. real-browser nominal, failure, reload, and reorg coverage.
 
-The withdrawal DApp lets a user burn wrapped NOCK on Base to request a
-withdrawal to Nockchain, then shows a small, honest set of public statuses
-until that withdrawal is confirmed on Nockchain.
+The ordinary 68-byte generated-ABI burn path is unsupported. Official clients
+submit only `WithdrawalWireV1`.
 
-## Core Mental Model
+## Withdrawal Identity
 
-The most important thing to understand is:
+A bridge withdrawal is keyed by:
 
-1. The DApp does not build, authorize, or submit withdrawal transactions by
-   itself.
-2. The user starts a withdrawal by burning wrapped NOCK on Base.
-3. That burn creates a withdrawal inside the bridge system if and only if the
-   amount is strictly above the configured minimum.
-4. From that point on, the bridge backend owns the process.
-5. The UI is mainly responsible for:
-   - collecting the withdrawal destination and amount
-   - helping the user send the Base burn transaction
-   - displaying accurate coarse-grained withdrawal state
-   - surfacing delays or support-worthy problems honestly
-
-For the frontend, a withdrawal is a single object keyed by:
-- `withdrawal_id = (as_of, base_event_id)`
-
-Where:
-
-1. `as_of` is the Base block hash the bridge uses as the counterpart reference
-   point for the withdrawal
-2. `base_event_id` is the unique identifier of the burn event within that
-   Base-side history
-
-This is mostly a backend/internal identifier. You may not want to show it
-directly in the public UI, but the current product direction is to show both
-the internal `withdrawal_id` and the more human-friendly references like the
-Base burn tx hash and timestamps.
-
-Do not think of the UI as operating on "attempts" or "tx proposals." Those
-exist in backend coordination, but the user-facing object is the withdrawal.
-
-## What Counts As A Withdrawal
-
-A Base burn becomes a withdrawal only if:
-
-1. the burn event is observed by the bridge
-2. the kernel admits it into withdrawal state
-3. the burned amount is strictly above the withdrawal minimum
-
-Important:
-
-1. Burns at or below the minimum should not be represented in the UI as active
-   withdrawals.
-2. The current target minimum in the canonical spec is `10,000 NOCKS`.
-3. For now, the DApp should hardcode that minimum rather than fetch it from a
-   backend API.
-4. Do not assume the amount burned on Base is the same as the amount received
-   on Nockchain. The withdrawal fee is deducted, so the received amount is
-   lower than the burned amount.
-
-## What The User Does
-
-At a high level:
-
-1. User connects Base wallet.
-2. User enters:
-   - withdrawal amount
-   - Nockchain destination lock root
-3. DApp validates the request client-side as much as it can.
-4. User signs and submits the Base burn transaction.
-5. DApp tracks the burn transaction on Base.
-6. After the burn is confirmed enough on Base, the DApp transitions to a coarse
-   "withdrawal pending" state.
-7. Keep the DApp in that pending state until the withdrawal is confirmed on
-   Nockchain or is delayed long enough that you should point the user to
-   support/status guidance.
-
-## What The UI Is Not Responsible For
-
-The DApp must not pretend to own these steps:
-
-1. proposal construction
-2. peer canonicalization
-3. sequencer authorization
-4. withdrawal tx submission to Nockchain
-5. withdrawal confirmation reconciliation
-6. note reservation logic
-7. replay/equivocation detection
-
-Those belong to the bridge runtime, sequencer gRPC service, and kernel.
-
-Do not expose those internal stages in the public DApp unless there is a real,
-reliable product requirement for them.
-
-## Public User-Facing Lifecycle
-
-The public withdrawal DApp should use a very small number of states. The user
-probably will not have reliable visibility into bridge-internal progress
-between the Base burn and the final Nockchain confirmation.
-
-Recommended user-facing stages:
-
-1. `draft`
-   - user is filling out the form
-2. `awaiting_wallet_confirmation`
-   - wallet popup is open for the Base burn tx
-3. `awaiting_base_confirmation`
-   - Base burn transaction has been sent but is not yet confirmed enough from
-     the user’s point of view
-4. `withdrawal_pending`
-   - the burn is done and the user is now waiting for the bridge withdrawal to
-     complete on Nockchain
-5. `confirmed`
-   - confirmed settlement observed and reconciled
-6. `delayed`
-   - the withdrawal is taking longer than expected and you should point the
-     user to support or system status guidance
-
-The public UI should not expose backend-internal states like:
-
-1. proposal built
-2. peer-canonical
-3. sequencer authorized
-4. sequencer submitted
-5. hold
-6. stop
-
-Those may exist in admin/operator tooling, but keep the public DApp coarse
-unless the backend exposes a deliberate user-safe product surface for them.
-
-## Internal Backend States
-
-The canonical spec implies these important backend facts:
-
-1. A withdrawal is either live/unconfirmed or confirmed at the kernel level.
-2. The sequencer gRPC service owns:
-   - the authoritative authorized withdrawal record
-   - the submitted / in-flight withdrawal record
-   - the durable confirmation record for authorized withdrawals
-3. Only one withdrawal may be sequencer-authorized / submitted / unconfirmed
-   at a time.
-4. If the sequencer is unavailable, withdrawals pause.
-5. Unknown counterpart chain state can produce a hold.
-6. Irreconcilable mismatch can produce a stop.
-
-These are useful for backend and operator tooling, but not necessarily for the
-public DApp.
-
-If an internal/admin view exists, it may show:
-
-1. sequencing
-2. authorized
-3. submitted
-4. held
-5. stopped
-6. sequencer unavailable
-
-## Recommended DApp Screens
-
-### 1. Withdrawal Form
-
-Purpose:
-- create a new withdrawal request by helping the user submit the Base burn tx
-
-Fields:
-
-1. amount
-2. destination
-3. wallet/network status
-
-Behavior:
-
-1. Validate amount is present and positive.
-2. Treat the destination as a lock root, not as a generic address field.
-3. Provide a helper that can derive the simple-PKH lock root from a v1 address
-   for the common case.
-4. Still allow direct lock-root entry, since lock root is the canonical input.
-5. Validate destination shape before wallet submission.
-6. Warn if amount is below or near the hardcoded minimum.
-7. Show the exact Base network the transaction will be submitted to.
-8. Make it clear that the user is burning wrapped NOCK on Base to receive
-   NOCK on Nockchain.
-9. Make it clear that the user receives the post-fee amount on Nockchain, not
-   the full burned amount.
-
-### 2. Burn Submission Status
-
-Purpose:
-- track the user’s Base burn transaction before bridge-side processing starts
-
-Show:
-
-1. wallet-submitted tx hash
-2. pending / confirmed status on Base
-3. failure/revert if the burn tx fails
-
-Important:
-
-1. A successful wallet submission is not the same thing as a successful
-   withdrawal.
-2. After Base confirmation, the DApp can move into a coarse
-   `withdrawal_pending` state even if it does not have bridge-internal
-   visibility.
-
-### 3. Withdrawal Status View
-
-Purpose:
-- show the backend-owned lifecycle once the burn has become a bridge withdrawal
-
-Show:
-
-1. withdrawal id
-2. burned amount
-3. expected received amount if the backend exposes it
-4. destination
-5. Base burn tx reference
-6. current stage
-7. timestamps for major stage changes when available
-8. delay/support guidance if the withdrawal is taking longer than expected
-9. human-friendly references like burn tx hash and timestamps alongside the
-   internal `withdrawal_id`
-
-### 4. Withdrawal History
-
-Purpose:
-- let the user see prior withdrawals and their final status
-
-Show:
-
-1. recent withdrawals
-2. withdrawal id
-3. burned amount
-4. received amount if available
-5. destination
-6. created time
-7. confirmed time if complete
-8. current/final state
-
-## UX Rules
-
-### Rule 1: Never imply that backend-internal progress is public truth
-
-Do not show:
-- "confirmed" because peers agreed
-- "complete" because a proposal was built
-- "done" because the sequencer submitted a tx
-- "authorized" or "submitted" unless the product deliberately exposes internal
-  operator-level states
-
-Show confirmed only after confirmed settlement has been observed and reconciled.
-
-### Rule 2: Separate Base burn progress from Nockchain withdrawal progress
-
-The user performs one Base transaction, but the actual withdrawal completes
-later on the bridge/Nockchain side.
-
-The UI should visually separate:
-
-1. Base burn submitted/confirmed
-2. waiting for bridge completion
-3. Nockchain confirmed settlement
-
-### Rule 3: Public UI should prefer delay messaging over internal hold/stop jargon
-
-The words `hold` and `stop` are useful for operators, but may not be good
-public-user concepts.
-
-For most users, the better public states are:
-
-1. pending
-2. delayed
-3. confirmed
-
-### Rule 4: Stop is a real operator-visible problem
-
-If the product exposes an actual user-visible terminal problem:
-
-1. show the stop reason clearly
-2. say bridge processing halted for this withdrawal
-3. point the user to support/operator guidance if available
-
-### Rule 5: Sequencer pause is usually internal/backend state
-
-Because there is one sequencer-owned in-flight withdrawal at a time, the UI
-may need internal/operator visibility for things like:
-
-1. waiting for sequencer
-2. sequencer unavailable
-3. withdrawal paused pending sequencer recovery
-
-But you should usually translate this into a coarse pending/delayed state
-rather than expose sequencer internals directly.
-
-### Rule 6: Delayed withdrawals need explicit support guidance
-
-For public users:
-
-1. say that a small delay is expected
-2. if no withdrawal has shown up after 24 hours, direct the user to reach out
-   on Telegram
-3. do not imply the user should retry the burn or create a duplicate
-   withdrawal request on their own
-
-## Suggested Data Model For The Frontend
-
-This is not the canonical backend schema. It is a frontend view model.
-
-```ts
-type WithdrawalUiStatus =
-  | "draft"
-  | "awaiting_wallet_confirmation"
-  | "awaiting_base_confirmation"
-  | "withdrawal_pending"
-  | "confirmed"
-  | "delayed";
-
-type WithdrawalUiRecord = {
-  withdrawalId: string;
-  baseTxHash?: string;
-  amount: string;
-  destination: string;
-  createdAt?: string;
-  updatedAt?: string;
-  status: WithdrawalUiStatus;
-  nockTxName?: string;
-  nockConfirmationRef?: string;
-};
+```text
+withdrawal_id = (as_of, base_event_id)
 ```
 
-The backend may expose more detail, but you should normalize it into a model
-like this.
+- `as_of` is the canonical Base block reference used by the bridge.
+- `base_event_id` is the unique burn-log identity derived from transaction hash
+  and log index.
 
-## API Expectations
+The public UI uses `base_event_id` as soon as the Base receipt is verified. The
+full `withdrawal_id` may remain absent until the backend has authoritative
+kernel context. Display the Base transaction hash and timestamps alongside the
+internal identifier.
 
-This doc does not define the final backend API, but the DApp probably needs
-something close to:
+## Canonical Burn Transaction
 
-1. `create burn transaction` or contract-write integration
-2. `get withdrawal by id`
-3. `list withdrawals for account`
-4. `stream or poll withdrawal status updates`
-5. `get bridge/sequencer status` for internal/admin tools if needed
+The DApp must not submit a withdrawal through a generated
+`burn(uint256,bytes32)` contract helper. The five-limb Nockchain destination
+requires the 116-byte `WithdrawalWireV1` input.
 
-Minimum useful payload for a withdrawal status API:
+| Byte range | Size | Meaning |
+|---|---:|---|
+| `0..4` | 4 | `burn(uint256,bytes32)` selector |
+| `4..36` | 32 | wrapped-NOCK amount, unsigned big-endian |
+| `36..68` | 32 | withdrawal commitment passed as ABI `lockRoot` |
+| `68..76` | 8 | ASCII `NOCKWD1!` |
+| `76..116` | 40 | five unsigned 64-bit big-endian Tip5 limbs |
 
-1. `withdrawal_id`
-2. burned amount
-3. expected or actual received amount if available
-4. destination
-5. base burn tx hash
-6. current user-facing status
-7. optional machine state
-8. optional delay/support hint
-9. timestamps
-10. optional Nockchain tx name/reference
+The commitment is:
 
-One unresolved product/API question is where public Nockchain-side visibility
-should come from. The current expectation is that another operator may already
-have an API for viewing incoming Nockchain transactions that the DApp can lean
-on, because the team is reluctant to expose bridge-operated services publicly.
+```text
+keccak256(
+  "nock-withdrawal-calldata-v1"
+  || nock_token_address[20]
+  || burner_address[20]
+  || amount_be[32]
+  || lock_root_limbs_be[40]
+)
+```
 
-## Internal/Admin Sequencer UI Needs
+The five limbs are the destination. A 32-byte digest is not a substitute. Each
+limb must satisfy the Tip5 field bound.
 
-Because the sequencer is now a separate gRPC service in the canonical design,
-an internal/admin surface should assume backend status may come from more than
-one subsystem:
+Before opening the wallet, the DApp must:
 
-1. bridge runtime
-2. kernel-derived withdrawal state
-3. sequencer service status
+1. resolve the configured Base deployment for the expected chain;
+2. verify the connected account and chain after any wallet switch;
+3. reject contract and delegated-account burners;
+4. parse the amount without JavaScript floating-point conversion;
+5. parse a direct lock root or derive one from a v1 PKH address;
+6. obtain a current positive quote for the exact gross amount and destination;
+7. construct the 116-byte input with the pinned Iris SDK;
+8. decode the constructed bytes and compare every field with current state;
+9. simulate and estimate gas using those exact bytes;
+10. submit those same bytes through a chain-bound Base client.
 
-At minimum, an internal/admin surface should be able to show:
+Any account, chain, token, amount, destination, policy, or quote change
+invalidates the prepared transaction.
 
-1. whether the sequencer is healthy
-2. whether the withdrawal is waiting on sequencer authorization
-3. whether the withdrawal was submitted by the sequencer
-4. whether the sequencer has recorded confirmation for the withdrawal
+## Amount Policy and Quote
 
-The DApp does not need direct gRPC access. It just needs a backend/API layer
-that exposes sequencer status in a frontend-safe way.
+`withdrawal-policy-v1` defines the amount contract:
 
-## Recommended Engineering Order For The DApp
+- inclusive gross minimum: `100,000 NOCK`;
+- exact conversion: `65,536` nicks per NOCK;
+- Base token scale: `10^16` base units per NOCK;
+- Base units per nick: `152,587,890,625`;
+- bridge fee: `195` nicks per started NOCK;
+- maximum nick amount: `u64::MAX`;
+- net payout must remain positive after bridge and Nockchain transaction fees.
 
-If you are getting started, this is the right order:
+The frontend consumes these values from the pinned Iris SDK and requires the
+backend readiness document to match them exactly. It does not maintain a second
+policy table.
 
-1. Build a static withdrawal form and status screen.
-2. Add wallet/network connection state.
-3. Add Base burn submission flow.
-4. Add polling/streaming for backend withdrawal status.
-5. Implement the UI state machine for:
-   - awaiting base confirmation
-   - withdrawal pending
-   - confirmed
-   - delayed
-6. Add withdrawal history.
-7. If needed, add a separate internal/operator status view.
-8. Add better delay/support messaging and empty/error states.
+The quote endpoint uses the sequencer's current private Nockchain snapshot and
+reservation state. A quote contains gross amount, bridge fee, transaction fee,
+net payout, snapshot height and block, observation time, and revision. The DApp
+blocks confirmation when the quote is unavailable, stale, for another amount,
+or has a non-positive payout. The displayed payout remains an estimate until
+settlement is confirmed.
 
-## Non-Goals For The First UI Iteration
+## User Flow
 
-Do not block initial UI work on:
+1. Connect a Base wallet.
+2. Enter the gross amount and Nockchain destination.
+3. Validate deployment readiness, policy, destination, storage, and quote.
+4. Review the exact gross burn, fees, estimated payout, destination, and Base
+   network.
+5. Sign one Base transaction containing the canonical 116-byte input.
+6. Persist the submitted transaction identity before waiting for its receipt.
+7. Verify the mined transaction and exactly one matching
+   `BurnForWithdrawal` log.
+8. Persist the Base block, log index, and `base_event_id`.
+9. Poll authoritative history until the withdrawal is confirmed or requires
+   support.
 
-1. exposing every backend attempt/epoch detail
-2. displaying full proposal-envelope internals
-3. exposing raw note-selection or reservation data to the user
-4. implementing recovery controls in the UI
-5. multi-withdrawal batch UX
+A wallet rejection creates no record. An unknown submitted transaction remains
+tracked and must not be retried automatically.
 
-The first useful UI should focus on:
+## Public States
 
-1. initiating withdrawals
-2. showing accurate status
-3. explaining delays honestly
+| State | Meaning |
+|---|---|
+| `draft` | Client-only form state; no Base transaction identity exists. |
+| `awaiting_base` | A Base transaction identity exists, but no eligible canonical burn is authoritative yet. |
+| `withdrawal_pending` | An eligible canonical burn is indexed; confirmed Nockchain settlement is not yet reconciled. |
+| `confirmed` | Durable Nockchain settlement has been reconciled with the withdrawal. |
+| `delayed` | A time/readiness overlay on pending state with support guidance. |
+| `failure` | Authoritative facts report malformed input, below-policy admission, reorg invalidation, or inconsistency. |
 
-## Remaining Open Question
+Base confirmation, peer agreement, sequencer authorization, and mempool
+acceptance do not produce `confirmed`.
 
-This still needs a backend/product decision:
+A higher authoritative revision may move a record out of `confirmed` or
+`failure` after a reorg or reconciliation. Clients must apply higher revisions
+and reject lower revisions. A reorg regression clears the prior Nockchain
+transaction, block, payout, and confirmation timestamp before presenting the
+new state.
 
-1. What exact status API shape will expose coarse public states vs internal
-   operator states?
-   - There may already be an operator-owned API for viewing incoming
-     Nockchain transactions to be able to flag withdrawals as complete that the DApp can reuse.
-   - The bridge team is reluctant to expose bridge-operated services publicly,
-     so this likely should not depend on making the bridge or sequencer
-     directly public.
+The public API does not expose proposal hashes, epochs, signers, selected
+inputs, reservations, raw transactions, handoff indices, or internal hold/stop
+state.
 
-## Bottom Line
+## UI Requirements
 
-If you remember only a few things, remember these:
+### Withdrawal form
 
-1. The user starts a withdrawal by burning on Base.
-2. The burn only becomes a withdrawal if it clears the withdrawal minimum and
-   is admitted by the bridge.
-3. The UI is not the sequencer and not the bridge runtime.
-4. The public UI should only show coarse states it can actually know.
-5. Burned amount and received amount are not the same thing; the fee is
-   deducted before the user receives NOCK on Nockchain.
-6. Confirmed means confirmed settlement on Nockchain, not just "submitted" or
-   "peer agreed."
-7. The destination should be a lock root, with a helper for deriving the
-   simple-PKH lock root from a v1 address.
-8. Show both the internal `withdrawal_id` and the human-friendly references.
-9. A small delay is expected; after 24 hours without a withdrawal showing up,
-   tell the user to reach out on Telegram.
+Display and validate:
+
+- connected Base account and network;
+- gross wrapped-NOCK amount;
+- direct lock root or v1 PKH destination;
+- bridge fee, Nockchain transaction fee, and estimated payout;
+- deployment readiness and the first blocking reason.
+
+The confirmation action remains disabled until readiness, policy, storage,
+quote, chain, account, and destination checks all pass.
+
+### Base submission
+
+Display the submitted and replacement transaction hashes, receipt status, Base
+block, and verified burn-log identity. A submitted transaction with an unknown
+receipt remains a support state. Do not recommend another burn.
+
+### Withdrawal status
+
+Display:
+
+- Base transaction and `base_event_id`;
+- gross amount and estimated or confirmed payout;
+- destination;
+- public state and authoritative revision;
+- recovery reason and invalidated block when present;
+- Nockchain transaction and block only for current terminal proof;
+- support guidance for delayed, unavailable, or inconsistent states.
+
+### History
+
+Merge local records with the authoritative burner history. Local submitted
+records remain visible during public API outages. The UI supports multiple
+active withdrawals and never evicts a tracked record to make room for another
+burn.
+
+## Browser Persistence and Recovery
+
+The browser stores at most 50 versioned withdrawal records per local store.
+Before submission it verifies that storage can be read and written and that
+capacity remains. Reaching capacity blocks a new burn instead of deleting an
+existing record.
+
+A record contains:
+
+- account, chain, Nock token, and MessageInbox identity;
+- submitted and current Base transaction hashes;
+- amount, destination, commitment, and canonical calldata;
+- receipt block, block hash, log index, and `base_event_id`;
+- estimated and confirmed payouts;
+- authoritative revision and recovery generation;
+- invalidated block, prior status, and recovery reason;
+- lifecycle history and timestamps.
+
+Receipt replacement callbacks are serialized and persisted before receipt
+processing continues. If persistence fails after submission, the DApp enters a
+support state and preserves the known transaction identity.
+
+On reload, account change, or network change, the DApp reloads records for the
+exact account and deployment. Corrupt or unsupported data is never overwritten
+silently. Confirmed and failed records continue polling because a higher
+revision may supersede them.
+
+## Public Query Service
+
+The normative read-only service is
+`bridge.ingress.v1.WithdrawalPublicQuery` in
+`crates/bridge/proto/bridge_ingress.proto`.
+
+| Method | Purpose |
+|---|---|
+| `ResolveBaseWithdrawal` | Resolve deployment, Base transaction, and optional log index. |
+| `GetWithdrawal` | Lookup by Base locator, `base_event_id`, or full `withdrawal_id`. |
+| `ListWithdrawalsByBurner` | Return bounded, stable history for a Base burner. |
+| `GetWithdrawalReadiness` | Return deployment readiness and safe blocking reasons. |
+| `GetWithdrawalQuote` | Return a reservation-aware payout quote. |
+
+The public listener routes only `WithdrawalPublicQuery`. It does not expose
+`WithdrawalSequencer`, `BridgeIngress`, reflection for private services, or a
+generic proxy. Mutation RPCs remain on the authenticated private listener.
+
+Every request is bound to Base chain ID, Nock token address, policy ID, and
+protocol ID. Unknown or partial deployment identities fail closed. Log index
+zero is valid. Omitting a log index for a transaction with multiple matching
+logs returns `AMBIGUOUS_LOG`; the server does not guess.
+
+History is ordered newest first by:
+
+```text
+(base_block_number, log_index, base_event_id)
+```
+
+The default page size is 20 and the maximum is 100. Opaque cursors bind the
+deployment, burner, snapshot revision, and last sort key. Invalid,
+cross-deployment, cross-burner, expired, or reorg-superseded cursors are
+rejected.
+
+## Browser HTTP Adapter
+
+The optional production adapter binds `--withdrawal-public-http-addr` and
+exposes `GET` and `OPTIONS` on `/withdrawal-status`:
+
+| Query | Response |
+|---|---|
+| none | readiness schema 1 |
+| `base_event_id=...` | status schema 2 |
+| `history=1&account=...&limit=...` | burner history schema 1 |
+| `quote=1&gross_amount_nicks=...&destination_lock_root=...` | quote schema 1 |
+
+Configure the MessageInbox, Iris version, and request limit with the matching
+`--withdrawal-public-http-*` arguments. Signer roster and threshold come from
+the validated sequencer configuration and are not separately overrideable.
+
+`WITHDRAWAL_PUBLIC_HTTP_ALLOWED_ORIGINS` is an exact origin allowlist.
+Production origins require HTTPS; explicit loopback HTTP is accepted for local
+verification. Wildcards, credentials, paths, fragments, and non-loopback plain
+HTTP are rejected. Responses use `Cache-Control: no-store`; unknown origins
+receive `403`; rate-limited clients receive `429` before bridge-state work.
+Internal errors are logged server-side and redacted in public responses.
+
+## Readiness Contract
+
+Burn submission is enabled only when all of these facts match the pinned
+frontend deployment:
+
+1. Base chain ID and Nock token address;
+2. MessageInbox address, `Nock.inbox()`, and `MessageInbox.nock()`;
+3. signer PKH set and threshold;
+4. `WithdrawalWireV1`, `withdrawal-policy-v1`, and Iris SDK version;
+5. complete numeric policy values;
+6. operator admission enabled;
+7. on-chain withdrawal gate observed enabled;
+8. fresh Base observation and current reconciliation frontier;
+9. available Nockchain state for a positive quote.
+
+The Base watcher clears the observed contract gate when the configured
+MessageInbox differs from `Nock.inbox()`. Stale or unavailable observations
+make readiness and quotes unavailable.
+
+## Privacy and Abuse Controls
+
+Burner history derives from public-chain facts but remains bounded by per-IP
+request limits, page limits, response-size limits, and request deadlines.
+Destination and account data must not be added to analytics or logs beyond the
+identifiers required for operations. Public errors must not include private
+endpoints, credentials, raw backend errors, node identities, IAM details,
+reserved inputs, or transaction bytes.
+
+## Operator-Only State
+
+Operator tooling may display assembly, peer-canonical, authorized, submitted,
+mempool-accepted, held, stopped, sequencer-unavailable, reservation, and
+recovery state. The public DApp normalizes those facts into the public states
+above.
+
+## Acceptance Criteria
+
+1. The frontend cannot initiate an ordinary 68-byte ABI burn.
+2. One user confirmation produces at most one canonical Base burn.
+3. Submitted and replacement transaction identities survive reload and errors.
+4. Storage failure blocks submission or produces a support state without
+   suggesting a duplicate burn.
+5. Only a current positive quote enables confirmation.
+6. Contract and delegated-account burners fail before submission.
+7. Public deployment, signer, policy, protocol, SDK, and gate mismatches fail
+   closed.
+8. Authoritative higher revisions can regress local terminal state safely.
+9. Confirmed UI state requires a current Nockchain transaction, block, payout,
+   and terminal proof.
+10. Local and authoritative history remain accessible across reload and public
+    API outages.
+11. Nominal, real-service failure, mock failure, and reorg lifecycle browser
+    suites pass against the production adapter.

--- a/crates/bridge/scripts/multi-bridge.sh
+++ b/crates/bridge/scripts/multi-bridge.sh
@@ -277,6 +277,7 @@ my_nock_key = "${nock_key}"
 grpc_address = "http://127.0.0.1:${NODE_PRIVATE_GRPC_PORT}"
 base_confirmation_depth = ${BASE_CONFIRMATION_DEPTH}
 nockchain_confirmation_depth = ${NOCKCHAIN_CONFIRMATION_DEPTH}
+withdrawal_policy = "withdrawal-policy-v1"
 ingress_listen_address = "127.0.0.1:${ingress_port}"
 withdrawal_activation_nock_next_height = ${NOCKCHAIN_START_HEIGHT}
 EOF
@@ -328,7 +329,7 @@ nock_pkh = "${BRIDGE_NOCK_PKHS[4]}"
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000       # Lower for testing (prod: 1_000_000)
+minimum_event_nocks = 100000     # withdrawal-policy-v1
 nicks_fee_per_nock = 195
 base_blocks_chunk = 1
 base_start_height = ${BASE_START_HEIGHT}

--- a/crates/bridge/scripts/run-bridge-only.sh
+++ b/crates/bridge/scripts/run-bridge-only.sh
@@ -133,6 +133,7 @@ my_nock_key = "${BRIDGE_NOCK_KEY}"
 grpc_address = "http://127.0.0.1:${NODE_PRIVATE_GRPC_PORT}"
 base_confirmation_depth = ${BASE_CONFIRMATION_DEPTH}
 nockchain_confirmation_depth = ${NOCKCHAIN_CONFIRMATION_DEPTH}
+withdrawal_policy = "withdrawal-policy-v1"
 ingress_listen_address = "127.0.0.1:8001"
 
 # Fake test data (node 0 address derived from BRIDGE_ETH_KEY)
@@ -165,7 +166,7 @@ nock_pkh = "6666666666666666666666666666666666666666666666666666"
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000       # Lower for testing (prod: 1_000_000)
+minimum_event_nocks = 100000     # withdrawal-policy-v1
 nicks_fee_per_nock = 195
 base_blocks_chunk = 100
 base_start_height = ${BASE_START_HEIGHT}

--- a/crates/bridge/scripts/run-node-and-bridge.sh
+++ b/crates/bridge/scripts/run-node-and-bridge.sh
@@ -205,6 +205,7 @@ my_nock_key = "${BRIDGE_NOCK_KEY}"
 grpc_address = "http://127.0.0.1:${NODE_PRIVATE_GRPC_PORT}"
 base_confirmation_depth = ${BASE_CONFIRMATION_DEPTH}
 nockchain_confirmation_depth = ${NOCKCHAIN_CONFIRMATION_DEPTH}
+withdrawal_policy = "withdrawal-policy-v1"
 ingress_listen_address = "127.0.0.1:8002"
 
 # Fake test data (valid format placeholders for local testing)
@@ -237,7 +238,7 @@ nock_pkh = "6666666666666666666666666666666666666666666666666666"
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000       # Lower for testing (prod: 1_000_000)
+minimum_event_nocks = 100000     # withdrawal-policy-v1
 nicks_fee_per_nock = 195
 base_blocks_chunk = 100
 base_start_height = ${BASE_START_HEIGHT}

--- a/crates/bridge/src/main.rs
+++ b/crates/bridge/src/main.rs
@@ -1301,7 +1301,7 @@ mod tests {
     use bridge::deposit::log::persist_commit_nock_deposits_requests;
     use bridge::observability::tui;
     use bridge::shared::config::{BridgeConfigToml, NodeInfoToml};
-    use bridge::shared::types::{EthAddress, Tip5Hash};
+    use bridge::shared::types::{EthAddress, Tip5Hash, WITHDRAWAL_POLICY_V1_ID};
     use nockapp::kernel::boot;
     use nockchain_math::belt::Belt;
     use nockchain_types::default_fakenet_blockchain_constants;
@@ -1340,6 +1340,7 @@ mod tests {
             nockchain_sequencer_api_address: None,
             base_confirmation_depth: 1,
             nockchain_confirmation_depth: 1,
+            withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
             deposit_nonce_epoch_base: None,
             deposit_nonce_epoch_start_height: None,
             deposit_nonce_epoch_start_tx_id_base58: None,

--- a/crates/bridge/src/shared/base.rs
+++ b/crates/bridge/src/shared/base.rs
@@ -45,7 +45,11 @@ fn is_rate_limit_error<E: std::fmt::Display>(e: &E) -> bool {
 use crate::deposit::types::{BaseDepositSettlementEntry, DepositSettlement, DepositSettlementData};
 use crate::shared::types::{
     zero_tip5_hash, AtomBytes, BaseBlockRef, BaseEvent, BaseEventContent, BaseEventId, EthAddress,
-    NullTag, Tip5Hash,
+    NullTag, Tip5Hash, WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NICK,
+};
+#[cfg(test)]
+use crate::shared::types::{
+    WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NOCK, WITHDRAWAL_POLICY_V1_NICKS_PER_NOCK,
 };
 use crate::withdrawal::types::{BaseWithdrawalEntry, Withdrawal};
 
@@ -91,14 +95,16 @@ alloy::sol!(
 );
 
 /// Base unit for Nock token (10^16) - Nock.sol uses 16 decimals, not 18
-pub(crate) const NOCK_BASE_UNIT: u128 = 10_000_000_000_000_000;
+#[cfg(test)]
+pub(crate) const NOCK_BASE_UNIT: u128 = WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NOCK;
 
 /// Nicks per NOCK on Nockchain (2^16)
-const NICKS_PER_NOCK: u128 = 65_536;
+#[cfg(test)]
+const NICKS_PER_NOCK: u128 = WITHDRAWAL_POLICY_V1_NICKS_PER_NOCK as u128;
 
 /// Conversion factor: NOCK base units per nick
 /// 1 nick = 10^16 / 65,536 = 152,587,890,625 NOCK base units
-pub(crate) const NOCK_BASE_PER_NICK: u128 = NOCK_BASE_UNIT / NICKS_PER_NOCK;
+pub(crate) const NOCK_BASE_PER_NICK: u128 = WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NICK;
 
 pub(crate) use self::MessageInbox as MessageInboxContract;
 
@@ -1375,6 +1381,60 @@ mod tests {
         "BRIDGE_REFUNDED_WITHDRAWAL_BASE_RPC_URL";
     const BASE_RPC_URL_ENV: &str = "BASE_RPC_URL";
 
+    const WITHDRAWAL_WIRE_V1_VECTORS_JSON: &str =
+        include_str!("../../test-fixtures/withdrawal_wire_v1_vectors.json");
+
+    #[derive(Debug, serde::Deserialize)]
+    struct WithdrawalWireFixture {
+        schema_version: u64,
+        protocol: String,
+        constants: WithdrawalWireConstantsFixture,
+        valid_vectors: Vec<WithdrawalWireValidFixture>,
+        amount_policy_vectors: Vec<WithdrawalAmountPolicyFixture>,
+        invalid_vectors: Vec<WithdrawalWireInvalidFixture>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct WithdrawalWireConstantsFixture {
+        commitment_domain: String,
+        calldata_length: usize,
+        base_calldata_length: usize,
+        trailer_magic_ascii: String,
+        full_lock_root_length: usize,
+        tip5_prime: String,
+        nock_base_units_per_nick: String,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct WithdrawalWireValidFixture {
+        name: String,
+        nock_token_address: String,
+        burner_address: String,
+        amount_base_units: String,
+        lock_root_limbs: Vec<String>,
+        selector: String,
+        commitment: String,
+        calldata: String,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct WithdrawalAmountPolicyFixture {
+        name: String,
+        amount_base_units: String,
+        expected: String,
+        amount_nicks: Option<String>,
+        bridge_fee_nicks: Option<String>,
+        amount_after_bridge_fee_nicks: Option<String>,
+    }
+
+    #[derive(Debug, serde::Deserialize)]
+    struct WithdrawalWireInvalidFixture {
+        name: String,
+        base_vector: String,
+        calldata: String,
+        expected_error: String,
+    }
+
     fn b256_from_u64(value: u64) -> B256 {
         let mut bytes = [0u8; 32];
         bytes[24..].copy_from_slice(&value.to_be_bytes());
@@ -1532,6 +1592,259 @@ mod tests {
 
     fn format_tx_hash_hex(tx_hash: &B256) -> String {
         format!("0x{}", hex_encode(tx_hash.as_slice()))
+    }
+
+    fn parse_fixture_lock_root(limbs: &[String], vector_name: &str) -> Result<Tip5Hash> {
+        if limbs.len() != 5 {
+            bail!(
+                "vector {vector_name} has {} lock-root limbs, expected 5",
+                limbs.len()
+            );
+        }
+        let limbs = limbs
+            .iter()
+            .enumerate()
+            .map(|(index, raw)| {
+                raw.parse::<u64>().with_context(|| {
+                    format!("vector {vector_name} has invalid lock-root limb {index}")
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let limbs: [u64; 5] = limbs.try_into().map_err(|limbs: Vec<u64>| {
+            anyhow::anyhow!(
+                "vector {vector_name} has {} parsed lock-root limbs, expected 5",
+                limbs.len()
+            )
+        })?;
+        Ok(Tip5Hash::from_limbs(&limbs))
+    }
+
+    fn burn_decode_error_kind(error: &BurnForWithdrawalDecodeError) -> &'static str {
+        match error {
+            BurnForWithdrawalDecodeError::NotBurnForWithdrawal(_) => "not_burn_for_withdrawal",
+            BurnForWithdrawalDecodeError::AmountNotDivisible { .. } => "amount_not_divisible",
+            BurnForWithdrawalDecodeError::AmountOverflow { .. } => "amount_overflow",
+            BurnForWithdrawalDecodeError::MissingCalldataTrailer { .. } => {
+                "missing_calldata_trailer"
+            }
+            BurnForWithdrawalDecodeError::MalformedCalldata { .. } => "malformed_calldata",
+            BurnForWithdrawalDecodeError::CalldataAmountMismatch { .. } => {
+                "calldata_amount_mismatch"
+            }
+            BurnForWithdrawalDecodeError::CalldataCommitmentMismatch { .. } => {
+                "calldata_commitment_mismatch"
+            }
+            BurnForWithdrawalDecodeError::CommitmentMismatch { .. } => "commitment_mismatch",
+            BurnForWithdrawalDecodeError::InvalidLockRoot { .. } => "invalid_lock_root",
+        }
+    }
+
+    #[test]
+    fn withdrawal_wire_v1_valid_vectors_match_canonical_codec() -> Result<()> {
+        let fixture: WithdrawalWireFixture = serde_json::from_str(WITHDRAWAL_WIRE_V1_VECTORS_JSON)
+            .context("decoding WithdrawalWireV1 fixture")?;
+
+        assert_eq!(fixture.schema_version, 1);
+        assert_eq!(fixture.protocol, "WithdrawalWireV1");
+        assert_eq!(
+            fixture.constants.commitment_domain.as_bytes(),
+            WITHDRAWAL_BURN_COMMITMENT_DOMAIN
+        );
+        assert_eq!(
+            fixture.constants.calldata_length,
+            WITHDRAWAL_BURN_CALLDATA_LEN
+        );
+        assert_eq!(
+            fixture.constants.base_calldata_length,
+            WITHDRAWAL_BURN_BASE_CALLDATA_LEN
+        );
+        assert_eq!(
+            fixture.constants.trailer_magic_ascii.as_bytes(),
+            WITHDRAWAL_BURN_TRAILER_MAGIC
+        );
+        assert_eq!(
+            fixture.constants.full_lock_root_length,
+            WITHDRAWAL_BURN_FULL_LOCK_ROOT_LEN
+        );
+        assert_eq!(fixture.constants.tip5_prime.parse::<u64>()?, PRIME);
+        assert_eq!(
+            fixture.constants.nock_base_units_per_nick.parse::<u128>()?,
+            NOCK_BASE_PER_NICK
+        );
+
+        for vector in &fixture.valid_vectors {
+            let nock_contract_address = Address::from_str(&vector.nock_token_address)
+                .with_context(|| format!("vector {} token address", vector.name))?;
+            let burner = Address::from_str(&vector.burner_address)
+                .with_context(|| format!("vector {} burner address", vector.name))?;
+            let amount_raw = U256::from_str(&vector.amount_base_units)
+                .with_context(|| format!("vector {} amount", vector.name))?;
+            let lock_root = parse_fixture_lock_root(&vector.lock_root_limbs, &vector.name)?;
+            let expected_selector = parse_fixed_hex::<4>(&vector.selector, "selector")?;
+            let expected_commitment =
+                B256::from(parse_fixed_hex::<32>(&vector.commitment, "commitment")?);
+            let expected_calldata = parse_hex_bytes(&vector.calldata, "calldata")?;
+
+            assert_eq!(
+                withdrawal_burn_selector(),
+                expected_selector,
+                "selector mismatch for {}",
+                vector.name
+            );
+            assert_eq!(
+                withdrawal_burn_commitment(nock_contract_address, burner, amount_raw, &lock_root,),
+                expected_commitment,
+                "commitment mismatch for {}",
+                vector.name
+            );
+            let calldata = encode_withdrawal_burn_calldata(
+                nock_contract_address, burner, amount_raw, &lock_root,
+            );
+            assert_eq!(
+                calldata.as_ref(),
+                expected_calldata,
+                "calldata mismatch for {}",
+                vector.name
+            );
+
+            let log = withdrawal_burn_log(
+                nock_contract_address, burner, amount_raw, expected_commitment,
+            );
+            let decoded = decode_burn_for_withdrawal_log_with_calldata(
+                &log,
+                &b256_from_u64(0xabcd),
+                Some(7),
+                nock_contract_address,
+                calldata.as_ref(),
+            )
+            .with_context(|| format!("decoding valid vector {}", vector.name))?;
+            assert_eq!(decoded.burner, eth_address_from_alloy(burner));
+            assert_eq!(
+                decoded.amount,
+                (amount_raw / U256::from(NOCK_BASE_PER_NICK)).to::<u64>()
+            );
+            assert_eq!(decoded.lock_root, lock_root);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn withdrawal_wire_v1_invalid_vectors_match_rejection_taxonomy() -> Result<()> {
+        let fixture: WithdrawalWireFixture = serde_json::from_str(WITHDRAWAL_WIRE_V1_VECTORS_JSON)
+            .context("decoding WithdrawalWireV1 fixture")?;
+
+        for invalid in &fixture.invalid_vectors {
+            let base = fixture
+                .valid_vectors
+                .iter()
+                .find(|vector| vector.name == invalid.base_vector)
+                .with_context(|| {
+                    format!(
+                        "invalid vector {} references missing base {}",
+                        invalid.name, invalid.base_vector
+                    )
+                })?;
+            let nock_contract_address = Address::from_str(&base.nock_token_address)
+                .with_context(|| format!("vector {} token address", base.name))?;
+            let burner = Address::from_str(&base.burner_address)
+                .with_context(|| format!("vector {} burner address", base.name))?;
+            let amount_raw = U256::from_str(&base.amount_base_units)
+                .with_context(|| format!("vector {} amount", base.name))?;
+            let event_commitment =
+                B256::from(parse_fixed_hex::<32>(&base.commitment, "commitment")?);
+            let calldata = parse_hex_bytes(&invalid.calldata, "calldata")?;
+            let log =
+                withdrawal_burn_log(nock_contract_address, burner, amount_raw, event_commitment);
+
+            let error = decode_burn_for_withdrawal_log_with_calldata(
+                &log,
+                &b256_from_u64(0xabcd),
+                Some(7),
+                nock_contract_address,
+                &calldata,
+            )
+            .expect_err("invalid WithdrawalWireV1 vector must be rejected");
+            assert_eq!(
+                burn_decode_error_kind(&error),
+                invalid.expected_error,
+                "unexpected rejection for invalid vector {}: {error}",
+                invalid.name
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn withdrawal_policy_v1_amount_vectors_match_backend_boundaries() -> Result<()> {
+        let fixture: WithdrawalWireFixture = serde_json::from_str(WITHDRAWAL_WIRE_V1_VECTORS_JSON)
+            .context("decoding WithdrawalWireV1 fixture")?;
+        let policy = crate::shared::types::WithdrawalPolicy::v1();
+        let minimum_nicks = policy
+            .minimum_gross_nocks
+            .checked_mul(policy.nicks_per_nock)
+            .context("withdrawal policy minimum overflowed")?;
+
+        for vector in &fixture.amount_policy_vectors {
+            let amount_raw = U256::from_str(&vector.amount_base_units)
+                .with_context(|| format!("vector {} amount", vector.name))?;
+            let base_units_per_nick = U256::from(policy.base_units_per_nick);
+            let actual = if amount_raw == U256::ZERO {
+                "amount_not_positive"
+            } else if amount_raw % base_units_per_nick != U256::ZERO {
+                "amount_not_divisible"
+            } else {
+                let amount_nicks = amount_raw / base_units_per_nick;
+                if amount_nicks > U256::from(policy.maximum_nicks) {
+                    "amount_overflow"
+                } else if amount_nicks < U256::from(minimum_nicks) {
+                    "amount_below_minimum"
+                } else {
+                    "valid"
+                }
+            };
+            assert_eq!(
+                actual, vector.expected,
+                "unexpected policy result for {}",
+                vector.name
+            );
+
+            if actual == "valid" {
+                let amount_nicks = (amount_raw / base_units_per_nick).to::<u64>();
+                let bridge_fee = wallet_tx_builder::fee::compute_bridge_fee(
+                    amount_nicks, policy.bridge_fee_nicks_per_started_nock,
+                );
+                assert_eq!(
+                    Some(amount_nicks),
+                    vector.amount_nicks.as_deref().map(str::parse).transpose()?,
+                    "amount nicks mismatch for {}",
+                    vector.name
+                );
+                assert_eq!(
+                    Some(bridge_fee),
+                    vector
+                        .bridge_fee_nicks
+                        .as_deref()
+                        .map(str::parse)
+                        .transpose()?,
+                    "bridge fee mismatch for {}",
+                    vector.name
+                );
+                assert_eq!(
+                    Some(amount_nicks - bridge_fee),
+                    vector
+                        .amount_after_bridge_fee_nicks
+                        .as_deref()
+                        .map(str::parse)
+                        .transpose()?,
+                    "post-bridge-fee amount mismatch for {}",
+                    vector.name
+                );
+            }
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/bridge/src/shared/config.rs
+++ b/crates/bridge/src/shared/config.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::shared::errors::BridgeError;
 use crate::shared::types::{
-    AtomBytes, BridgeConstants, NodeConfig, NodeInfo, SchnorrSecretKey, Tip5Hash,
+    AtomBytes, BridgeConstants, NodeConfig, NodeInfo, SchnorrSecretKey, Tip5Hash, WithdrawalPolicy,
+    WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK, WITHDRAWAL_POLICY_V1_ID,
+    WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -36,6 +38,9 @@ pub struct BridgeConfigToml {
     /// Number of confirmations required on nockchain before sending a block to the kernel.
     /// Zero means the latest observed tip is eligible immediately.
     pub nockchain_confirmation_depth: u64,
+    /// Versioned withdrawal amount and wire policy.
+    #[serde(default = "default_withdrawal_policy_id")]
+    pub withdrawal_policy: String,
     /// Base contract lastDepositNonce at the time the deposit nonce epoch is activated.
     ///
     /// When non-zero, this must equal the nonce of the anchor deposit identified by
@@ -94,6 +99,9 @@ pub struct NodeInfoToml {
 pub struct SequencerConfigToml {
     pub nock_contract_address: String,
     pub nockchain_confirmation_depth: u64,
+    /// Versioned withdrawal amount and wire policy.
+    #[serde(default = "default_withdrawal_policy_id")]
+    pub withdrawal_policy: String,
     #[serde(default)]
     pub manual_submit_approval: bool,
     #[serde(default)]
@@ -233,10 +241,10 @@ fn default_total_signers() -> u64 {
     5
 }
 fn default_minimum_event_nocks() -> u64 {
-    100_000
+    WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS
 }
 fn default_nicks_fee_per_nock() -> u64 {
-    195
+    WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK
 }
 fn default_base_blocks_chunk() -> u64 {
     100
@@ -249,6 +257,9 @@ fn default_nockchain_start_height() -> u64 {
 }
 fn default_true() -> bool {
     true
+}
+fn default_withdrawal_policy_id() -> String {
+    WITHDRAWAL_POLICY_V1_ID.to_string()
 }
 fn default_sequencer_journal_region() -> String {
     "auto".to_string()
@@ -321,6 +332,30 @@ impl BridgeConstantsToml {
             nockchain_start_height: self.nockchain_start_height,
         })
     }
+}
+
+fn resolve_withdrawal_policy(
+    policy_id: &str,
+    constants: &BridgeConstants,
+) -> Result<WithdrawalPolicy, BridgeError> {
+    if policy_id != WITHDRAWAL_POLICY_V1_ID {
+        return Err(BridgeError::Config(format!(
+            "unsupported withdrawal_policy '{policy_id}', expected '{WITHDRAWAL_POLICY_V1_ID}'"
+        )));
+    }
+    if constants.minimum_event_nocks != WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS {
+        return Err(BridgeError::Config(format!(
+            "withdrawal_policy '{policy_id}' requires minimum_event_nocks={}, found {}",
+            WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS, constants.minimum_event_nocks
+        )));
+    }
+    if constants.nicks_fee_per_nock != WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK {
+        return Err(BridgeError::Config(format!(
+            "withdrawal_policy '{policy_id}' requires nicks_fee_per_nock={}, found {}",
+            WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK, constants.nicks_fee_per_nock
+        )));
+    }
+    Ok(WithdrawalPolicy::v1())
 }
 
 #[derive(Debug, Deserialize)]
@@ -536,12 +571,19 @@ impl BridgeConfigToml {
         self.ingress_listen_address.as_deref()
     }
 
-    /// Get bridge constants, using defaults if not configured.
+    /// Get bridge constants and verify they match the selected withdrawal policy.
     pub fn bridge_constants(&self) -> Result<BridgeConstants, BridgeError> {
-        match &self.constants {
-            Some(c) => c.to_bridge_constants(),
-            None => Ok(BridgeConstants::default()),
-        }
+        let constants = match &self.constants {
+            Some(c) => c.to_bridge_constants()?,
+            None => BridgeConstants::default(),
+        };
+        resolve_withdrawal_policy(&self.withdrawal_policy, &constants)?;
+        Ok(constants)
+    }
+
+    pub fn withdrawal_policy(&self) -> Result<WithdrawalPolicy, BridgeError> {
+        self.bridge_constants()?;
+        Ok(WithdrawalPolicy::v1())
     }
 
     /// Parses the optional nonce-epoch anchor tx id from base58.
@@ -590,12 +632,19 @@ impl SequencerConfigToml {
             .map_err(|e| BridgeError::Config(format!("Invalid nock_contract_address: {}", e)))
     }
 
-    /// Get bridge constants, using defaults if not configured.
+    /// Get bridge constants and verify they match the selected withdrawal policy.
     pub fn bridge_constants(&self) -> Result<BridgeConstants, BridgeError> {
-        match &self.constants {
-            Some(c) => c.to_bridge_constants(),
-            None => Ok(BridgeConstants::default()),
-        }
+        let constants = match &self.constants {
+            Some(c) => c.to_bridge_constants()?,
+            None => BridgeConstants::default(),
+        };
+        resolve_withdrawal_policy(&self.withdrawal_policy, &constants)?;
+        Ok(constants)
+    }
+
+    pub fn withdrawal_policy(&self) -> Result<WithdrawalPolicy, BridgeError> {
+        self.bridge_constants()?;
+        Ok(WithdrawalPolicy::v1())
     }
 
     /// Converts public operator facts into the validated node set required by
@@ -900,8 +949,55 @@ mod tests {
 
     #[test]
     fn bridge_constants_default_minimum_event_matches_kernel_floor() {
-        assert_eq!(default_minimum_event_nocks(), 100_000);
-        assert_eq!(BridgeConstants::default().minimum_event_nocks, 100_000);
+        let policy = WithdrawalPolicy::v1();
+        assert_eq!(default_minimum_event_nocks(), policy.minimum_gross_nocks);
+        assert_eq!(
+            BridgeConstants::default().minimum_event_nocks,
+            policy.minimum_gross_nocks
+        );
+        assert_eq!(
+            BridgeConstants::default().nicks_fee_per_nock,
+            policy.bridge_fee_nicks_per_started_nock
+        );
+    }
+
+    #[test]
+    fn withdrawal_policy_v1_accepts_matching_bridge_constants() {
+        assert_eq!(
+            resolve_withdrawal_policy(WITHDRAWAL_POLICY_V1_ID, &BridgeConstants::default())
+                .expect("policy should match defaults"),
+            WithdrawalPolicy::v1()
+        );
+    }
+
+    #[test]
+    fn withdrawal_policy_rejects_unknown_id() {
+        let error =
+            resolve_withdrawal_policy("withdrawal-policy-unknown", &BridgeConstants::default())
+                .expect_err("unknown policy must fail");
+        assert!(error.to_string().contains("unsupported withdrawal_policy"));
+    }
+
+    #[test]
+    fn withdrawal_policy_v1_rejects_minimum_mismatch() {
+        let constants = BridgeConstants {
+            minimum_event_nocks: 1_000,
+            ..BridgeConstants::default()
+        };
+        let error = resolve_withdrawal_policy(WITHDRAWAL_POLICY_V1_ID, &constants)
+            .expect_err("mismatched minimum must fail");
+        assert!(error.to_string().contains("requires minimum_event_nocks"));
+    }
+
+    #[test]
+    fn withdrawal_policy_v1_rejects_fee_mismatch() {
+        let constants = BridgeConstants {
+            nicks_fee_per_nock: 1,
+            ..BridgeConstants::default()
+        };
+        let error = resolve_withdrawal_policy(WITHDRAWAL_POLICY_V1_ID, &constants)
+            .expect_err("mismatched fee must fail");
+        assert!(error.to_string().contains("requires nicks_fee_per_nock"));
     }
 
     #[test]

--- a/crates/bridge/src/shared/types.rs
+++ b/crates/bridge/src/shared/types.rs
@@ -425,11 +425,49 @@ impl Default for BridgeConstants {
             version: 0,
             min_signers: 3,
             total_signers: 5,
-            minimum_event_nocks: 100_000,
-            nicks_fee_per_nock: 195,
+            minimum_event_nocks: WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS,
+            nicks_fee_per_nock: WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK,
             base_blocks_chunk: 100,
             base_start_height: 39_694_000,
             nockchain_start_height: 46_810,
+        }
+    }
+}
+
+pub const WITHDRAWAL_POLICY_V1_ID: &str = "withdrawal-policy-v1";
+pub const WITHDRAWAL_WIRE_V1_ID: &str = "WithdrawalWireV1";
+pub const WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS: u64 = 100_000;
+pub const WITHDRAWAL_POLICY_V1_NICKS_PER_NOCK: u64 = 65_536;
+pub const WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NOCK: u128 = 10_000_000_000_000_000;
+pub const WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NICK: u128 = 152_587_890_625;
+pub const WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK: u64 = 195;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WithdrawalPolicy {
+    pub id: &'static str,
+    pub wire_format: &'static str,
+    pub minimum_gross_nocks: u64,
+    pub minimum_is_inclusive: bool,
+    pub nicks_per_nock: u64,
+    pub base_units_per_nock: u128,
+    pub base_units_per_nick: u128,
+    pub maximum_nicks: u64,
+    pub bridge_fee_nicks_per_started_nock: u64,
+}
+
+impl WithdrawalPolicy {
+    pub const fn v1() -> Self {
+        Self {
+            id: WITHDRAWAL_POLICY_V1_ID,
+            wire_format: WITHDRAWAL_WIRE_V1_ID,
+            minimum_gross_nocks: WITHDRAWAL_POLICY_V1_MINIMUM_GROSS_NOCKS,
+            minimum_is_inclusive: true,
+            nicks_per_nock: WITHDRAWAL_POLICY_V1_NICKS_PER_NOCK,
+            base_units_per_nock: WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NOCK,
+            base_units_per_nick: WITHDRAWAL_POLICY_V1_BASE_UNITS_PER_NICK,
+            maximum_nicks: u64::MAX,
+            bridge_fee_nicks_per_started_nock:
+                WITHDRAWAL_POLICY_V1_BRIDGE_FEE_NICKS_PER_STARTED_NOCK,
         }
     }
 }

--- a/crates/bridge/test-fixtures/withdrawal_wire_v1_vectors.json
+++ b/crates/bridge/test-fixtures/withdrawal_wire_v1_vectors.json
@@ -1,0 +1,153 @@
+{
+  "schema_version": 1,
+  "protocol": "WithdrawalWireV1",
+  "constants": {
+    "commitment_domain": "nock-withdrawal-calldata-v1",
+    "calldata_length": 116,
+    "base_calldata_length": 68,
+    "trailer_magic_ascii": "NOCKWD1!",
+    "full_lock_root_length": 40,
+    "tip5_prime": "18446744069414584321",
+    "nock_base_units_per_nick": "152587890625"
+  },
+  "valid_vectors": [
+    {
+      "name": "minimum_inclusive",
+      "nock_token_address": "0x1111111111111111111111111111111111111111",
+      "burner_address": "0x2222222222222222222222222222222222222222",
+      "amount_base_units": "1000000000000000000000",
+      "lock_root_limbs": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ],
+      "selector": "0xbcf64e05",
+      "commitment": "0x76bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab03231",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b5744312100000000000000010000000000000002000000000000000300000000000000040000000000000005"
+    },
+    {
+      "name": "leading_zero_and_max_limb",
+      "nock_token_address": "0xa5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5",
+      "burner_address": "0x5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a",
+      "amount_base_units": "1000000000152587890625",
+      "lock_root_limbs": [
+        "0",
+        "18446744069414584320",
+        "42",
+        "4294967296",
+        "99"
+      ],
+      "selector": "0xbcf64e05",
+      "commitment": "0xf463c089b4074b6f63e50a0552d584ff24743aa003042a94062a9a56d5727e90",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9ade965926fc1f463c089b4074b6f63e50a0552d584ff24743aa003042a94062a9a56d5727e904e4f434b574431210000000000000000ffffffff00000000000000000000002a00000001000000000000000000000063"
+    },
+    {
+      "name": "maximum_u64_nicks",
+      "nock_token_address": "0x0101010101010101010101010101010101010101",
+      "burner_address": "0xfefefefefefefefefefefefefefefefefefefefe",
+      "amount_base_units": "2814749767106559999847412109375",
+      "lock_root_limbs": [
+        "18446744069414584319",
+        "0",
+        "1",
+        "2",
+        "3"
+      ],
+      "selector": "0xbcf64e05",
+      "commitment": "0x991a7b8a2bfb015302153ce9bb5576b9f4968200de9cbff39262abd3f1ed19f0",
+      "calldata": "0xbcf64e05000000000000000000000000000000000000002386f26fc0ffffffdc790d903f991a7b8a2bfb015302153ce9bb5576b9f4968200de9cbff39262abd3f1ed19f04e4f434b57443121fffffffeffffffff0000000000000000000000000000000100000000000000020000000000000003"
+    }
+  ],
+  "amount_policy_vectors": [
+    {
+      "name": "zero",
+      "amount_base_units": "0",
+      "expected": "amount_not_positive"
+    },
+    {
+      "name": "one_nick_below_minimum",
+      "amount_base_units": "999999999847412109375",
+      "expected": "amount_below_minimum"
+    },
+    {
+      "name": "minimum_inclusive",
+      "amount_base_units": "1000000000000000000000",
+      "expected": "valid",
+      "amount_nicks": "6553600000",
+      "bridge_fee_nicks": "19500000",
+      "amount_after_bridge_fee_nicks": "6534100000"
+    },
+    {
+      "name": "minimum_plus_one_nick",
+      "amount_base_units": "1000000000152587890625",
+      "expected": "valid",
+      "amount_nicks": "6553600001",
+      "bridge_fee_nicks": "19500195",
+      "amount_after_bridge_fee_nicks": "6534099806"
+    },
+    {
+      "name": "one_base_unit_dust",
+      "amount_base_units": "1000000000000000000001",
+      "expected": "amount_not_divisible"
+    },
+    {
+      "name": "maximum_u64_nicks",
+      "amount_base_units": "2814749767106559999847412109375",
+      "expected": "valid",
+      "amount_nicks": "18446744073709551615",
+      "bridge_fee_nicks": "54887620458577920",
+      "amount_after_bridge_fee_nicks": "18391856453250973695"
+    },
+    {
+      "name": "overflow_u64_nicks",
+      "amount_base_units": "2814749767106560000000000000000",
+      "expected": "amount_overflow"
+    }
+  ],
+  "invalid_vectors": [
+    {
+      "name": "missing_trailer",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab03231",
+      "expected_error": "missing_calldata_trailer"
+    },
+    {
+      "name": "wrong_selector",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbdf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b5744312100000000000000010000000000000002000000000000000300000000000000040000000000000005",
+      "expected_error": "malformed_calldata"
+    },
+    {
+      "name": "wrong_magic",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab03231004f434b5744312100000000000000010000000000000002000000000000000300000000000000040000000000000005",
+      "expected_error": "malformed_calldata"
+    },
+    {
+      "name": "limb_equal_to_prime",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b57443121ffffffff000000010000000000000002000000000000000300000000000000040000000000000005",
+      "expected_error": "invalid_lock_root"
+    },
+    {
+      "name": "extra_trailing_byte",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000076bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b574431210000000000000001000000000000000200000000000000030000000000000004000000000000000500",
+      "expected_error": "malformed_calldata"
+    },
+    {
+      "name": "calldata_amount_mismatch",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000176bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b5744312100000000000000010000000000000002000000000000000300000000000000040000000000000005",
+      "expected_error": "calldata_amount_mismatch"
+    },
+    {
+      "name": "calldata_commitment_mismatch",
+      "base_vector": "minimum_inclusive",
+      "calldata": "0xbcf64e0500000000000000000000000000000000000000000000003635c9adc5dea0000077bdf80083f6c3ea86e4ddd4fd62c28d0400c1c783a1e5919afdd5e9cab032314e4f434b5744312100000000000000010000000000000002000000000000000300000000000000040000000000000005",
+      "expected_error": "calldata_commitment_mismatch"
+    }
+  ]
+}

--- a/crates/bridge/tests/config_tests.rs
+++ b/crates/bridge/tests/config_tests.rs
@@ -7,6 +7,7 @@ use bridge::shared::config::{
     BridgeConfigToml, NodeInfoToml, SequencerConfigToml, CANONICAL_TESTING_BRIDGE_LOCK_ROOT_B58,
     CANONICAL_TESTING_BRIDGE_NODE_PKHS_B58,
 };
+use bridge::shared::types::WITHDRAWAL_POLICY_V1_ID;
 use nockchain_math::belt::{Belt, PRIME};
 use nockchain_types::tx_engine::common::{Hash as NockPkh, SchnorrPubkey};
 use num_bigint::BigUint;
@@ -487,6 +488,7 @@ fn node_config_requires_matching_nock_signer_before_enabling_withdrawals() {
         nockchain_sequencer_api_address: None,
         base_confirmation_depth: 0,
         nockchain_confirmation_depth: 0,
+        withdrawal_policy: WITHDRAWAL_POLICY_V1_ID.to_string(),
         deposit_nonce_epoch_base: None,
         deposit_nonce_epoch_start_height: None,
         deposit_nonce_epoch_start_tx_id_base58: None,
@@ -1269,6 +1271,7 @@ fn sequencer_config_parses_public_facts_without_bridge_private_keys() {
         r#"
 nock_contract_address = "0x0000000000000000000000000000000000000001"
 nockchain_confirmation_depth = 100
+withdrawal_policy = "withdrawal-policy-v1"
 
 [sequencer_journal]
 enabled = false
@@ -1276,7 +1279,7 @@ enabled = false
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000000
+minimum_event_nocks = 100000
 nicks_fee_per_nock = 195
 base_blocks_chunk = 100
 base_start_height = 33387036
@@ -1304,6 +1307,20 @@ nockchain_start_height = 25
     assert!(!config.sequencer_journal.enabled);
     assert_eq!(
         config
+            .withdrawal_policy()
+            .expect("withdrawal policy should validate")
+            .id,
+        WITHDRAWAL_POLICY_V1_ID
+    );
+    assert_eq!(
+        config
+            .bridge_constants()
+            .expect("bridge constants should match policy")
+            .minimum_event_nocks,
+        100_000
+    );
+    assert_eq!(
+        config
             .validated_nodes()
             .expect("sequencer nodes should validate")
             .len(),
@@ -1321,11 +1338,12 @@ fn sequencer_config_defaults_journal_when_section_is_omitted() {
         r#"
 nock_contract_address = "0x0000000000000000000000000000000000000001"
 nockchain_confirmation_depth = 100
+withdrawal_policy = "withdrawal-policy-v1"
 
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000000
+minimum_event_nocks = 100000
 nicks_fee_per_nock = 195
 base_blocks_chunk = 100
 base_start_height = 33387036

--- a/crates/nockchain-bridge-sequencer/sequencer-conf.example.toml
+++ b/crates/nockchain-bridge-sequencer/sequencer-conf.example.toml
@@ -8,6 +8,9 @@ nock_contract_address = "0x..."
 # Nockchain confirmations required before sequencer settlement observations are final.
 nockchain_confirmation_depth = 400
 
+# Must match every bridge node's versioned withdrawal policy.
+withdrawal_policy = "withdrawal-policy-v1"
+
 # Optional manual operator approval gate for authorized withdrawal submission.
 manual_submit_approval = false
 manual_submit_approval_dir = "/var/lib/nockchain-bridge-sequencer/withdrawal-approvals"
@@ -36,7 +39,7 @@ secret_access_key = "..."  # Prefer WITHDRAWAL_SEQUENCER_JOURNAL_OBJECT_STORE_SE
 [constants]
 min_signers = 3
 total_signers = 5
-minimum_event_nocks = 1000000
+minimum_event_nocks = 100000
 nicks_fee_per_nock = 195
 base_blocks_chunk = 100
 base_start_height = 33387036


### PR DESCRIPTION
> [!NOTE]
> This PR is 1 of 7 in the withdrawal stack.
> Merge this PR first. Then review [PR #170](https://github.com/nockchain/nockchain/pull/170).

## Summary

This PR defines the protocol for withdrawals from Base to Nockchain.

This PR does not enable the public withdrawal route.

## Changes

- The protocol defines the 116-byte `WithdrawalWireV1` format.
- The policy defines the amount limits, divisibility rules, fee rules, and malformed-event rules.
- The repository contains one set of JSON vectors for the Rust bridge and the Iris SDK.
- The contract tests and the Rust tests use these vectors.
- The example configuration uses fail-closed defaults.
- The launch scripts use the same defaults.
- The operator documents describe the contract and the launch requirements.

## Safety

- The bridge rejects a withdrawal when required deployment data is absent.
- The bridge rejects a withdrawal when a required launch flag is absent.
- This PR keeps the public withdrawal route disabled.

## Tests

- [x] The Iris package tests passed with these vectors.
- [x] The complete stack test used 116-byte calldata.
- [x] The test recorded one burn and one payout.

## Nockchain PR stack

Merge these PRs in order:

1. [PR #169: Define the canonical withdrawal protocol](https://github.com/nockchain/nockchain/pull/169)
2. [PR #170: Make withdrawal state recoverable and queryable](https://github.com/nockchain/nockchain/pull/170)
3. [PR #171: Enforce reorg-safe single-flight settlement](https://github.com/nockchain/nockchain/pull/171)
4. [PR #172: Add the deterministic withdrawal harness](https://github.com/nockchain/nockchain/pull/172)
5. [PR #173: Prove terminal withdrawal settlement](https://github.com/nockchain/nockchain/pull/173)
6. [PR #174: Model and replay withdrawal failures](https://github.com/nockchain/nockchain/pull/174)
7. [PR #175: Add the production browser path](https://github.com/nockchain/nockchain/pull/175)

GitHub uses `master` as the base for this PR.

The head commit is `c0436e3ba08b3b38244ba55ed358a84534c388e3`.