### PR TITLE
feat(bridge): enforce reorg-safe single-flight settlement

### DIFF
--- a/.github/workflows/bridge-contracts.yml
+++ b/.github/workflows/bridge-contracts.yml
@@ -1,0 +1,58 @@
+name: Withdrawal contract conformance
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "crates/bridge/contracts/**"
+      - "crates/bridge/src/shared/base.rs"
+      - "crates/bridge/src/withdrawal/**"
+      - "crates/bridge/test-fixtures/withdrawal_wire_v1_vectors.json"
+      - "crates/bridge/BUILD.bazel"
+      - "tools/foundry/**"
+      - "MODULE.bazel"
+      - "MODULE.bazel.lock"
+      - ".github/workflows/bridge-contracts.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "crates/bridge/contracts/**"
+      - "crates/bridge/src/shared/base.rs"
+      - "crates/bridge/src/withdrawal/**"
+      - "crates/bridge/test-fixtures/withdrawal_wire_v1_vectors.json"
+      - "crates/bridge/BUILD.bazel"
+      - "tools/foundry/**"
+      - "MODULE.bazel"
+      - "MODULE.bazel.lock"
+      - ".github/workflows/bridge-contracts.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: withdrawal-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  forge:
+    name: Full Forge and 68-vs-116 conformance suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Run pinned Foundry suite through Bazel
+        run: bazel build //crates/bridge:withdrawal_contract_conformance --verbose_failures
+
+      - name: Publish Forge test count and results
+        if: always()
+        run: |
+          summary=bazel-bin/crates/bridge/contracts/out/forge-test-summary.txt
+          if [[ -f "$summary" ]]; then
+            cat "$summary"
+          else
+            echo "Forge did not produce a summary; inspect the Bazel action failure above." >&2
+            exit 1
+          fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,30 @@ build-kernels:
       - assets/*.jam
     expire_in: 1 day
 
+forge-withdrawal-protocol:
+  stage: test
+  needs: []
+  rules:
+    - <<: *open_sync_merge_train_rule
+      when: never
+    - changes:
+        - "crates/bridge/contracts/**/*"
+        - "crates/bridge/src/shared/base.rs"
+        - "crates/bridge/src/withdrawal/**/*"
+        - "crates/bridge/test-fixtures/withdrawal_wire_v1_vectors.json"
+        - "crates/bridge/BUILD.bazel"
+        - "tools/foundry/**/*"
+        - "MODULE.bazel"
+        - "MODULE.bazel.lock"
+        - ".gitlab-ci.yml"
+        - ".github/workflows/bridge-contracts.yml"
+    - when: never
+  script:
+    - |
+      set -euo pipefail
+      bazel build //crates/bridge:withdrawal_contract_conformance --verbose_failures
+      cat bazel-bin/crates/bridge/contracts/out/forge-test-summary.txt
+
 cargo-test:
   stage: test
   needs:

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -448,7 +448,7 @@
         "bzlTransitiveDigest": "BLNa1u0y13qLgDKGij8ls2b7sXaZEmc8AvRIqdW6N0Q=",
         "usagesDigest": "4HMANCe1hCsY10ISmZRF/nHKN88kNTZQ+cqdS97Aprc=",
         "recordedFileInputs": {
-          "@@//Cargo.lock": "16ad9b969cf124caac76c35f19d50ef6e6d483104dbe8df6bd808ac9a29a29da",
+          "@@//Cargo.lock": "5db2c17fa6c6ac5cf856fb182a97319b10e7438f728a7b77a149e702fc67cfa5",
           "@@//Cargo.toml": "97e65884564bb51f90557648826350a88ea9052093fe1baab96abb513528c161",
           "@@//crates/ai-pow-jets/Cargo.toml": "a89d44bbbdc6a7e8a09162233d9bb94f275e268497c90c714422204cddfd49c6",
           "@@//crates/ai-pow-miner/Cargo.toml": "3255003bb0c301d292e18f7b41bea72110361ab356b4c1e02825dcca39ae6bcf",

--- a/crates/bridge/BUILD.bazel
+++ b/crates/bridge/BUILD.bazel
@@ -35,6 +35,7 @@ genrule(
     name = "build_contracts",
     srcs = [
         ":contracts_inputs",
+        ":test_fixtures",
         "@forge_std//:all_files",
         "@forge_std//:root_marker",
         "@openzeppelin_contracts//:all_files",
@@ -45,18 +46,22 @@ genrule(
     outs = [
         "contracts/out/MessageInbox.sol/MessageInbox.json",
         "contracts/out/Nock.sol/Nock.json",
+        "contracts/out/forge-test-summary.txt",
     ],
     cmd = """
     set -e
 
     # Set up the contracts directory structure in the sandbox
     FORGE=$$(realpath $(location //tools/foundry:forge))
-    WORK_DIR=$$(mktemp -d)
+    WORK_ROOT=$$(mktemp -d)
+    WORK_DIR=$$WORK_ROOT/contracts
+    mkdir -p $$WORK_DIR
     export HOME=$$WORK_DIR
     export SVM_HOME=$$WORK_DIR/.svm
     export FOUNDRY_CACHE_PATH=$$WORK_DIR/.foundry/cache
     mkdir -p $$SVM_HOME $$FOUNDRY_CACHE_PATH
     OUT_DIR=$$PWD/$(@D)
+    mkdir -p $$OUT_DIR/contracts/out
     EXEC_ROOT=$$PWD
 
     # Resolve external repo roots before leaving the execroot
@@ -79,6 +84,14 @@ genrule(
       fi
     done
 
+    # Solidity reads the same canonical fixture consumed by Rust and Iris.
+    mkdir -p "$$WORK_ROOT/test-fixtures"
+    for f in $(locations :test_fixtures); do
+      rel=$${f#*test-fixtures/}
+      mkdir -p "$$WORK_ROOT/test-fixtures/$$(dirname $$rel)"
+      cp "$$f" "$$WORK_ROOT/test-fixtures/$$rel"
+    done
+
     # Wire Foundry deps from Bazel external repos
     mkdir -p "$$WORK_DIR/lib/forge-std" "$$WORK_DIR/lib/openzeppelin-contracts" "$$WORK_DIR/lib/openzeppelin-contracts-upgradeable"
     cp -R "$$FORGE_STD_ROOT"/. "$$WORK_DIR/lib/forge-std"
@@ -88,8 +101,18 @@ genrule(
 
     cd $$WORK_DIR
 
-    # Run forge build
+    # Contract artifacts and every Forge test use the same pinned v1.5.1
+    # binary and hermetic dependency tree.
     $$FORGE build --force --via-ir 2>&1
+    set +e
+    TEST_OUTPUT=$$($$FORGE test --force --via-ir 2>&1)
+    TEST_STATUS=$$?
+    set -e
+    printf '%s\n' "$$TEST_OUTPUT"
+    if [ "$$TEST_STATUS" -ne 0 ]; then
+      exit "$$TEST_STATUS"
+    fi
+    printf '%s\n' "$$TEST_OUTPUT" > "$$OUT_DIR/contracts/out/forge-test-summary.txt"
 
     # Copy the generated artifacts to Bazel's expected output locations
     # $$OUT_DIR is Bazel's output directory for this genrule
@@ -98,10 +121,14 @@ genrule(
     cp $$WORK_DIR/out/MessageInbox.sol/MessageInbox.json "$$OUT_DIR/contracts/out/MessageInbox.sol/MessageInbox.json"
     cp $$WORK_DIR/out/Nock.sol/Nock.json "$$OUT_DIR/contracts/out/Nock.sol/Nock.json"
 
-    # Clean up
-    rm -rf $$WORK_DIR
+    # Bazel owns the sandbox and its temporary contract workspace.
     """,
     tools = ["//tools/foundry:forge"],
+)
+
+filegroup(
+    name = "withdrawal_contract_conformance",
+    srcs = [":contracts/out/forge-test-summary.txt"],
 )
 
 # Build-time code generator for proto files
@@ -381,6 +408,11 @@ _BRIDGE_WITHDRAWAL_TEST_SRCS = glob(
     allow_empty = True,
 )
 
+_BRIDGE_REORG_TEST_SRCS = glob(
+    ["tests/reorg_recovery_tests.rs"],
+    allow_empty = True,
+)
+
 # Roswell kernel harness for integration tests that avoid mocks.
 [
     rust_library(
@@ -425,6 +457,7 @@ rust_test_suite(
             "tests/roswell_harness.rs",
             "tests/test_harness.rs",
             "tests/withdrawal_tests.rs",
+            "tests/reorg_recovery_tests.rs",
         ],
     ),
     compile_data = ["bridge-conf.example.toml"],
@@ -532,6 +565,43 @@ rust_test_suite(
         ),
     )
     for _ in _BRIDGE_WITHDRAWAL_TEST_SRCS
+]
+
+# reorg_recovery_tests.rs drives the real Roswell kernel through stop, start,
+# and retry transitions, so give the compiled Hoon suite a moderate timeout.
+[
+    rust_test(
+        name = "reorg_recovery_tests_test",
+        timeout = "moderate",
+        srcs = _BRIDGE_REORG_TEST_SRCS,
+        crate_features = ["bazel_build"],
+        crate_root = "tests/reorg_recovery_tests.rs",
+        data = [
+            ":contracts/out/MessageInbox.sol/MessageInbox.json",
+            ":contracts/out/Nock.sol/Nock.json",
+        ],
+        edition = "2021",
+        proc_macro_deps = all_crate_deps(
+            proc_macro = True,
+            proc_macro_dev = True,
+        ),
+        rustc_env = {
+            "MESSAGE_INBOX_JSON": "$(execpath :contracts/out/MessageInbox.sol/MessageInbox.json)",
+            "NOCK_JSON": "$(execpath :contracts/out/Nock.sol/Nock.json)",
+        },
+        deps = [
+            ":bridge",
+            ":bridge_roswell_harness",
+            ":bridge_test_harness",
+            "//crates/nockchain-math",
+            "//crates/nockchain-types",
+            "//crates/nockvm/rust/ibig",
+        ] + all_crate_deps(
+            normal = True,
+            normal_dev = True,
+        ),
+    )
+    for _ in _BRIDGE_REORG_TEST_SRCS
 ]
 
 # core_runner_integration.rs depends on tests/harness/in_memory_ports.rs as a module.

--- a/crates/bridge/contracts/environments/base-sepolia-testnet-accounts.md
+++ b/crates/bridge/contracts/environments/base-sepolia-testnet-accounts.md
@@ -2,7 +2,7 @@
 
 Status: Active
 Owner: Nockchain Maintainers
-Last Reviewed: 2026-02-20
+Last Reviewed: 2026-08-25
 Canonical/Legacy: Legacy (operational reference for Base Sepolia bridge contracts and script accounts)
 
 Bridge contracts deployed to real Base Sepolia network through Tenderly Node RPC.
@@ -81,17 +81,47 @@ cd crates/bridge
 
 ## Live Deployment (2025-12-17)
 
-| Contract                      | Address                                      | Basescan                                                                             |
-| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------ |
-| MessageInbox (Proxy)          | `0x9b1becA13c39b9Be10dB616F1bE10C3CeF9Dfb36` | https://sepolia.basescan.org/address/0x9b1becA13c39b9Be10dB616F1bE10C3CeF9Dfb36#code |
-| MessageInbox (Implementation) | `0x7627Db3A99596668c9d42693efa352Ca69F089e3` | https://sepolia.basescan.org/address/0x7627Db3A99596668c9d42693efa352Ca69F089e3#code |
-| Nock Token                    | `0xA9cd4087D9B050D8B35727AAf810296CA957c7B3` | https://sepolia.basescan.org/address/0xA9cd4087D9B050D8B35727AAf810296CA957c7B3#code |
+The canonical public deployment identity is
+[`../../e2e/environments/base-sepolia.json`](../../e2e/environments/base-sepolia.json).
+It records the pinned finalized block, proxy and implementation distinction,
+runtime code hashes, deployment receipts, pristine ownership and signer state,
+reciprocal pairing, verified compiler artifacts, ABI hashes, and withdrawal
+protocol/policy identifiers.
 
-Tenderly dashboard: https://dashboard.tenderly.co/nockchain/bridge/contracts
+Read the current values without duplicating them:
+
+```bash
+MANIFEST=../../e2e/environments/base-sepolia.json
+jq '.source_chain.fork_block' "$MANIFEST"
+jq '.contracts' "$MANIFEST"
+jq '.pristine_state' "$MANIFEST"
+```
+
+## Refresh Procedure
+
+1. Select a Base Sepolia block reported as `finalized`; never certify `latest`.
+2. Record the exact block number, hash, and timestamp.
+3. At that block, read the ERC-1967 implementation slot, all runtime bytecode,
+   both owners, five bridge nodes, threshold, withdrawal gate, and reciprocal
+   contract pairing.
+4. Repeat every read through a second independent RPC provider. Stop on any
+   disagreement or empty runtime bytecode.
+5. Compute Keccak-256 over the exact runtime bytecode returned for the proxy,
+   implementation, and Nock token.
+6. Confirm deployment transaction hashes, block numbers, block hashes, status,
+   and created addresses from chain receipts and an independent explorer.
+7. Fetch the explorer-verified compiler artifacts and ABIs. Recompute hashes
+   using the manifest's declared canonicalization and SHA-256 scheme.
+8. Update all manifest facts together, run
+   `cargo test -p bridge --test base_sepolia_manifest`, and review every block,
+   address, state, artifact, ABI, and code-hash change before committing.
+
+RPC endpoints and credentials remain external inputs and must not be added to
+the manifest.
 
 ## Verification
 
-Preferred path for this repo:
+Preferred contract validation path:
 
 ```bash
 cd crates/bridge/contracts

--- a/crates/bridge/docs/bridge-withdrawals.md
+++ b/crates/bridge/docs/bridge-withdrawals.md
@@ -1469,6 +1469,25 @@ the certified manual recovery procedure satisfies the same safety invariant.
 Missing kernel assets, live credentials, or a tested recovery procedure block
 launch. Mocks do not satisfy these gates.
 
+The focused recovery proof matrix is:
+
+```sh
+bazel build --jobs=1 //assets/native:roswell_native
+KERNEL_JAM_PATH="$PWD/bazel-bin/assets/native/roswell_native.jam" \
+  cargo test --locked -p bridge reorg -- --test-threads=1
+```
+
+It runs the real Roswell bridge kernel plus the Rust recovery tests. The Hoon
+fixtures bypass the configured confirmation depths and prove the fail-stop
+boundary if already-accepted Base or Nockchain history changes: the old
+hashchain remains, a retry fails identically, and an orphaned withdrawal stays
+in kernel state. The Rust cases prove bounded invalidation and readmission,
+unsafe-value holds, durable replay, exact Nock transaction recovery,
+reservation restoration, mutation refusal, public status regression, and
+fail-closed readiness. This matrix covers a post-confirmation assumption
+violation; it does not show that ordinary shallow forks reach Hoon or that
+automatic in-place rewind is required for launch.
+
 ## Component Ownership
 
 ### Hoon kernel

--- a/crates/bridge/src/core/withdrawal/submission.rs
+++ b/crates/bridge/src/core/withdrawal/submission.rs
@@ -63,9 +63,10 @@ fn submission_row_decision(
     node_pkhs: &[nockchain_types::tx_engine::common::Hash],
 ) -> Result<WithdrawalSubmissionRowDecision, BridgeError> {
     match row.state {
-        WithdrawalState::MempoolAccepted | WithdrawalState::Confirmed => {
-            Ok(WithdrawalSubmissionRowDecision::SkipReleasedNonce)
+        WithdrawalState::MempoolAccepted => {
+            Ok(WithdrawalSubmissionRowDecision::BlockedFrontierState)
         }
+        WithdrawalState::Confirmed => Ok(WithdrawalSubmissionRowDecision::SkipReleasedNonce),
         WithdrawalState::PeerCanonical => {
             if withdrawal_turn_proposer(&row.id, row.current_epoch, handoff_index, node_pkhs)
                 != local_node_id as usize
@@ -90,6 +91,8 @@ fn submission_row_decision(
             Ok(WithdrawalSubmissionRowDecision::BlockedFrontierState)
         }
         WithdrawalState::Pending => Ok(WithdrawalSubmissionRowDecision::SkipReleasedNonce),
+        WithdrawalState::Invalidated => Ok(WithdrawalSubmissionRowDecision::SkipReleasedNonce),
+        WithdrawalState::ReorgHold => Ok(WithdrawalSubmissionRowDecision::BlockedFrontierState),
     }
 }
 
@@ -225,6 +228,21 @@ mod tests {
         assert_eq!(
             candidate.kind,
             WithdrawalSubmissionCandidateKind::SubmitAuthorized
+        );
+    }
+
+    #[test]
+    fn mempool_accepted_frontier_blocks_later_work_until_confirmation() {
+        let decision = submission_row_decision(
+            &sample_row(4, 4, 0, WithdrawalState::MempoolAccepted),
+            0,
+            0,
+            &sample_node_pkhs(),
+        )
+        .expect("plan mempool-accepted frontier");
+        assert_eq!(
+            decision,
+            WithdrawalSubmissionRowDecision::BlockedFrontierState
         );
     }
 

--- a/crates/bridge/src/main.rs
+++ b/crates/bridge/src/main.rs
@@ -561,9 +561,9 @@ mod planner_fee_tests {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum KernelBlockchainConstantsBootAction {
-    InitializeKernel,
-    MigrateKernel,
-    UseExistingKernel,
+    Initialize,
+    Migrate,
+    UseExisting,
 }
 
 fn resolve_effective_blockchain_constants(
@@ -578,7 +578,7 @@ fn resolve_effective_blockchain_constants(
         {
             Ok((
                 connected_blockchain_constants,
-                KernelBlockchainConstantsBootAction::MigrateKernel,
+                KernelBlockchainConstantsBootAction::Migrate,
             ))
         }
         Some(kernel_blockchain_constants) => {
@@ -587,12 +587,12 @@ fn resolve_effective_blockchain_constants(
             )?;
             Ok((
                 kernel_blockchain_constants,
-                KernelBlockchainConstantsBootAction::UseExistingKernel,
+                KernelBlockchainConstantsBootAction::UseExisting,
             ))
         }
         None => Ok((
             connected_blockchain_constants,
-            KernelBlockchainConstantsBootAction::InitializeKernel,
+            KernelBlockchainConstantsBootAction::Initialize,
         )),
     }
 }
@@ -802,14 +802,14 @@ async fn main() -> Result<(), BridgeError> {
         cli.migrate_blockchain_constants,
     )?;
     match boot_action {
-        KernelBlockchainConstantsBootAction::InitializeKernel => {
+        KernelBlockchainConstantsBootAction::Initialize => {
             set_kernel_blockchain_constants(&mut app, &effective_blockchain_constants).await?;
             info!(
                 target: "bridge.withdrawal",
                 "initialized bridge kernel blockchain-constants from connected private nockchain node"
             );
         }
-        KernelBlockchainConstantsBootAction::MigrateKernel => {
+        KernelBlockchainConstantsBootAction::Migrate => {
             set_kernel_blockchain_constants(&mut app, &effective_blockchain_constants).await?;
             let persisted = peek_kernel_blockchain_constants(&mut app)
                 .await?
@@ -828,7 +828,7 @@ async fn main() -> Result<(), BridgeError> {
                 "migrated bridge kernel blockchain-constants from connected private nockchain node"
             );
         }
-        KernelBlockchainConstantsBootAction::UseExistingKernel => {
+        KernelBlockchainConstantsBootAction::UseExisting => {
             info!(
                 target: "bridge.withdrawal",
                 "confirmed bridge kernel blockchain-constants match the connected private nockchain node"
@@ -1478,10 +1478,7 @@ mod tests {
                 .expect("missing kernel constants should initialize");
 
         assert_eq!(effective, connected);
-        assert_eq!(
-            action,
-            KernelBlockchainConstantsBootAction::InitializeKernel
-        );
+        assert_eq!(action, KernelBlockchainConstantsBootAction::Initialize);
     }
 
     #[test]
@@ -1494,10 +1491,7 @@ mod tests {
                 .expect("matching kernel constants should be accepted");
 
         assert_eq!(effective, kernel);
-        assert_eq!(
-            action,
-            KernelBlockchainConstantsBootAction::UseExistingKernel
-        );
+        assert_eq!(action, KernelBlockchainConstantsBootAction::UseExisting);
     }
 
     #[test]
@@ -1522,7 +1516,7 @@ mod tests {
                 .expect("explicit migration should accept a mismatch");
 
         assert_eq!(effective, connected);
-        assert_eq!(action, KernelBlockchainConstantsBootAction::MigrateKernel);
+        assert_eq!(action, KernelBlockchainConstantsBootAction::Migrate);
     }
 
     #[test]

--- a/crates/bridge/src/shared/base.rs
+++ b/crates/bridge/src/shared/base.rs
@@ -59,6 +59,20 @@ use crate::withdrawal::types::{BaseWithdrawalEntry, Withdrawal};
 /// The bridge kernel assumes blocks it receives are final; this is enforced by the Rust driver.
 pub const DEFAULT_BASE_CONFIRMATION_DEPTH: u64 = 300;
 
+/// Hard cap on automatic rewinds of already-confirmed Base headers.
+///
+/// The effective deployment limit is the smaller of this cap and the configured
+/// confirmation depth. Crossing activation/policy boundaries is never automatic.
+pub const BASE_MAX_AUTOMATIC_REORG_REWIND_BLOCKS: u64 = 64;
+
+pub const fn base_automatic_reorg_rewind_depth(confirmation_depth: u64) -> u64 {
+    if confirmation_depth < BASE_MAX_AUTOMATIC_REORG_REWIND_BLOCKS {
+        confirmation_depth
+    } else {
+        BASE_MAX_AUTOMATIC_REORG_REWIND_BLOCKS
+    }
+}
+
 // In Bazel builds, contract JSON paths are provided via rustc_env.
 // In Cargo builds, they're relative to CARGO_MANIFEST_DIR.
 #[cfg(feature = "bazel_build")]
@@ -1957,6 +1971,17 @@ mod tests {
             BurnForWithdrawalDecodeError::CommitmentMismatch { .. } => "commitment_mismatch",
             BurnForWithdrawalDecodeError::InvalidLockRoot { .. } => "invalid_lock_root",
         }
+    }
+
+    #[test]
+    fn automatic_reorg_rewind_depth_is_confirmation_bounded_and_hard_capped() {
+        assert_eq!(base_automatic_reorg_rewind_depth(0), 0);
+        assert_eq!(base_automatic_reorg_rewind_depth(1), 1);
+        assert_eq!(base_automatic_reorg_rewind_depth(64), 64);
+        assert_eq!(
+            base_automatic_reorg_rewind_depth(DEFAULT_BASE_CONFIRMATION_DEPTH),
+            BASE_MAX_AUTOMATIC_REORG_REWIND_BLOCKS
+        );
     }
 
     #[test]

--- a/crates/bridge/src/shared/nockchain.rs
+++ b/crates/bridge/src/shared/nockchain.rs
@@ -39,6 +39,20 @@ pub const BLOCKCHAIN_CONSTANTS_PATH: &str = "blockchain-constants";
 /// The bridge kernel assumes blocks it receives are final; this is enforced by the Rust driver.
 pub const DEFAULT_NOCKCHAIN_CONFIRMATION_DEPTH: u64 = 400;
 
+pub const NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS: u64 = 64;
+
+pub const fn nockchain_reinclusion_within_rewind(old_height: u64, new_height: u64) -> bool {
+    old_height.abs_diff(new_height) <= NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS
+}
+
+pub const fn nockchain_snapshot_is_stable_for_replay(
+    snapshot_height: u64,
+    old_inclusion_height: u64,
+) -> bool {
+    old_inclusion_height.saturating_sub(snapshot_height)
+        >= NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS
+}
+
 #[cfg(test)]
 fn confirmed_height(chain_tip: u64, confirmation_depth: u64) -> Option<u64> {
     let target = if confirmation_depth == 0 {
@@ -1357,6 +1371,14 @@ mod tests {
         let target = confirmed_height(tip, depth);
         assert!(target.is_some());
         assert_eq!(target.expect("target should be Some for valid input"), 50);
+    }
+
+    #[test]
+    fn nockchain_reorg_recovery_boundaries_are_exact() {
+        assert!(nockchain_reinclusion_within_rewind(1_000, 1_064));
+        assert!(!nockchain_reinclusion_within_rewind(1_000, 1_065));
+        assert!(nockchain_snapshot_is_stable_for_replay(900, 964));
+        assert!(!nockchain_snapshot_is_stable_for_replay(901, 964));
     }
 
     #[test]

--- a/crates/bridge/src/withdrawal/assembly.rs
+++ b/crates/bridge/src/withdrawal/assembly.rs
@@ -54,7 +54,8 @@ use crate::withdrawal::state::{
 #[cfg(test)]
 use crate::withdrawal::submission::WithdrawalSequencerSubmitOutcome;
 use crate::withdrawal::submission::{
-    register_withdrawal_or_alert, sequenced_withdrawal_released, WithdrawalSequencerPort,
+    register_withdrawal_or_alert, sequenced_withdrawal_needs_no_bridge_work,
+    WithdrawalSequencerPort,
 };
 use crate::withdrawal::transport::{
     required_withdrawal_commit_signature_threshold, signed_proposal_matches_base,
@@ -1628,7 +1629,7 @@ async fn next_stageable_withdrawal_request<K: WithdrawalKernelPort>(
                     .sequencer
                     .get_sequenced_withdrawal_status(&tracked.id)
                     .await?;
-                if sequenced_withdrawal_released(&status) {
+                if sequenced_withdrawal_needs_no_bridge_work(&status) {
                     continue;
                 }
                 register_withdrawal_or_alert(
@@ -1645,7 +1646,7 @@ async fn next_stageable_withdrawal_request<K: WithdrawalKernelPort>(
                     .sequencer
                     .get_sequenced_withdrawal_status(&tracked.id)
                     .await?;
-                if sequenced_withdrawal_released(&status) {
+                if sequenced_withdrawal_needs_no_bridge_work(&status) {
                     continue;
                 }
                 return Ok(None);
@@ -2090,7 +2091,7 @@ mod tests {
             for (id, withdrawal_nonce) in candidates {
                 let released = statuses
                     .get(&id)
-                    .map(|status| matches!(status.state.as_str(), "mempool_accepted" | "confirmed"))
+                    .map(|status| status.state == "confirmed")
                     .unwrap_or(false);
                 if !released {
                     return Ok(Some(
@@ -4053,7 +4054,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn withdrawal_assembly_tick_stages_later_request_after_prior_nonce_mempool_acceptance() {
+    async fn withdrawal_assembly_tick_waits_for_prior_nonce_confirmation() {
         let (_dir, registry) = open_services().await;
         let mut earlier = sample_withdrawal_request_with_seed(1);
         let mut later = sample_withdrawal_request_with_seed(2);
@@ -4135,7 +4136,7 @@ mod tests {
         let context = WithdrawalAssemblyContext {
             kernel: kernel.clone(),
             snapshot_service,
-            sequencer,
+            sequencer: sequencer.clone(),
             proposal_registry: registry,
             bridge_status: sample_bridge_status(1),
             planner,
@@ -4147,6 +4148,19 @@ mod tests {
         let outcome = withdrawal_assembly_tick_once(&context)
             .await
             .expect("assembly tick");
+        assert_eq!(outcome, WithdrawalAssemblyTickOutcome::Idle);
+        assert!(kernel.requests.lock().expect("requests lock").is_empty());
+
+        sequencer
+            .statuses
+            .lock()
+            .expect("sequencer statuses lock")
+            .get_mut(&earlier.withdrawal_id())
+            .expect("earlier sequencer status")
+            .state = "confirmed".to_string();
+        let outcome = withdrawal_assembly_tick_once(&context)
+            .await
+            .expect("assembly tick after confirmation");
         assert!(matches!(
             outcome,
             WithdrawalAssemblyTickOutcome::RequestedBuild {

--- a/crates/bridge/src/withdrawal/proposals.rs
+++ b/crates/bridge/src/withdrawal/proposals.rs
@@ -524,6 +524,20 @@ impl WithdrawalProjectionStore {
         .await
     }
 
+    pub async fn reconcile_base_reorg_state(
+        &self,
+        id: &WithdrawalId,
+        sequencer_epoch: u64,
+        hold: bool,
+    ) -> Result<bool, BridgeError> {
+        let id = id.clone();
+        let updated_at = now_unix_secs()?;
+        self.with_conn(move |conn| {
+            reconcile_base_reorg_state(conn, &id, sequencer_epoch, hold, updated_at)
+        })
+        .await
+    }
+
     async fn validate_and_stage_prepared(
         &self,
         proposal: WithdrawalProposalData,
@@ -981,6 +995,22 @@ impl WithdrawalProposalRegistry {
             .reconcile_prepared_with_pending_sequencer(
                 id, sequencer_epoch, sequencer_handoff_index, sequencer_turn_started_base_height,
             )
+            .await?;
+        if changed {
+            self.clear_cache();
+        }
+        Ok(changed)
+    }
+
+    pub async fn reconcile_base_reorg_state(
+        &self,
+        id: &WithdrawalId,
+        sequencer_epoch: u64,
+        hold: bool,
+    ) -> Result<bool, BridgeError> {
+        let changed = self
+            .store
+            .reconcile_base_reorg_state(id, sequencer_epoch, hold)
             .await?;
         if changed {
             self.clear_cache();
@@ -1915,12 +1945,16 @@ fn reconcile_pending_epoch(
     let Some(existing) = find_withdrawal_row(conn, id)? else {
         return Ok(false);
     };
-    if parse_state_tag(&existing.state)? != WithdrawalState::Pending {
+    let state = parse_state_tag(&existing.state)?;
+    if !matches!(
+        state,
+        WithdrawalState::Pending | WithdrawalState::Invalidated
+    ) {
         return Ok(false);
     }
     let current_epoch = u64::try_from(existing.current_epoch)
         .map_err(|err| BridgeError::ValueConversion(format!("current_epoch overflow: {err}")))?;
-    if current_epoch == sequencer_epoch {
+    if state == WithdrawalState::Pending && current_epoch == sequencer_epoch {
         return Ok(false);
     }
 
@@ -1936,6 +1970,7 @@ fn reconcile_pending_epoch(
             withdrawals::submitted_at.eq::<Option<i64>>(None),
             withdrawals::confirmed_height.eq::<Option<i64>>(None),
             withdrawals::confirmed_block_id.eq::<Option<Vec<u8>>>(None),
+            withdrawals::state.eq(state_tag(WithdrawalState::Pending).to_string()),
             withdrawals::updated_at.eq(updated_at),
         ))
         .execute(conn)
@@ -1990,6 +2025,77 @@ fn reconcile_prepared_with_pending_sequencer(
     Ok(true)
 }
 
+fn reconcile_base_reorg_state(
+    conn: &mut SqliteConnection,
+    id: &WithdrawalId,
+    sequencer_epoch: u64,
+    hold: bool,
+    updated_at: i64,
+) -> Result<bool, BridgeError> {
+    let Some(existing) = find_withdrawal_row(conn, id)? else {
+        return Ok(false);
+    };
+    let state = parse_state_tag(&existing.state)?;
+    let target = if hold {
+        WithdrawalState::ReorgHold
+    } else {
+        WithdrawalState::Invalidated
+    };
+    if state == target {
+        return Ok(false);
+    }
+    if !hold
+        && matches!(
+            state,
+            WithdrawalState::Authorized
+                | WithdrawalState::MempoolAccepted
+                | WithdrawalState::Confirmed
+                | WithdrawalState::ReorgHold
+        )
+    {
+        return Err(BridgeError::Runtime(format!(
+            "sequencer invalidated Base burn {:?} while local lifecycle is {}",
+            id,
+            state.as_str()
+        )));
+    }
+    let epoch = i64::try_from(sequencer_epoch)
+        .map_err(|err| BridgeError::ValueConversion(format!("epoch too large: {err}")))?;
+    if hold {
+        diesel::update(withdrawals::table.find(existing.id))
+            .set((
+                withdrawals::current_epoch.eq(epoch),
+                withdrawals::state.eq(state_tag(target).to_string()),
+                withdrawals::updated_at.eq(updated_at),
+            ))
+            .execute(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!("withdrawal Base reorg hold update failed: {err}"))
+            })?;
+    } else {
+        diesel::update(withdrawals::table.find(existing.id))
+            .set((
+                withdrawals::current_epoch.eq(epoch),
+                withdrawals::proposal_hash.eq::<Option<String>>(None),
+                withdrawals::peer_commit_certificate.eq::<Option<Vec<u8>>>(None),
+                withdrawals::state.eq(state_tag(target).to_string()),
+                withdrawals::turn_started_base_height.eq::<Option<i64>>(None),
+                withdrawals::submitted_tx_name.eq::<Option<String>>(None),
+                withdrawals::submitted_tx_hash.eq::<Option<String>>(None),
+                withdrawals::submitted_at.eq::<Option<i64>>(None),
+                withdrawals::confirmed_height.eq::<Option<i64>>(None),
+                withdrawals::confirmed_block_id.eq::<Option<Vec<u8>>>(None),
+                withdrawals::updated_at.eq(updated_at),
+            ))
+            .execute(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!(
+                    "withdrawal Base reorg invalidation update failed: {err}"
+                ))
+            })?;
+    }
+    Ok(true)
+}
 fn expire_prepared_row(
     conn: &mut SqliteConnection,
     row_id: i64,
@@ -2240,6 +2346,7 @@ fn count_withdrawals(
     }
     if exclude_confirmed {
         query = query.filter(withdrawal_dsl::state.ne(state_tag(WithdrawalState::Confirmed)));
+        query = query.filter(withdrawal_dsl::state.ne(state_tag(WithdrawalState::Invalidated)));
     }
     let count = query
         .select(diesel::dsl::count_star())
@@ -2258,6 +2365,7 @@ fn count_ordering_blocking_withdrawals(conn: &mut SqliteConnection) -> Result<u6
         state_tag(WithdrawalState::Prepared).to_string(),
         state_tag(WithdrawalState::PeerCanonical).to_string(),
         state_tag(WithdrawalState::Authorized).to_string(),
+        state_tag(WithdrawalState::ReorgHold).to_string(),
     ];
     let count = withdrawals::table
         .filter(withdrawal_dsl::state.eq_any(blocking_states))
@@ -2283,6 +2391,7 @@ fn count_relative_to_frontier(
         .map_err(|err| BridgeError::ValueConversion(format!("withdrawal nonce overflow: {err}")))?;
     let mut query = withdrawals::table
         .filter(withdrawal_dsl::state.ne(state_tag(WithdrawalState::Confirmed)))
+        .filter(withdrawal_dsl::state.ne(state_tag(WithdrawalState::Invalidated)))
         .into_boxed::<diesel::sqlite::Sqlite>();
     query = if below {
         query.filter(withdrawal_dsl::withdrawal_nonce.lt(frontier_nonce))
@@ -2397,9 +2506,12 @@ fn build_live_withdrawal_view(
 fn has_active_operator_attempt(state: WithdrawalState) -> bool {
     // "Live" is intentionally narrower than "tracked": a Pending row is a
     // durable Base burn fact waiting for assembly, while a Confirmed row is
-    // terminal. Live rows are only active operator attempts:
-    // Assembling, Prepared, PeerCanonical, Authorized, or MempoolAccepted.
-    !matches!(state, WithdrawalState::Pending | WithdrawalState::Confirmed)
+    // terminal/inactive. Live rows are active operator attempts or a reorg
+    // hold that must continue blocking later work.
+    !matches!(
+        state,
+        WithdrawalState::Pending | WithdrawalState::Confirmed | WithdrawalState::Invalidated
+    )
 }
 
 fn now_unix_secs() -> Result<i64, BridgeError> {
@@ -3046,5 +3158,57 @@ mod tests {
         assert_eq!(counts.confirmed_count, 1);
         assert_eq!(counts.below_frontier_count, 1);
         assert_eq!(counts.above_frontier_count, 1);
+    }
+    #[tokio::test]
+    async fn base_reorg_invalidation_clears_local_proposal_and_live_state() {
+        let (_dir, registry) = open_registry().await;
+        let request = sample_request();
+        registry
+            .track_withdrawal_request(&request)
+            .await
+            .expect("track");
+        let proposal = sample_proposal(0);
+        registry
+            .validate_and_cache_prepared(&proposal)
+            .await
+            .expect("prepare");
+        assert!(registry
+            .reconcile_base_reorg_state(&proposal.id, proposal.epoch, false)
+            .await
+            .expect("reconcile Base invalidation"));
+        assert!(registry
+            .fetch_cached_proposal(proposal.id.clone(), proposal.epoch)
+            .await
+            .expect("cached proposal")
+            .is_none());
+        assert!(registry
+            .fetch_live_withdrawal(&proposal.id)
+            .await
+            .expect("live withdrawal")
+            .is_none());
+        let rows = registry
+            .load_tui_rows_around_nonce(Some(1), 10)
+            .await
+            .expect("TUI rows");
+        assert_eq!(rows[0].state, WithdrawalState::Invalidated);
+        let counts = registry.load_tui_counts(Some(1)).await.expect("counts");
+        assert_eq!(counts.live_count, 0);
+        assert_eq!(counts.ordering_blocking_count, 0);
+        assert!(registry
+            .reconcile_pending_epoch(&proposal.id, 1)
+            .await
+            .expect("reconcile canonical Base re-admission"));
+        let rows = registry
+            .load_tui_rows_around_nonce(Some(1), 10)
+            .await
+            .expect("readmitted TUI rows");
+        assert_eq!(rows[0].state, WithdrawalState::Pending);
+        assert_eq!(rows[0].current_epoch, 1);
+        let counts = registry
+            .load_tui_counts(Some(1))
+            .await
+            .expect("readmitted counts");
+        assert_eq!(counts.pending_count, 1);
+        assert_eq!(counts.ordering_blocking_count, 1);
     }
 }

--- a/crates/bridge/src/withdrawal/sequencer/base_activity.rs
+++ b/crates/bridge/src/withdrawal/sequencer/base_activity.rs
@@ -46,6 +46,14 @@ impl VerifiedBaseWithdrawalBurn {
         )
     }
 }
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicBaseWithdrawalBurn {
+    pub burn: VerifiedBaseWithdrawalBurn,
+    pub canonical: bool,
+    pub invalidated_at: Option<i64>,
+    pub invalidation_generation: Option<u64>,
+    pub invalidation_reason: Option<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaseActivityCursor {
@@ -57,6 +65,27 @@ pub struct BaseActivityCursor {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseActivityHeaderCheckpoint {
+    pub chain_id: u64,
+    pub nock_contract_address: Address,
+    pub block_number: u64,
+    pub block_hash: B256,
+    pub parent_hash: B256,
+    pub block_timestamp: u64,
+    pub verified_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseActivityReorgPlan {
+    pub chain_id: u64,
+    pub nock_contract_address: Address,
+    pub old_cursor: BaseActivityCursor,
+    pub common_ancestor: BaseActivityHeaderCheckpoint,
+    pub canonical_cursor_header: BaseActivityHeaderCheckpoint,
+    pub rewind_depth: u64,
+    pub detected_at: i64,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaseActivityPageCursor {
     pub snapshot_revision: u64,
     pub snapshot_rowid: u64,
@@ -67,7 +96,7 @@ pub struct BaseActivityPageCursor {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BaseActivityBurnPage {
-    pub burns: Vec<VerifiedBaseWithdrawalBurn>,
+    pub burns: Vec<PublicBaseWithdrawalBurn>,
     pub snapshot_rowid: u64,
 }
 
@@ -106,6 +135,17 @@ impl BaseActivityStore {
         records: Vec<VerifiedBaseWithdrawalBurn>,
         cursor: BaseActivityCursor,
     ) -> Result<u64, BridgeError> {
+        self.apply_verified_chunk_with_headers(records, Vec::new(), cursor, 0)
+            .await
+    }
+
+    pub async fn apply_verified_chunk_with_headers(
+        &self,
+        records: Vec<VerifiedBaseWithdrawalBurn>,
+        headers: Vec<BaseActivityHeaderCheckpoint>,
+        cursor: BaseActivityCursor,
+        retained_from_block: u64,
+    ) -> Result<u64, BridgeError> {
         self.with_conn(move |conn| {
             conn.immediate_transaction::<_, anyhow::Error, _>(|conn| {
                 let existing =
@@ -126,6 +166,30 @@ impl BaseActivityStore {
                     .map(|existing| existing.last_verified_block)
                     .unwrap_or_default()
                     .max(cursor.last_verified_block);
+                for header in &headers {
+                    if header.chain_id != cursor.chain_id
+                        || header.nock_contract_address != cursor.nock_contract_address
+                    {
+                        return Err(BridgeError::Runtime(format!(
+                            "Base header checkpoint {} does not belong to cursor chain/deployment",
+                            header.block_number
+                        ))
+                        .into());
+                    }
+                    if header.block_number > effective_ceiling {
+                        return Err(BridgeError::Runtime(format!(
+                            "Base header checkpoint {} exceeds verified cursor ceiling {}",
+                            header.block_number, effective_ceiling
+                        ))
+                        .into());
+                    }
+                    insert_header_checkpoint_checked(conn, header)?;
+                }
+                if !headers.is_empty() {
+                    prune_header_checkpoints_before(
+                        conn, cursor.chain_id, cursor.nock_contract_address, retained_from_block,
+                    )?;
+                }
                 let mut inserted = 0u64;
                 for record in &records {
                     if record.chain_id != cursor.chain_id
@@ -174,6 +238,18 @@ impl BaseActivityStore {
         })
         .await
     }
+    pub async fn load_public_burn(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        base_event_id: &BaseEventId,
+    ) -> Result<Option<PublicBaseWithdrawalBurn>, BridgeError> {
+        let base_event_id = base_event_id.clone();
+        self.with_conn(move |conn| {
+            load_public_burn_row(conn, chain_id, nock_contract_address, &base_event_id)
+        })
+        .await
+    }
 
     pub async fn load_verified_burn_by_tx_log(
         &self,
@@ -184,6 +260,20 @@ impl BaseActivityStore {
     ) -> Result<Option<VerifiedBaseWithdrawalBurn>, BridgeError> {
         self.with_conn(move |conn| {
             load_verified_burn_by_tx_log_row(
+                conn, chain_id, nock_contract_address, tx_hash, log_index,
+            )
+        })
+        .await
+    }
+    pub async fn load_public_burn_by_tx_log(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        tx_hash: B256,
+        log_index: u64,
+    ) -> Result<Option<PublicBaseWithdrawalBurn>, BridgeError> {
+        self.with_conn(move |conn| {
+            load_public_burn_by_tx_log_row(
                 conn, chain_id, nock_contract_address, tx_hash, log_index,
             )
         })
@@ -215,7 +305,19 @@ impl BaseActivityStore {
         .await
     }
 
-    pub async fn list_verified_burns_by_burner_page(
+    pub async fn list_public_burns_by_tx_hash(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        tx_hash: B256,
+    ) -> Result<Vec<PublicBaseWithdrawalBurn>, BridgeError> {
+        self.with_conn(move |conn| {
+            load_public_burn_rows_by_tx_hash(conn, chain_id, nock_contract_address, tx_hash)
+        })
+        .await
+    }
+
+    pub async fn list_public_burns_by_burner_page(
         &self,
         chain_id: u64,
         nock_contract_address: Address,
@@ -253,6 +355,21 @@ impl BaseActivityStore {
     ) -> Result<Option<BaseActivityCursor>, BridgeError> {
         self.with_conn(move |conn| load_cursor_row(conn, chain_id, nock_contract_address))
             .await
+    }
+
+    pub async fn load_header_checkpoints(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        start_block: u64,
+        end_block: u64,
+    ) -> Result<Vec<BaseActivityHeaderCheckpoint>, BridgeError> {
+        self.with_conn(move |conn| {
+            load_header_checkpoint_rows(
+                conn, chain_id, nock_contract_address, start_block, end_block,
+            )
+        })
+        .await
     }
 
     pub async fn advance_cursor(&self, cursor: BaseActivityCursor) -> Result<(), BridgeError> {
@@ -336,6 +453,10 @@ pub(crate) fn ensure_base_activity_schema(conn: &mut SqliteConnection) -> Result
             observed_at_unix_secs INTEGER,
             policy_id TEXT,
             protocol_id TEXT,
+            canonical INTEGER NOT NULL DEFAULT 1,
+            invalidated_at INTEGER,
+            invalidation_generation INTEGER,
+            invalidation_reason TEXT,
             PRIMARY KEY (chain_id, nock_contract_address, base_event_id)
         );
 
@@ -351,12 +472,67 @@ pub(crate) fn ensure_base_activity_schema(conn: &mut SqliteConnection) -> Result
             block_number DESC, log_index DESC, base_event_id DESC
           );
 
+
         CREATE TABLE IF NOT EXISTS sequencer_base_activity_cursor (
             chain_id INTEGER NOT NULL,
             nock_contract_address BLOB NOT NULL CHECK(length(nock_contract_address) = 20),
             last_verified_block INTEGER NOT NULL,
             last_verified_block_hash BLOB NOT NULL CHECK(length(last_verified_block_hash) = 32),
             updated_at INTEGER NOT NULL,
+            PRIMARY KEY (chain_id, nock_contract_address)
+        );
+
+        CREATE TABLE IF NOT EXISTS sequencer_base_header_checkpoints (
+            chain_id INTEGER NOT NULL,
+            nock_contract_address BLOB NOT NULL CHECK(length(nock_contract_address) = 20),
+            block_number INTEGER NOT NULL,
+            block_hash BLOB NOT NULL CHECK(length(block_hash) = 32),
+            parent_hash BLOB NOT NULL CHECK(length(parent_hash) = 32),
+            block_timestamp INTEGER NOT NULL,
+            verified_at INTEGER NOT NULL,
+            PRIMARY KEY (chain_id, nock_contract_address, block_number)
+        );
+
+        CREATE TABLE IF NOT EXISTS sequencer_base_reorg_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chain_id INTEGER NOT NULL,
+            nock_contract_address BLOB NOT NULL CHECK(length(nock_contract_address) = 20),
+            generation INTEGER NOT NULL,
+            detected_at INTEGER NOT NULL,
+            old_cursor_block INTEGER NOT NULL,
+            old_cursor_hash BLOB NOT NULL CHECK(length(old_cursor_hash) = 32),
+            common_ancestor_block INTEGER,
+            common_ancestor_hash BLOB,
+            canonical_tip_block INTEGER NOT NULL,
+            canonical_tip_hash BLOB NOT NULL CHECK(length(canonical_tip_hash) = 32),
+            rewind_depth INTEGER,
+            outcome TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            UNIQUE (chain_id, nock_contract_address, generation)
+        );
+
+        CREATE TABLE IF NOT EXISTS sequencer_base_burn_invalidations (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chain_id INTEGER NOT NULL,
+            nock_contract_address BLOB NOT NULL CHECK(length(nock_contract_address) = 20),
+            generation INTEGER NOT NULL,
+            base_event_id BLOB NOT NULL CHECK(length(base_event_id) = 32),
+            old_block_number INTEGER NOT NULL,
+            old_block_hash BLOB NOT NULL CHECK(length(old_block_hash) = 32),
+            lifecycle_state TEXT,
+            invalidated_at INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            UNIQUE (
+                chain_id, nock_contract_address, generation, base_event_id
+            )
+        );
+
+        CREATE TABLE IF NOT EXISTS sequencer_base_reorg_guard (
+            chain_id INTEGER NOT NULL,
+            nock_contract_address BLOB NOT NULL CHECK(length(nock_contract_address) = 20),
+            generation INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
             PRIMARY KEY (chain_id, nock_contract_address)
         );
 
@@ -378,6 +554,23 @@ pub(crate) fn ensure_base_activity_schema(conn: &mut SqliteConnection) -> Result
     ensure_base_activity_column(conn, "policy_id", "TEXT")?;
     ensure_base_activity_column(conn, "protocol_id", "TEXT")?;
     ensure_base_incident_schema(conn)?;
+    ensure_base_activity_column(conn, "canonical", "INTEGER NOT NULL DEFAULT 1")?;
+    ensure_base_activity_column(conn, "invalidated_at", "INTEGER")?;
+    ensure_base_activity_column(conn, "invalidation_generation", "INTEGER")?;
+    ensure_base_activity_column(conn, "invalidation_reason", "TEXT")?;
+    conn.batch_execute(
+        r#"
+        CREATE INDEX IF NOT EXISTS sequencer_base_burns_by_canonical_block
+          ON sequencer_base_burns(
+            chain_id, nock_contract_address, canonical, block_number
+          );
+        "#,
+    )
+    .map_err(|error| {
+        BridgeError::Runtime(format!(
+            "Base activity canonical index migration failed: {error}"
+        ))
+    })?;
     Ok(())
 }
 
@@ -414,6 +607,22 @@ fn insert_verified_burn_checked(
     conn: &mut SqliteConnection,
     record: &VerifiedBaseWithdrawalBurn,
 ) -> Result<bool, BridgeError> {
+    let reactivated = diesel::sql_query(
+        r#"
+        DELETE FROM sequencer_base_burns
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND base_event_id = ? AND canonical = 0
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(record.chain_id, "chain_id")?)
+    .bind::<Binary, _>(record.nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(record.base_event_id.0.clone())
+    .execute(conn)
+    .map_err(|error| {
+        BridgeError::Runtime(format!(
+            "invalidated Base burn projection cleanup failed: {error}"
+        ))
+    })?;
     let inserted = insert_verified_burn_row(conn, record)?;
     backfill_verified_burn_public_metadata(conn, record)?;
     let mut stored = load_verified_burn_row(
@@ -433,7 +642,7 @@ fn insert_verified_burn_checked(
             record.base_event_id
         )));
     }
-    Ok(inserted)
+    Ok(inserted || reactivated == 1)
 }
 
 fn backfill_verified_burn_public_metadata(
@@ -509,6 +718,14 @@ struct BaseBurnSqlRow {
     policy_id: Option<String>,
     #[diesel(sql_type = Nullable<Text>)]
     protocol_id: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    canonical: i64,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    invalidated_at: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    invalidation_generation: Option<i64>,
+    #[diesel(sql_type = Nullable<Text>)]
+    invalidation_reason: Option<String>,
 }
 
 impl TryFrom<BaseBurnSqlRow> for VerifiedBaseWithdrawalBurn {
@@ -555,6 +772,32 @@ impl TryFrom<BaseBurnSqlRow> for VerifiedBaseWithdrawalBurn {
         })
     }
 }
+impl BaseBurnSqlRow {
+    fn into_public(self) -> Result<PublicBaseWithdrawalBurn, BridgeError> {
+        let canonical = match self.canonical {
+            0 => false,
+            1 => true,
+            value => {
+                return Err(BridgeError::Runtime(format!(
+                    "invalid Base activity canonical flag: {value}"
+                )));
+            }
+        };
+        let invalidated_at = self.invalidated_at;
+        let invalidation_generation = self
+            .invalidation_generation
+            .map(|value| i64_to_u64(value, "invalidation_generation"))
+            .transpose()?;
+        let invalidation_reason = self.invalidation_reason.clone();
+        Ok(PublicBaseWithdrawalBurn {
+            burn: self.try_into()?,
+            canonical,
+            invalidated_at,
+            invalidation_generation,
+            invalidation_reason,
+        })
+    }
+}
 
 #[derive(QueryableByName)]
 struct BaseActivityCursorSqlRow {
@@ -584,6 +827,42 @@ impl TryFrom<BaseActivityCursorSqlRow> for BaseActivityCursor {
                 &row.last_verified_block_hash, "last_verified_block_hash",
             )?),
             updated_at: row.updated_at,
+        })
+    }
+}
+
+#[derive(QueryableByName)]
+struct BaseActivityHeaderCheckpointSqlRow {
+    #[diesel(sql_type = BigInt)]
+    chain_id: i64,
+    #[diesel(sql_type = Binary)]
+    nock_contract_address: Vec<u8>,
+    #[diesel(sql_type = BigInt)]
+    block_number: i64,
+    #[diesel(sql_type = Binary)]
+    block_hash: Vec<u8>,
+    #[diesel(sql_type = Binary)]
+    parent_hash: Vec<u8>,
+    #[diesel(sql_type = BigInt)]
+    block_timestamp: i64,
+    #[diesel(sql_type = BigInt)]
+    verified_at: i64,
+}
+
+impl TryFrom<BaseActivityHeaderCheckpointSqlRow> for BaseActivityHeaderCheckpoint {
+    type Error = BridgeError;
+
+    fn try_from(row: BaseActivityHeaderCheckpointSqlRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            chain_id: i64_to_u64(row.chain_id, "chain_id")?,
+            nock_contract_address: address_from_bytes(
+                &row.nock_contract_address, "nock_contract_address",
+            )?,
+            block_number: i64_to_u64(row.block_number, "block_number")?,
+            block_hash: B256::from(fixed_bytes::<32>(&row.block_hash, "block_hash")?),
+            parent_hash: B256::from(fixed_bytes::<32>(&row.parent_hash, "parent_hash")?),
+            block_timestamp: i64_to_u64(row.block_timestamp, "block_timestamp")?,
+            verified_at: row.verified_at,
         })
     }
 }
@@ -650,9 +929,11 @@ fn load_verified_burn_row(
                block_hash, parent_hash, observed_at_unix_secs,
                tx_hash, tx_index, log_index, burner,
                amount_base_units, amount_nicks, lock_root, calldata,
-               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
         FROM sequencer_base_burns
         WHERE chain_id = ? AND nock_contract_address = ? AND base_event_id = ?
+          AND canonical = 1
         "#,
     )
     .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
@@ -662,6 +943,34 @@ fn load_verified_burn_row(
     .optional()
     .map_err(|error| BridgeError::Runtime(format!("Base activity burn load failed: {error}")))?
     .map(TryInto::try_into)
+    .transpose()
+}
+
+fn load_public_burn_row(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    base_event_id: &BaseEventId,
+) -> Result<Option<PublicBaseWithdrawalBurn>, BridgeError> {
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, base_event_id, block_number,
+               block_hash, parent_hash, observed_at_unix_secs,
+               tx_hash, tx_index, log_index, burner,
+               amount_base_units, amount_nicks, lock_root, calldata,
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
+        FROM sequencer_base_burns
+        WHERE chain_id = ? AND nock_contract_address = ? AND base_event_id = ?
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(base_event_id.0.clone())
+    .get_result::<BaseBurnSqlRow>(conn)
+    .optional()
+    .map_err(|error| BridgeError::Runtime(format!("public Base burn load failed: {error}")))?
+    .map(BaseBurnSqlRow::into_public)
     .transpose()
 }
 
@@ -678,7 +987,39 @@ fn load_verified_burn_by_tx_log_row(
                block_hash, parent_hash, observed_at_unix_secs,
                tx_hash, tx_index, log_index, burner,
                amount_base_units, amount_nicks, lock_root, calldata,
-               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
+        FROM sequencer_base_burns
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND tx_hash = ? AND log_index = ? AND canonical = 1
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(tx_hash.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(log_index, "log_index")?)
+    .get_result::<BaseBurnSqlRow>(conn)
+    .optional()
+    .map_err(|error| BridgeError::Runtime(format!("Base activity tx/log lookup failed: {error}")))?
+    .map(TryInto::try_into)
+    .transpose()
+}
+
+fn load_public_burn_by_tx_log_row(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    tx_hash: B256,
+    log_index: u64,
+) -> Result<Option<PublicBaseWithdrawalBurn>, BridgeError> {
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, base_event_id, block_number,
+               block_hash, parent_hash, observed_at_unix_secs,
+               tx_hash, tx_index, log_index, burner,
+               amount_base_units, amount_nicks, lock_root, calldata,
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
         FROM sequencer_base_burns
         WHERE chain_id = ? AND nock_contract_address = ?
           AND tx_hash = ? AND log_index = ?
@@ -690,8 +1031,8 @@ fn load_verified_burn_by_tx_log_row(
     .bind::<BigInt, _>(u64_to_i64(log_index, "log_index")?)
     .get_result::<BaseBurnSqlRow>(conn)
     .optional()
-    .map_err(|error| BridgeError::Runtime(format!("Base activity tx/log lookup failed: {error}")))?
-    .map(TryInto::try_into)
+    .map_err(|error| BridgeError::Runtime(format!("public Base tx/log lookup failed: {error}")))?
+    .map(BaseBurnSqlRow::into_public)
     .transpose()
 }
 
@@ -707,9 +1048,11 @@ fn load_verified_burn_rows_by_tx_hash(
                block_hash, parent_hash, observed_at_unix_secs,
                tx_hash, tx_index, log_index, burner,
                amount_base_units, amount_nicks, lock_root, calldata,
-               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
         FROM sequencer_base_burns
         WHERE chain_id = ? AND nock_contract_address = ? AND tx_hash = ?
+          AND canonical = 1
         ORDER BY log_index ASC
         "#,
     )
@@ -720,6 +1063,34 @@ fn load_verified_burn_rows_by_tx_hash(
     .map_err(|error| BridgeError::Runtime(format!("Base activity tx list failed: {error}")))?
     .into_iter()
     .map(TryInto::try_into)
+    .collect()
+}
+fn load_public_burn_rows_by_tx_hash(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    tx_hash: B256,
+) -> Result<Vec<PublicBaseWithdrawalBurn>, BridgeError> {
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, base_event_id, block_number,
+               block_hash, parent_hash, observed_at_unix_secs,
+               tx_hash, tx_index, log_index, burner,
+               amount_base_units, amount_nicks, lock_root, calldata,
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
+        FROM sequencer_base_burns
+        WHERE chain_id = ? AND nock_contract_address = ? AND tx_hash = ?
+        ORDER BY log_index ASC
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(tx_hash.as_slice().to_vec())
+    .load::<BaseBurnSqlRow>(conn)
+    .map_err(|error| BridgeError::Runtime(format!("public Base tx list failed: {error}")))?
+    .into_iter()
+    .map(BaseBurnSqlRow::into_public)
     .collect()
 }
 
@@ -736,9 +1107,11 @@ fn load_verified_burn_rows_by_burner(
                block_hash, parent_hash, observed_at_unix_secs,
                tx_hash, tx_index, log_index, burner,
                amount_base_units, amount_nicks, lock_root, calldata,
-               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
         FROM sequencer_base_burns
         WHERE chain_id = ? AND nock_contract_address = ? AND burner = ?
+          AND canonical = 1
         ORDER BY block_number DESC, log_index DESC, base_event_id DESC
         LIMIT ?
         "#,
@@ -802,7 +1175,8 @@ fn load_verified_burn_page_by_burner(
                    block_hash, parent_hash, observed_at_unix_secs,
                    tx_hash, tx_index, log_index, burner,
                    amount_base_units, amount_nicks, lock_root, calldata,
-                   base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+                   base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+                   canonical, invalidated_at, invalidation_generation, invalidation_reason
             FROM sequencer_base_burns
             WHERE chain_id = ? AND nock_contract_address = ? AND burner = ?
               AND rowid <= ?
@@ -833,7 +1207,8 @@ fn load_verified_burn_page_by_burner(
                    block_hash, parent_hash, observed_at_unix_secs,
                    tx_hash, tx_index, log_index, burner,
                    amount_base_units, amount_nicks, lock_root, calldata,
-                   base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+                   base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+                   canonical, invalidated_at, invalidation_generation, invalidation_reason
             FROM sequencer_base_burns
             WHERE chain_id = ? AND nock_contract_address = ? AND burner = ?
               AND rowid <= ?
@@ -854,7 +1229,7 @@ fn load_verified_burn_page_by_burner(
     Ok(BaseActivityBurnPage {
         burns: rows
             .into_iter()
-            .map(TryInto::try_into)
+            .map(BaseBurnSqlRow::into_public)
             .collect::<Result<Vec<_>, BridgeError>>()?,
         snapshot_rowid,
     })
@@ -872,11 +1247,13 @@ fn load_unmapped_verified_burn_rows(
                block_hash, parent_hash, observed_at_unix_secs,
                tx_hash, tx_index, log_index, burner,
                amount_base_units, amount_nicks, lock_root, calldata,
-               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id
+               base_batch_end, withdrawal_nonce, verified_at, policy_id, protocol_id,
+               canonical, invalidated_at, invalidation_generation, invalidation_reason
         FROM sequencer_base_burns
         WHERE chain_id = ?
           AND nock_contract_address = ?
           AND block_number >= ?
+          AND canonical = 1
           AND withdrawal_nonce IS NULL
         ORDER BY base_batch_end ASC, base_event_id ASC
         "#,
@@ -921,6 +1298,7 @@ pub(crate) fn assign_withdrawal_nonce(
         UPDATE sequencer_base_burns
         SET withdrawal_nonce = ?
         WHERE chain_id = ? AND nock_contract_address = ? AND base_event_id = ?
+          AND canonical = 1
         "#,
     )
     .bind::<BigInt, _>(u64_to_i64(withdrawal_nonce, "withdrawal_nonce")?)
@@ -949,6 +1327,110 @@ pub(crate) fn load_activity_cursor_for_reconciliation(
     nock_contract_address: Address,
 ) -> Result<Option<BaseActivityCursor>, BridgeError> {
     load_cursor_row(conn, chain_id, nock_contract_address)
+}
+
+fn insert_header_checkpoint_checked(
+    conn: &mut SqliteConnection,
+    checkpoint: &BaseActivityHeaderCheckpoint,
+) -> Result<(), BridgeError> {
+    diesel::sql_query(
+        r#"
+        INSERT OR IGNORE INTO sequencer_base_header_checkpoints (
+            chain_id, nock_contract_address, block_number, block_hash,
+            parent_hash, block_timestamp, verified_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(checkpoint.chain_id, "chain_id")?)
+    .bind::<Binary, _>(checkpoint.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(checkpoint.block_number, "block_number")?)
+    .bind::<Binary, _>(checkpoint.block_hash.as_slice().to_vec())
+    .bind::<Binary, _>(checkpoint.parent_hash.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(checkpoint.block_timestamp, "block_timestamp")?)
+    .bind::<BigInt, _>(checkpoint.verified_at)
+    .execute(conn)
+    .map_err(|error| {
+        BridgeError::Runtime(format!("Base header checkpoint insert failed: {error}"))
+    })?;
+    let stored: BaseActivityHeaderCheckpoint = diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, block_number, block_hash,
+               parent_hash, block_timestamp, verified_at
+        FROM sequencer_base_header_checkpoints
+        WHERE chain_id = ? AND nock_contract_address = ? AND block_number = ?
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(checkpoint.chain_id, "chain_id")?)
+    .bind::<Binary, _>(checkpoint.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(checkpoint.block_number, "block_number")?)
+    .get_result::<BaseActivityHeaderCheckpointSqlRow>(conn)
+    .map_err(|error| {
+        BridgeError::Runtime(format!("Base header checkpoint reload failed: {error}"))
+    })?
+    .try_into()?;
+    if stored.block_hash != checkpoint.block_hash
+        || stored.parent_hash != checkpoint.parent_hash
+        || stored.block_timestamp != checkpoint.block_timestamp
+    {
+        return Err(BridgeError::Runtime(format!(
+            "conflicting Base header checkpoint at block {}: stored {:?}, canonical {:?}",
+            checkpoint.block_number, stored.block_hash, checkpoint.block_hash
+        )));
+    }
+    Ok(())
+}
+
+fn load_header_checkpoint_rows(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    start_block: u64,
+    end_block: u64,
+) -> Result<Vec<BaseActivityHeaderCheckpoint>, BridgeError> {
+    if end_block < start_block {
+        return Ok(Vec::new());
+    }
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, block_number, block_hash,
+               parent_hash, block_timestamp, verified_at
+        FROM sequencer_base_header_checkpoints
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND block_number BETWEEN ? AND ?
+        ORDER BY block_number ASC
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(start_block, "start_block")?)
+    .bind::<BigInt, _>(u64_to_i64(end_block, "end_block")?)
+    .load::<BaseActivityHeaderCheckpointSqlRow>(conn)
+    .map_err(|error| BridgeError::Runtime(format!("Base header checkpoint load failed: {error}")))?
+    .into_iter()
+    .map(TryInto::try_into)
+    .collect()
+}
+
+fn prune_header_checkpoints_before(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    retained_from_block: u64,
+) -> Result<(), BridgeError> {
+    diesel::sql_query(
+        r#"
+        DELETE FROM sequencer_base_header_checkpoints
+        WHERE chain_id = ? AND nock_contract_address = ? AND block_number < ?
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(u64_to_i64(retained_from_block, "retained_from_block")?)
+    .execute(conn)
+    .map_err(|error| {
+        BridgeError::Runtime(format!("Base header checkpoint pruning failed: {error}"))
+    })?;
+    Ok(())
 }
 
 fn load_cursor_row(

--- a/crates/bridge/src/withdrawal/sequencer/base_incidents.rs
+++ b/crates/bridge/src/withdrawal/sequencer/base_incidents.rs
@@ -117,6 +117,18 @@ impl BaseIncidentStore {
         })
         .await
     }
+    pub async fn list_rejected_burns_by_burner(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        burner: Address,
+        limit: u32,
+    ) -> Result<Vec<RejectedBaseWithdrawalBurn>, BridgeError> {
+        self.with_conn(move |conn| {
+            load_rejected_burn_rows_by_burner(conn, chain_id, nock_contract_address, burner, limit)
+        })
+        .await
+    }
 
     pub async fn record_compensated_withdrawals(
         &self,
@@ -163,6 +175,19 @@ impl BaseIncidentStore {
         self.with_conn(move |conn| {
             load_compensated_withdrawal_by_tx_log_row(
                 conn, chain_id, nock_contract_address, tx_hash, log_index,
+            )
+        })
+        .await
+    }
+    pub async fn list_compensated_withdrawals_by_tx_hash(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        tx_hash: B256,
+    ) -> Result<Vec<CompensatedBaseWithdrawal>, BridgeError> {
+        self.with_conn(move |conn| {
+            load_compensated_withdrawal_rows_by_tx_hash(
+                conn, chain_id, nock_contract_address, tx_hash,
             )
         })
         .await
@@ -572,6 +597,37 @@ fn load_rejected_burn_rows_by_tx_hash(
     .map(TryInto::try_into)
     .collect()
 }
+fn load_rejected_burn_rows_by_burner(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    burner: Address,
+    limit: u32,
+) -> Result<Vec<RejectedBaseWithdrawalBurn>, BridgeError> {
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, base_event_id,
+               block_number, block_hash, parent_hash, observed_at_unix_secs,
+               tx_hash, tx_index, log_index, burner, amount_base_units,
+               commitment, calldata, rejection_code, rejection_detail,
+               first_observed_at, last_observed_at
+        FROM sequencer_base_burn_rejections
+        WHERE chain_id = ? AND nock_contract_address = ? AND burner = ?
+          AND canonical = 1
+        ORDER BY block_number DESC, log_index DESC, base_event_id DESC
+        LIMIT ?
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(burner.as_slice().to_vec())
+    .bind::<BigInt, _>(i64::from(limit))
+    .load::<RejectedBurnSqlRow>(conn)
+    .map_err(|error| BridgeError::Runtime(format!("Base rejection history failed: {error}")))?
+    .into_iter()
+    .map(TryInto::try_into)
+    .collect()
+}
 
 #[derive(QueryableByName)]
 struct CountRow {
@@ -730,6 +786,33 @@ fn load_compensated_withdrawal_by_tx_log_row(
     })?
     .map(TryInto::try_into)
     .transpose()
+}
+
+fn load_compensated_withdrawal_rows_by_tx_hash(
+    conn: &mut SqliteConnection,
+    chain_id: u64,
+    nock_contract_address: Address,
+    tx_hash: B256,
+) -> Result<Vec<CompensatedBaseWithdrawal>, BridgeError> {
+    diesel::sql_query(
+        r#"
+        SELECT chain_id, nock_contract_address, base_event_id,
+               tx_hash, log_index, reason, evidence_reference, recorded_at
+        FROM sequencer_compensated_withdrawals
+        WHERE chain_id = ? AND nock_contract_address = ? AND tx_hash = ?
+        ORDER BY log_index ASC
+        "#,
+    )
+    .bind::<BigInt, _>(u64_to_i64(chain_id, "chain_id")?)
+    .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+    .bind::<Binary, _>(tx_hash.as_slice().to_vec())
+    .load::<CompensatedWithdrawalSqlRow>(conn)
+    .map_err(|error| {
+        BridgeError::Runtime(format!("compensated withdrawal tx list failed: {error}"))
+    })?
+    .into_iter()
+    .map(TryInto::try_into)
+    .collect()
 }
 
 fn load_compensated_withdrawal_rows(

--- a/crates/bridge/src/withdrawal/sequencer/base_verifier.rs
+++ b/crates/bridge/src/withdrawal/sequencer/base_verifier.rs
@@ -15,15 +15,17 @@ use tracing::{info, info_span, warn, Instrument};
 
 use crate::core::loop_policy::BaseObserverLoopPolicy;
 use crate::shared::base::{
-    burn_for_withdrawal_signature_hash, compute_base_event_id, decode_burn_for_withdrawal_event,
-    decode_burn_for_withdrawal_log_with_calldata, fetch_base_block_info, validate_base_chain_id,
-    validate_base_log_block_hash, BurnForWithdrawalDecodeError,
+    base_automatic_reorg_rewind_depth, burn_for_withdrawal_signature_hash, compute_base_event_id,
+    decode_burn_for_withdrawal_event, decode_burn_for_withdrawal_log_with_calldata,
+    fetch_base_block_info, validate_base_chain_id, validate_base_log_block_hash,
+    BurnForWithdrawalDecodeError,
 };
 use crate::shared::errors::BridgeError;
 use crate::shared::types::{BaseEventId, WITHDRAWAL_POLICY_V1_ID, WITHDRAWAL_WIRE_V1_ID};
 use crate::withdrawal::proposals::TrackedWithdrawalRequest;
 use crate::withdrawal::sequencer::base_activity::{
-    current_unix_timestamp_secs, BaseActivityCursor, BaseActivityStore, VerifiedBaseWithdrawalBurn,
+    current_unix_timestamp_secs, BaseActivityCursor, BaseActivityHeaderCheckpoint,
+    BaseActivityReorgPlan, BaseActivityStore, VerifiedBaseWithdrawalBurn,
 };
 use crate::withdrawal::sequencer::base_height::SequencerBaseHeightTracker;
 use crate::withdrawal::sequencer::base_incidents::RejectedBaseWithdrawalBurn;
@@ -228,6 +230,7 @@ pub struct SequencerBaseRpcWithdrawalVerifier {
     base_start_height: u64,
     base_height_tracker: Arc<SequencerBaseHeightTracker>,
     base_blocks_chunk: u64,
+    automatic_rewind_depth: u64,
     nock_contract_address: Address,
     log_source: Arc<dyn SequencerBaseLogSource>,
 }
@@ -240,6 +243,7 @@ impl SequencerBaseRpcWithdrawalVerifier {
         base_height_tracker: Arc<SequencerBaseHeightTracker>,
         base_start_height: u64,
         base_blocks_chunk: u64,
+        base_confirmation_depth: u64,
     ) -> Result<Self, BridgeError> {
         if base_blocks_chunk == 0 {
             return Err(BridgeError::Config(
@@ -270,7 +274,7 @@ impl SequencerBaseRpcWithdrawalVerifier {
                 ))
             })?;
         validate_base_chain_id(&provider, expected_chain_id, "sequencer Base verifier").await?;
-        Ok(Self::with_log_source(
+        let mut verifier = Self::with_log_source(
             expected_chain_id,
             base_start_height,
             base_height_tracker,
@@ -280,7 +284,10 @@ impl SequencerBaseRpcWithdrawalVerifier {
                 provider,
                 nock_contract_address,
             }),
-        ))
+        );
+        verifier.automatic_rewind_depth =
+            base_automatic_reorg_rewind_depth(base_confirmation_depth);
+        Ok(verifier)
     }
 
     fn with_log_source(
@@ -296,6 +303,7 @@ impl SequencerBaseRpcWithdrawalVerifier {
             base_start_height,
             base_height_tracker,
             base_blocks_chunk,
+            automatic_rewind_depth: crate::shared::base::BASE_MAX_AUTOMATIC_REORG_REWIND_BLOCKS,
             nock_contract_address,
             log_source,
         }
@@ -375,11 +383,11 @@ impl SequencerBaseRpcWithdrawalVerifier {
         let verified_at = current_unix_timestamp_secs()?;
         let mut pending_records = Vec::new();
         let mut pending_rejections = Vec::new();
+        let mut pending_headers = Vec::new();
         let mut chunk_start = scan_start;
         while chunk_start <= confirmed_tip {
             let chunk_end = chunk_start
-                .checked_add(self.base_blocks_chunk.saturating_sub(1))
-                .unwrap_or(u64::MAX)
+                .saturating_add(self.base_blocks_chunk.saturating_sub(1))
                 .min(confirmed_tip);
             let chunk = self
                 .log_source
@@ -388,6 +396,17 @@ impl SequencerBaseRpcWithdrawalVerifier {
             validate_activity_chunk_headers(
                 &chunk, chunk_start, chunk_end, previous_chunk_end_hash,
             )?;
+            pending_headers.extend(chunk.headers.iter().map(|header| {
+                BaseActivityHeaderCheckpoint {
+                    chain_id: self.chain_id,
+                    nock_contract_address: self.nock_contract_address,
+                    block_number: header.number,
+                    block_hash: header.hash,
+                    parent_hash: header.parent_hash,
+                    block_timestamp: header.timestamp,
+                    verified_at,
+                }
+            }));
             if let Some(cursor) = &existing_cursor {
                 if cursor.last_verified_block >= chunk_start
                     && cursor.last_verified_block <= chunk_end
@@ -446,9 +465,18 @@ impl SequencerBaseRpcWithdrawalVerifier {
                         .record_rejected_burns(std::mem::take(&mut pending_rejections))
                         .await?,
                 );
+                let retained_from_block = cursor
+                    .last_verified_block
+                    .saturating_sub(self.automatic_rewind_depth)
+                    .max(self.base_start_height);
                 report.burns_inserted = report.burns_inserted.saturating_add(
                     store
-                        .apply_verified_chunk(std::mem::take(&mut pending_records), cursor)
+                        .apply_verified_chunk_with_headers(
+                            std::mem::take(&mut pending_records),
+                            std::mem::take(&mut pending_headers),
+                            cursor,
+                            retained_from_block,
+                        )
                         .await?,
                 );
             }
@@ -586,6 +614,133 @@ impl SequencerBaseRpcWithdrawalVerifier {
         }))
     }
 
+    async fn plan_confirmed_activity_reorg(
+        &self,
+        store: &BaseActivityStore,
+        activation_block: u64,
+    ) -> Result<Option<BaseActivityReorgPlan>, BridgeError> {
+        let Some(cursor) = store
+            .load_cursor(self.chain_id, self.nock_contract_address)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let checkpoint_start = cursor
+            .last_verified_block
+            .saturating_sub(self.automatic_rewind_depth)
+            .max(self.base_start_height);
+        let checkpoints = store
+            .load_header_checkpoints(
+                self.chain_id, self.nock_contract_address, checkpoint_start,
+                cursor.last_verified_block,
+            )
+            .await?;
+        if checkpoints.is_empty() {
+            // Legacy cursors acquire a bounded checkpoint window on their next
+            // successful overlap scan. Until then the existing fail-closed
+            // cursor comparison remains authoritative.
+            return Ok(None);
+        }
+        let (Some(oldest), Some(newest)) = (checkpoints.first(), checkpoints.last()) else {
+            return Ok(None);
+        };
+        if newest.block_number != cursor.last_verified_block
+            || newest.block_hash != cursor.last_verified_block_hash
+        {
+            return Err(BridgeError::Runtime(format!(
+                "Base reorg checkpoint/cursor mismatch: cursor {} {:?}, newest checkpoint {} {:?}",
+                cursor.last_verified_block,
+                cursor.last_verified_block_hash,
+                newest.block_number,
+                newest.block_hash
+            )));
+        }
+        let confirmed_tip = self
+            .base_height_tracker
+            .latest_confirmed_base_height()
+            .ok_or_else(|| {
+                BridgeError::Runtime("confirmed Base height unavailable for reorg planning".into())
+            })?;
+        if confirmed_tip < cursor.last_verified_block {
+            return Err(BridgeError::BaseBridgeMonitoring(format!(
+                "deep Base reorg: confirmed tip {confirmed_tip} is behind cursor {} {:?}; retained checkpoint range {}..={} max_depth={}",
+                cursor.last_verified_block,
+                cursor.last_verified_block_hash,
+                oldest.block_number,
+                newest.block_number,
+                self.automatic_rewind_depth
+            )));
+        }
+        let canonical = self
+            .log_source
+            .burn_log_chunk(checkpoint_start, cursor.last_verified_block)
+            .await?;
+        validate_activity_chunk_headers(
+            &canonical, checkpoint_start, cursor.last_verified_block, None,
+        )?;
+        let canonical_cursor = header_at(&canonical, cursor.last_verified_block)?;
+        if canonical_cursor.hash == cursor.last_verified_block_hash {
+            return Ok(None);
+        }
+        let common_ancestor = checkpoints.iter().rev().find_map(|checkpoint| {
+            let canonical_header = header_at(&canonical, checkpoint.block_number).ok()?;
+            (canonical_header.hash == checkpoint.block_hash).then_some(checkpoint.clone())
+        });
+        let Some(common_ancestor) = common_ancestor else {
+            return Err(BridgeError::BaseBridgeMonitoring(format!(
+                "deep Base reorg: no common ancestor in retained checkpoint range {}..={}; cursor_hash={:?} canonical_cursor_hash={:?} max_depth={} activation_block={activation_block}",
+                oldest.block_number,
+                newest.block_number,
+                cursor.last_verified_block_hash,
+                canonical_cursor.hash,
+                self.automatic_rewind_depth
+            )));
+        };
+        let rewind_depth = cursor
+            .last_verified_block
+            .saturating_sub(common_ancestor.block_number);
+        if rewind_depth > self.automatic_rewind_depth {
+            return Err(BridgeError::BaseBridgeMonitoring(format!(
+                "deep Base reorg: cursor={} ancestor={} depth={} exceeds max_depth={}; cursor_hash={:?} ancestor_hash={:?}",
+                cursor.last_verified_block,
+                common_ancestor.block_number,
+                rewind_depth,
+                self.automatic_rewind_depth,
+                cursor.last_verified_block_hash,
+                common_ancestor.block_hash
+            )));
+        }
+        if common_ancestor.block_number < activation_block
+            && cursor.last_verified_block >= activation_block
+        {
+            return Err(BridgeError::BaseBridgeMonitoring(format!(
+                "Base reorg crosses withdrawal activation boundary: cursor={} ancestor={} activation_block={} depth={}",
+                cursor.last_verified_block,
+                common_ancestor.block_number,
+                activation_block,
+                rewind_depth
+            )));
+        }
+        let detected_at = current_unix_timestamp_secs()?;
+        Ok(Some(BaseActivityReorgPlan {
+            chain_id: self.chain_id,
+            nock_contract_address: self.nock_contract_address,
+            old_cursor: cursor,
+            common_ancestor,
+            canonical_cursor_header: BaseActivityHeaderCheckpoint {
+                chain_id: self.chain_id,
+                nock_contract_address: self.nock_contract_address,
+                block_number: canonical_cursor.number,
+                block_hash: canonical_cursor.hash,
+                parent_hash: canonical_cursor.parent_hash,
+                block_timestamp: canonical_cursor.timestamp,
+                verified_at: detected_at,
+            },
+            rewind_depth,
+            detected_at,
+        }))
+    }
+
     pub async fn scan_and_recover_confirmed_burns(
         &self,
         activity_store: &BaseActivityStore,
@@ -593,6 +748,42 @@ impl SequencerBaseRpcWithdrawalVerifier {
         overlap_blocks: u64,
         activation_block: u64,
     ) -> Result<SequencerBaseRecoveryPassReport, BridgeError> {
+        sequencer_store.ensure_reorg_ready().await?;
+        let plan = match self
+            .plan_confirmed_activity_reorg(activity_store, activation_block)
+            .await
+        {
+            Ok(plan) => plan,
+            Err(error)
+                if error
+                    .to_string()
+                    .to_ascii_lowercase()
+                    .contains("base reorg") =>
+            {
+                sequencer_store
+                    .activate_base_reorg_guard(
+                        self.chain_id,
+                        self.nock_contract_address,
+                        error.to_string(),
+                    )
+                    .await?;
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
+        if let Some(plan) = plan {
+            let report = sequencer_store.apply_base_activity_reorg(plan).await?;
+            warn!(
+                target: "nockchain.withdrawal_sequencer.base_activity",
+                generation = report.generation,
+                old_cursor_block = report.old_cursor_block,
+                common_ancestor_block = report.common_ancestor_block,
+                rewind_depth = report.rewind_depth,
+                burns_invalidated = report.burns_invalidated,
+                lifecycle_rows_invalidated = report.lifecycle_rows_invalidated,
+                "completed bounded Base activity rewind"
+            );
+        }
         let scan = self
             .scan_confirmed_burn_tail(activity_store, overlap_blocks)
             .await?;
@@ -1023,6 +1214,7 @@ mod tests {
         error: Mutex<Option<String>>,
         requests: Mutex<Vec<(u64, u64)>>,
         header_hash_offset: Mutex<u64>,
+        fork_from: Mutex<Option<u64>>,
         omitted_header: Mutex<Option<u64>>,
         filter_logs_to_range: bool,
     }
@@ -1045,17 +1237,31 @@ mod tests {
                 .header_hash_offset
                 .lock()
                 .expect("mock header offset lock");
+            let fork_from = *self.fork_from.lock().expect("mock fork start lock");
             let omitted_header = *self
                 .omitted_header
                 .lock()
                 .expect("mock omitted header lock");
             let headers = (batch_start..=batch_end)
                 .filter(|number| Some(*number) != omitted_header)
-                .map(|number| SequencerBaseHeader {
-                    number,
-                    hash: mock_block_hash(number, offset),
-                    parent_hash: mock_block_hash(number.saturating_sub(1), offset),
-                    timestamp: 1_700_000_000u64.saturating_add(number),
+                .map(|number| {
+                    let hash_offset = if fork_from.is_some_and(|fork| number >= fork) {
+                        offset
+                    } else {
+                        0
+                    };
+                    let parent_number = number.saturating_sub(1);
+                    let parent_offset = if fork_from.is_some_and(|fork| parent_number >= fork) {
+                        offset
+                    } else {
+                        0
+                    };
+                    SequencerBaseHeader {
+                        number,
+                        hash: mock_block_hash(number, hash_offset),
+                        parent_hash: mock_block_hash(parent_number, parent_offset),
+                        timestamp: 1_700_000_000u64.saturating_add(number),
+                    }
                 })
                 .collect();
             let logs = self.logs.lock().expect("mock logs lock");
@@ -1085,6 +1291,7 @@ mod tests {
             error: Mutex::new(None),
             requests: Mutex::new(Vec::new()),
             header_hash_offset: Mutex::new(0),
+            fork_from: Mutex::new(Some(0)),
             omitted_header: Mutex::new(None),
             filter_logs_to_range,
         })
@@ -1733,5 +1940,186 @@ mod tests {
             .expect("idempotent scan and recovery");
         assert_eq!(second.scan.burns_inserted, 0);
         assert_eq!(second.recovery, BaseBurnRecoveryReport::default());
+    }
+    #[tokio::test]
+    async fn shallow_base_reorg_invalidates_orphan_and_readmits_only_canonical_burn() {
+        let directory = tempfile::TempDir::new().expect("temporary directory");
+        let path = directory.path().join("sequencer.sqlite");
+        let sequencer = WithdrawalSequencerStore::open(path.clone())
+            .await
+            .expect("open withdrawal state store");
+        let activity = sequencer.base_activity_store();
+        let policy = crate::shared::types::WithdrawalPolicy::v1();
+        let amount_nicks = policy
+            .minimum_gross_nocks
+            .checked_mul(policy.nicks_per_nock)
+            .expect("minimum withdrawal nicks");
+        let original = burn_log(
+            105,
+            U256::from(amount_nicks) * U256::from(NOCK_BASE_PER_NICK),
+            b256_from_u64(0x2468),
+        );
+        let base_event_id = compute_base_event_id(&original.transaction_hash, original.log_index);
+        let source = mock_scanner_source(vec![original.clone()]);
+        let scanner = scanner_with_source(109, 10, source.clone());
+        scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 100)
+            .await
+            .expect("initial burn recovery");
+
+        *source.fork_from.lock().expect("mock fork start lock") = Some(105);
+        *source
+            .header_hash_offset
+            .lock()
+            .expect("mock header offset lock") = 1_000;
+        source.logs.lock().expect("mock logs lock").clear();
+        let recovered = scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 100)
+            .await
+            .expect("shallow Base rewind");
+        assert_eq!(recovered.recovery, BaseBurnRecoveryReport::default());
+        let id = WithdrawalId {
+            as_of: crate::shared::types::zero_tip5_hash(),
+            base_event_id: base_event_id.clone(),
+        };
+        let row = sequencer
+            .fetch_sequenced_withdrawal(&id)
+            .await
+            .expect("fetch invalidated withdrawal")
+            .expect("invalidated withdrawal row");
+        assert_eq!(
+            row.state,
+            crate::withdrawal::state::WithdrawalState::Invalidated
+        );
+        assert_eq!(
+            sequencer
+                .current_live_withdrawal_nonce()
+                .await
+                .expect("current live nonce"),
+            None
+        );
+        assert!(activity
+            .load_verified_burn(8_453, Address::ZERO, &base_event_id)
+            .await
+            .expect("load orphaned burn")
+            .is_none());
+
+        let restarted = WithdrawalSequencerStore::open(path)
+            .await
+            .expect("restart withdrawal state store");
+        let restarted_activity = restarted.base_activity_store();
+        assert_eq!(
+            restarted
+                .fetch_sequenced_withdrawal(&id)
+                .await
+                .expect("fetch invalidated withdrawal after restart")
+                .expect("invalidated row after restart")
+                .state,
+            crate::withdrawal::state::WithdrawalState::Invalidated
+        );
+
+        let mut canonical = original;
+        canonical.block_hash = mock_block_hash(105, 1_000);
+        canonical.parent_hash = mock_block_hash(104, 0);
+        source.logs.lock().expect("mock logs lock").push(canonical);
+        let readmitted = scanner
+            .scan_and_recover_confirmed_burns(&restarted_activity, &restarted, 10, 100)
+            .await
+            .expect("canonical burn re-admission");
+        assert_eq!(readmitted.recovery.recovered_pending, 1);
+        let row = restarted
+            .fetch_sequenced_withdrawal(&id)
+            .await
+            .expect("fetch readmitted withdrawal")
+            .expect("readmitted withdrawal row");
+        assert_eq!(
+            row.state,
+            crate::withdrawal::state::WithdrawalState::Pending
+        );
+        assert_eq!(row.current_epoch, 1);
+        assert_eq!(row.withdrawal_nonce, Some(1));
+    }
+
+    #[tokio::test]
+    async fn deep_base_reorg_reports_exact_retained_checkpoint_evidence() {
+        let directory = tempfile::TempDir::new().expect("temporary directory");
+        let sequencer = WithdrawalSequencerStore::open(directory.path().join("sequencer.sqlite"))
+            .await
+            .expect("open withdrawal state store");
+        let activity = sequencer.base_activity_store();
+        let source = mock_scanner_source(Vec::new());
+        let scanner = scanner_with_source(109, 10, source.clone());
+        scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 100)
+            .await
+            .expect("initial checkpoint scan");
+        let cursor = activity
+            .load_cursor(8_453, Address::ZERO)
+            .await
+            .expect("load initial cursor")
+            .expect("initial cursor");
+        *source
+            .header_hash_offset
+            .lock()
+            .expect("mock header offset lock") = 10_000;
+        *source.fork_from.lock().expect("mock fork start lock") = Some(100);
+
+        let error = scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 100)
+            .await
+            .expect_err("deep fork must fail with checkpoint evidence");
+        let message = error.to_string();
+        assert!(message.contains("no common ancestor"));
+        assert!(message.contains("100..=109"));
+        assert!(message.contains("max_depth=64"));
+        let guard = sequencer
+            .ensure_reorg_ready()
+            .await
+            .expect_err("deep reorg must activate guard");
+        assert!(guard.to_string().contains("100..=109"));
+        assert_eq!(
+            activity
+                .load_cursor(8_453, Address::ZERO)
+                .await
+                .expect("load retained cursor"),
+            Some(cursor)
+        );
+    }
+    #[tokio::test]
+    async fn base_reorg_crossing_activation_boundary_fails_without_rewind() {
+        let directory = tempfile::TempDir::new().expect("temporary directory");
+        let sequencer = WithdrawalSequencerStore::open(directory.path().join("sequencer.sqlite"))
+            .await
+            .expect("open withdrawal state store");
+        let activity = sequencer.base_activity_store();
+        let source = mock_scanner_source(Vec::new());
+        let scanner = scanner_with_source(109, 10, source.clone());
+        scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 100)
+            .await
+            .expect("initial checkpoint scan");
+        *source.fork_from.lock().expect("mock fork start lock") = Some(105);
+        *source
+            .header_hash_offset
+            .lock()
+            .expect("mock header offset lock") = 1_000;
+
+        let error = scanner
+            .scan_and_recover_confirmed_burns(&activity, &sequencer, 10, 107)
+            .await
+            .expect_err("activation-crossing fork must fail");
+        assert!(error
+            .to_string()
+            .contains("crosses withdrawal activation boundary"));
+        assert!(sequencer.ensure_reorg_ready().await.is_err());
+        assert_eq!(
+            activity
+                .load_cursor(8_453, Address::ZERO)
+                .await
+                .expect("load retained cursor")
+                .expect("retained cursor")
+                .last_verified_block,
+            109
+        );
     }
 }

--- a/crates/bridge/src/withdrawal/sequencer/journal.rs
+++ b/crates/bridge/src/withdrawal/sequencer/journal.rs
@@ -120,6 +120,9 @@ pub enum SequencerJournalEventType {
     TxSeenMempoolAccepted,
     MempoolRetryAttempted,
     TxConfirmed,
+    BaseBurnInvalidated,
+    BaseReorgHold,
+    NockInclusionInvalidated,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -145,6 +148,20 @@ pub struct SequencerJournalBaseContext {
     pub turn_started_base_height: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_submit_attempt_base_height: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reorg_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalidated_block_height: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalidated_block_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub common_ancestor_height: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub common_ancestor_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prior_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reorg_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -202,6 +219,12 @@ pub struct SequencerJournalConfirmationContext {
     pub confirmed_height: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confirmed_block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reorg_generation: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reorg_reason: Option<String>,
 }
 
 impl SequencerJournalRecord {
@@ -2022,6 +2045,13 @@ mod tests {
                 base_batch_end: Some(44),
                 turn_started_base_height: Some(45),
                 last_submit_attempt_base_height: None,
+                reorg_generation: None,
+                invalidated_block_height: None,
+                invalidated_block_hash: None,
+                common_ancestor_height: None,
+                common_ancestor_hash: None,
+                prior_state: None,
+                reorg_reason: None,
             }),
             Some(SequencerJournalNockchainContext {
                 snapshot_height: Some(100),

--- a/crates/bridge/src/withdrawal/sequencer/public_rpc.rs
+++ b/crates/bridge/src/withdrawal/sequencer/public_rpc.rs
@@ -14,14 +14,14 @@ use crate::shared::ingress::proto::withdrawal_public_query_server::{
 };
 use crate::withdrawal::quote::WithdrawalQuotePort;
 use crate::withdrawal::sequencer::base_activity::{
-    BaseActivityPageCursor, BaseActivityStore, VerifiedBaseWithdrawalBurn,
+    BaseActivityPageCursor, BaseActivityStore, PublicBaseWithdrawalBurn,
 };
 use crate::withdrawal::sequencer::base_height::SequencerBaseHeightTracker;
 use crate::withdrawal::sequencer::base_incidents::{
     BaseIncidentStore, CompensatedBaseWithdrawal, RejectedBaseWithdrawalBurn,
 };
 use crate::withdrawal::sequencer::store::{
-    WithdrawalSequencerStore, WithdrawalSubmissionEventRecord,
+    PublicWithdrawalRecoveryProjection, WithdrawalSequencerStore, WithdrawalSubmissionEventRecord,
 };
 use crate::withdrawal::state::{LiveWithdrawalView, WithdrawalState};
 use crate::withdrawal::submission::WithdrawalSubmitPort;
@@ -135,12 +135,12 @@ impl PublicWithdrawalQueryService {
         &self,
         locator: &proto::PublicBaseWithdrawalLocator,
         require_unique: bool,
-    ) -> Result<Option<VerifiedBaseWithdrawalBurn>, Status> {
+    ) -> Result<Option<PublicBaseWithdrawalBurn>, Status> {
         let tx_hash = Self::parse_tx_hash(&locator.transaction_hash)?;
         if let Some(log_index) = locator.log_index {
             return self
                 .activity
-                .load_verified_burn_by_tx_log(
+                .load_public_burn_by_tx_log(
                     self.config.base_chain_id, self.config.nock_contract_address, tx_hash,
                     log_index,
                 )
@@ -149,7 +149,7 @@ impl PublicWithdrawalQueryService {
         }
         let burns = self
             .activity
-            .list_verified_burns_by_tx_hash(
+            .list_public_burns_by_tx_hash(
                 self.config.base_chain_id, self.config.nock_contract_address, tx_hash,
             )
             .await
@@ -224,14 +224,15 @@ impl PublicWithdrawalQueryService {
 
     async fn single_record(
         &self,
-        burn: VerifiedBaseWithdrawalBurn,
+        burn: PublicBaseWithdrawalBurn,
     ) -> Result<proto::PublicWithdrawalRecord, Status> {
+        let base_event_id = burn.burn.base_event_id.clone();
         let mut projections = self
             .store
-            .public_lifecycle_projections(vec![burn.base_event_id.clone()])
+            .public_lifecycle_projections(vec![base_event_id.clone()])
             .await
             .map_err(|err| self.internal_status("public lifecycle lookup", err))?;
-        let projection = projections.remove(&burn.base_event_id);
+        let projection = projections.remove(&base_event_id);
         let lifecycle = projection.as_ref().map(|projection| &projection.lifecycle);
         let net_amount = projection
             .as_ref()
@@ -239,6 +240,9 @@ impl PublicWithdrawalQueryService {
         let confirmation = projection
             .as_ref()
             .and_then(|projection| projection.confirmation.as_ref());
+        let recovery = projection
+            .as_ref()
+            .and_then(|projection| projection.recovery.as_ref());
         let revision = self
             .store
             .public_projection_revision()
@@ -247,7 +251,7 @@ impl PublicWithdrawalQueryService {
         let compensated = self
             .incidents
             .load_compensated_withdrawal(
-                self.config.base_chain_id, self.config.nock_contract_address, &burn.base_event_id,
+                self.config.base_chain_id, self.config.nock_contract_address, &base_event_id,
             )
             .await
             .map_err(|err| self.internal_status("compensation lookup", err))?;
@@ -257,6 +261,7 @@ impl PublicWithdrawalQueryService {
             lifecycle,
             net_amount,
             confirmation,
+            recovery,
             revision,
             unix_now_secs().map_err(|err| self.internal_status("system time", err))?,
         )
@@ -265,14 +270,20 @@ impl PublicWithdrawalQueryService {
 
     fn build_record(
         &self,
-        burn: VerifiedBaseWithdrawalBurn,
+        public_burn: PublicBaseWithdrawalBurn,
         compensated: Option<&CompensatedBaseWithdrawal>,
         lifecycle: Option<&LiveWithdrawalView>,
         net_amount: Option<u64>,
         confirmation: Option<&WithdrawalSubmissionEventRecord>,
+        recovery: Option<&PublicWithdrawalRecoveryProjection>,
         projection_revision: u64,
         now_secs: u64,
     ) -> Result<proto::PublicWithdrawalRecord, BridgeError> {
+        let canonical_base_event = public_burn.canonical;
+        let fallback_generation = public_burn.invalidation_generation;
+        let fallback_reason = public_burn.invalidation_reason.clone();
+        let fallback_invalidated_at = public_burn.invalidated_at;
+        let burn = public_burn.burn;
         let policy_matches = burn.policy_id.as_deref() == Some(self.config.policy_id.as_str())
             && burn.protocol_id.as_deref() == Some(self.config.protocol_id.as_str());
         let minimum_nicks = crate::shared::types::WithdrawalPolicy::v1()
@@ -286,6 +297,26 @@ impl PublicWithdrawalQueryService {
         let delayed = observed_secs
             .and_then(|observed| now_secs.checked_sub(observed))
             .is_some_and(|elapsed| elapsed >= self.config.delayed_after.as_secs());
+        let recovery = recovery.filter(|recovery| {
+            !matches!(
+                (lifecycle, confirmation),
+                (Some(row), Some(event))
+                    if row.state == WithdrawalState::Confirmed
+                        && event.created_at > recovery.observed_at
+            )
+        });
+        let active_confirmation = confirmation.filter(|event| {
+            lifecycle.is_some_and(|row| row.state == WithdrawalState::Confirmed)
+                && recovery.is_none_or(|recovery| event.created_at > recovery.observed_at)
+        });
+        let reorged = !canonical_base_event
+            || recovery.is_some()
+            || lifecycle.is_some_and(|row| {
+                matches!(
+                    row.state,
+                    WithdrawalState::Invalidated | WithdrawalState::ReorgHold
+                )
+            });
         let (status, resolution, support_hint) = if compensated.is_some() {
             (
                 proto::PublicWithdrawalStatus::Failure,
@@ -304,7 +335,24 @@ impl PublicWithdrawalQueryService {
                 proto::PublicWithdrawalResolution::BelowPolicy,
                 "This burn is below the active withdrawal policy. Contact support; do not burn again.",
             )
-        } else if lifecycle.is_some_and(|row| row.state == WithdrawalState::Confirmed) {
+        } else if reorged {
+            (
+                if !canonical_base_event
+                    || lifecycle.is_some_and(|row| {
+                        matches!(
+                            row.state,
+                            WithdrawalState::Invalidated | WithdrawalState::ReorgHold
+                        )
+                    })
+                {
+                    proto::PublicWithdrawalStatus::Failure
+                } else {
+                    proto::PublicWithdrawalStatus::WithdrawalPending
+                },
+                proto::PublicWithdrawalResolution::Reorged,
+                "Authoritative chain recovery invalidated prior settlement facts. Do not submit another burn.",
+            )
+        } else if active_confirmation.is_some() {
             (
                 proto::PublicWithdrawalStatus::Confirmed,
                 proto::PublicWithdrawalResolution::Found,
@@ -327,11 +375,18 @@ impl PublicWithdrawalQueryService {
             .filter(|row| row.id.as_of != crate::shared::types::zero_tip5_hash())
             .map(|row| withdrawal_id_to_proto(&row.id));
         let observed_at_unix_ms = observed_secs.map(seconds_u64_to_millis_i64).transpose()?;
-        let updated_at_unix_ms = lifecycle
-            .map(|row| seconds_i64_to_millis(row.updated_at))
+        let lifecycle_updated_at = lifecycle.map(|row| row.updated_at);
+        let recovery_updated_at = recovery
+            .map(|recovery| recovery.observed_at)
+            .or(fallback_invalidated_at);
+        let updated_at_unix_ms = [lifecycle_updated_at, recovery_updated_at]
+            .into_iter()
+            .flatten()
+            .max()
+            .map(seconds_i64_to_millis)
             .transpose()?
             .or(observed_at_unix_ms);
-        let confirmed_at_unix_ms = confirmation
+        let confirmed_at_unix_ms = active_confirmation
             .map(|event| seconds_i64_to_millis(event.created_at))
             .transpose()?;
         let revision = compose_public_revision(burn.verified_at, projection_revision)?;
@@ -352,24 +407,41 @@ impl PublicWithdrawalQueryService {
             status: status as i32,
             resolution: resolution as i32,
             revision,
-            canonical_base_event: true,
+            canonical_base_event,
             base_block_number: Some(burn.block_number),
             base_block_hash: Some(burn.block_hash.as_slice().to_vec()),
             observed_at_unix_ms,
             updated_at_unix_ms,
             nock_transaction_name: lifecycle
                 .and_then(|row| row.authorized_transaction_name.clone()),
-            nock_confirmed_height: confirmation.and_then(|event| event.confirmed_height),
-            nock_confirmed_block_id: confirmation
+            nock_confirmed_height: active_confirmation.and_then(|event| event.confirmed_height),
+            nock_confirmed_block_id: active_confirmation
                 .and_then(|event| event.confirmed_block_id.as_ref())
                 .map(|block_id| block_id.to_be_limb_bytes().to_vec()),
             confirmed_at_unix_ms,
             support_hint: support_hint.to_string(),
-            recovery_generation: None,
-            invalidated_block_height: None,
-            invalidated_block_id: None,
-            prior_status: String::new(),
-            recovery_reason: String::new(),
+            recovery_generation: recovery
+                .map(|recovery| recovery.generation)
+                .or(fallback_generation),
+            invalidated_block_height: recovery
+                .map(|recovery| recovery.invalidated_block_height)
+                .or_else(|| (!canonical_base_event).then_some(burn.block_number)),
+            invalidated_block_id: recovery
+                .map(|recovery| recovery.invalidated_block_id.clone())
+                .or_else(|| (!canonical_base_event).then(|| burn.block_hash.as_slice().to_vec())),
+            prior_status: recovery
+                .map(|recovery| recovery.prior_status.clone())
+                .unwrap_or_else(|| {
+                    if canonical_base_event {
+                        String::new()
+                    } else {
+                        "pending".to_string()
+                    }
+                }),
+            recovery_reason: recovery
+                .map(|recovery| recovery.reason.clone())
+                .or(fallback_reason)
+                .unwrap_or_default(),
         })
     }
 
@@ -453,7 +525,7 @@ impl PublicWithdrawalQueryService {
         burner: Address,
         snapshot_revision: u64,
         snapshot_rowid: u64,
-        last: &VerifiedBaseWithdrawalBurn,
+        last: &PublicBaseWithdrawalBurn,
     ) -> String {
         let mut payload = Vec::with_capacity(PUBLIC_WITHDRAWAL_PAGE_TOKEN_PAYLOAD_LEN);
         payload.push(2);
@@ -464,9 +536,9 @@ impl PublicWithdrawalQueryService {
         payload.extend_from_slice(blake3::hash(self.config.protocol_id.as_bytes()).as_bytes());
         payload.extend_from_slice(&snapshot_revision.to_be_bytes());
         payload.extend_from_slice(&snapshot_rowid.to_be_bytes());
-        payload.extend_from_slice(&last.block_number.to_be_bytes());
-        payload.extend_from_slice(&last.log_index.to_be_bytes());
-        payload.extend_from_slice(&last.base_event_id.0);
+        payload.extend_from_slice(&last.burn.block_number.to_be_bytes());
+        payload.extend_from_slice(&last.burn.log_index.to_be_bytes());
+        payload.extend_from_slice(&last.burn.base_event_id.0);
         let tag = blake3::keyed_hash(&self.config.page_token_key, &payload);
         payload.extend_from_slice(tag.as_bytes());
         hex::encode(payload)
@@ -489,7 +561,7 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
         if locator.log_index.is_none() {
             let burns = self
                 .activity
-                .list_verified_burns_by_tx_hash(
+                .list_public_burns_by_tx_hash(
                     self.config.base_chain_id, self.config.nock_contract_address, tx_hash,
                 )
                 .await
@@ -503,19 +575,16 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
                 .map_err(|err| self.internal_status("rejected Base transaction resolution", err))?;
             let compensated = self
                 .incidents
-                .list_compensated_withdrawals(
-                    self.config.base_chain_id, self.config.nock_contract_address,
+                .list_compensated_withdrawals_by_tx_hash(
+                    self.config.base_chain_id, self.config.nock_contract_address, tx_hash,
                 )
                 .await
                 .map_err(|err| {
                     self.internal_status("compensated Base transaction resolution", err)
-                })?
-                .into_iter()
-                .filter(|record| record.tx_hash == tx_hash)
-                .collect::<Vec<_>>();
+                })?;
             let candidate_log_indices = burns
                 .iter()
-                .map(|burn| burn.log_index)
+                .map(|burn| burn.burn.log_index)
                 .chain(rejected.iter().map(|burn| burn.log_index))
                 .chain(compensated.iter().map(|record| record.log_index))
                 .collect::<BTreeSet<_>>()
@@ -634,7 +703,7 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
                 let base_event_id = Self::parse_base_event_id(&base_event_id)?;
                 base_event_id_hint = Some(base_event_id.clone());
                 self.activity
-                    .load_verified_burn(
+                    .load_public_burn(
                         self.config.base_chain_id, self.config.nock_contract_address,
                         &base_event_id,
                     )
@@ -647,7 +716,7 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
                 base_event_id_hint = Some(withdrawal_id.base_event_id.clone());
                 let burn = self
                     .activity
-                    .load_verified_burn(
+                    .load_public_burn(
                         self.config.base_chain_id, self.config.nock_contract_address,
                         &withdrawal_id.base_event_id,
                     )
@@ -778,7 +847,7 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
             .ok_or_else(|| Status::invalid_argument("page_size overflow"))?;
         let mut page = self
             .activity
-            .list_verified_burns_by_burner_page(
+            .list_public_burns_by_burner_page(
                 self.config.base_chain_id, self.config.nock_contract_address, burner, cursor,
                 fetch_limit,
             )
@@ -799,7 +868,7 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
         let base_event_ids = page
             .burns
             .iter()
-            .map(|burn| burn.base_event_id.clone())
+            .map(|burn| burn.burn.base_event_id.clone())
             .collect::<Vec<_>>();
         let projections = self
             .store
@@ -819,14 +888,16 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
         let now_secs = unix_now_secs().map_err(|err| self.internal_status("system time", err))?;
         let mut withdrawals = Vec::with_capacity(page.burns.len());
         for burn in page.burns {
-            let projection = projections.get(&burn.base_event_id);
+            let projection = projections.get(&burn.burn.base_event_id);
             let lifecycle = projection.map(|projection| &projection.lifecycle);
-            let compensation = compensated.get(&burn.base_event_id);
+            let compensation = compensated.get(&burn.burn.base_event_id);
             let net_amount = projection.and_then(|projection| projection.net_amount);
             let confirmation = projection.and_then(|projection| projection.confirmation.as_ref());
+            let recovery = projection.and_then(|projection| projection.recovery.as_ref());
             withdrawals.push(
                 self.build_record(
-                    burn, compensation, lifecycle, net_amount, confirmation, revision, now_secs,
+                    burn, compensation, lifecycle, net_amount, confirmation, recovery, revision,
+                    now_secs,
                 )
                 .map_err(|err| self.internal_status("history record projection", err))?,
             );
@@ -883,10 +954,12 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
             .public_projection_revision()
             .await
             .map_err(|err| self.internal_status("projection readiness", err))?;
-        let observed_nockchain_height = match self.nockchain.current_nockchain_tip_height().await {
-            Ok(height) => height,
-            Err(_) => None,
-        };
+        let reorg_hold = self.store.ensure_reorg_ready().await.is_err();
+        let observed_nockchain_height = self
+            .nockchain
+            .current_nockchain_tip_height()
+            .await
+            .unwrap_or_default();
         let mut reasons = Vec::new();
         let indexed_base_height = activity_cursor
             .as_ref()
@@ -902,6 +975,12 @@ impl WithdrawalPublicQuery for PublicWithdrawalQueryService {
             Some(frontier.base_block) != indexed_base_height
                 || frontier.journal_sequence != projection_revision
         }) {
+            reasons.push(proto::PublicWithdrawalReadinessReason::JournalReconciling as i32);
+        }
+        if reorg_hold
+            && !reasons
+                .contains(&(proto::PublicWithdrawalReadinessReason::JournalReconciling as i32))
+        {
             reasons.push(proto::PublicWithdrawalReadinessReason::JournalReconciling as i32);
         }
         if observed_nockchain_height.is_none() {
@@ -1285,6 +1364,15 @@ mod tests {
             protocol_id: Some(policy.wire_format.to_string()),
         }
     }
+    fn canonical_public_burn(burn: VerifiedBaseWithdrawalBurn) -> PublicBaseWithdrawalBurn {
+        PublicBaseWithdrawalBurn {
+            burn,
+            canonical: true,
+            invalidated_at: None,
+            invalidation_generation: None,
+            invalidation_reason: None,
+        }
+    }
 
     struct PublicQueryFixture {
         _directory: TempDir,
@@ -1559,6 +1647,122 @@ mod tests {
         assert_eq!(quote.transaction_fee_nicks, "256");
         assert!(quote.net_payout_nicks.parse::<u64>().expect("net quote") > 0);
         assert_eq!(quote.snapshot_height, Some(700));
+    }
+
+    #[tokio::test]
+    async fn public_withdrawal_regresses_confirmed_facts_on_nock_reorg() {
+        let fixture = PublicQueryFixture::new().await;
+        let before = fixture
+            .service
+            .get_withdrawal(Request::new(proto::GetPublicWithdrawalRequest {
+                lookup: Some(proto::PublicWithdrawalLookupKey {
+                    deployment: Some(fixture.deployment()),
+                    key: Some(proto::public_withdrawal_lookup_key::Key::WithdrawalId(
+                        withdrawal_id_to_proto(&fixture.confirmed_id),
+                    )),
+                }),
+            }))
+            .await
+            .expect("get confirmed withdrawal")
+            .into_inner()
+            .withdrawal
+            .expect("confirmed withdrawal");
+        let page_before = fixture
+            .service
+            .list_withdrawals_by_burner(Request::new(proto::ListPublicWithdrawalsByBurnerRequest {
+                deployment: Some(fixture.deployment()),
+                burner: fixture.burner.as_slice().to_vec(),
+                page_size: 1,
+                page_token: String::new(),
+            }))
+            .await
+            .expect("history page before reorg")
+            .into_inner();
+        assert!(!page_before.next_page_token.is_empty());
+        let invalidated_block_id = Tip5Hash::from_limbs(&[71, 72, 73, 74, 75]);
+        fixture
+            .store
+            .record_nockchain_inclusion_invalidated(
+                &fixture.confirmed_id,
+                700,
+                invalidated_block_id.clone(),
+                WithdrawalState::ReorgHold,
+                "Nockchain confirmation was orphaned".to_string(),
+            )
+            .await
+            .expect("record Nockchain reorg");
+        let stale_page = fixture
+            .service
+            .list_withdrawals_by_burner(Request::new(proto::ListPublicWithdrawalsByBurnerRequest {
+                deployment: Some(fixture.deployment()),
+                burner: fixture.burner.as_slice().to_vec(),
+                page_size: 1,
+                page_token: page_before.next_page_token,
+            }))
+            .await
+            .expect_err("pre-reorg page token must be superseded");
+        assert_eq!(stale_page.code(), tonic::Code::FailedPrecondition);
+
+        let after = fixture
+            .service
+            .get_withdrawal(Request::new(proto::GetPublicWithdrawalRequest {
+                lookup: Some(proto::PublicWithdrawalLookupKey {
+                    deployment: Some(fixture.deployment()),
+                    key: Some(proto::public_withdrawal_lookup_key::Key::WithdrawalId(
+                        withdrawal_id_to_proto(&fixture.confirmed_id),
+                    )),
+                }),
+            }))
+            .await
+            .expect("get reorged withdrawal")
+            .into_inner()
+            .withdrawal
+            .expect("reorged withdrawal");
+        assert!(after.revision > before.revision);
+        assert_eq!(
+            after.resolution,
+            proto::PublicWithdrawalResolution::Reorged as i32
+        );
+        assert_eq!(after.status, proto::PublicWithdrawalStatus::Failure as i32);
+        assert_eq!(after.recovery_generation, Some(1));
+        assert_eq!(after.invalidated_block_height, Some(700));
+        assert_eq!(
+            after.invalidated_block_id,
+            Some(invalidated_block_id.to_be_limb_bytes().to_vec())
+        );
+        assert_eq!(after.prior_status, "confirmed");
+        assert!(after.recovery_reason.contains("orphaned"));
+        assert_eq!(after.nock_confirmed_height, None);
+        assert_eq!(after.nock_confirmed_block_id, None);
+        assert_eq!(after.confirmed_at_unix_ms, None);
+    }
+
+    #[tokio::test]
+    async fn public_readiness_fails_closed_while_base_reorg_guard_is_active() {
+        let fixture = PublicQueryFixture::new().await;
+        fixture
+            .store
+            .activate_base_reorg_guard(
+                8_453,
+                Address::from([0x11; 20]),
+                "proof fixture: kernel hashchain has not been recovered".to_string(),
+            )
+            .await
+            .expect("activate Base reorg guard");
+
+        let readiness = fixture
+            .service
+            .get_withdrawal_readiness(Request::new(proto::GetPublicWithdrawalReadinessRequest {
+                deployment: Some(fixture.deployment()),
+            }))
+            .await
+            .expect("reorg-held readiness")
+            .into_inner();
+
+        assert!(!readiness.accepting_new_withdrawals);
+        assert!(readiness
+            .reasons
+            .contains(&(proto::PublicWithdrawalReadinessReason::JournalReconciling as i32)));
     }
 
     #[tokio::test]
@@ -1906,9 +2110,10 @@ mod tests {
             let record = fixture
                 .service
                 .build_record(
-                    burn.clone(),
+                    canonical_public_burn(burn.clone()),
                     None,
                     Some(&lifecycle),
+                    None,
                     None,
                     None,
                     10,
@@ -1925,9 +2130,10 @@ mod tests {
         delayed_service.config.delayed_after = Duration::from_secs(1);
         let delayed = delayed_service
             .build_record(
-                burn.clone(),
+                canonical_public_burn(burn.clone()),
                 None,
                 Some(&lifecycle),
+                None,
                 None,
                 None,
                 11,
@@ -1943,7 +2149,16 @@ mod tests {
         below_policy.amount_nicks = 1;
         let failure = fixture
             .service
-            .build_record(below_policy, None, None, None, None, 12, 1_700_000_000)
+            .build_record(
+                canonical_public_burn(below_policy),
+                None,
+                None,
+                None,
+                None,
+                None,
+                12,
+                1_700_000_000,
+            )
             .expect("normalize below-policy burn");
         assert_eq!(
             failure.status,
@@ -1958,7 +2173,16 @@ mod tests {
         unknown_policy.policy_id = None;
         let inconsistent = fixture
             .service
-            .build_record(unknown_policy, None, None, None, None, 13, 1_700_000_000)
+            .build_record(
+                canonical_public_burn(unknown_policy),
+                None,
+                None,
+                None,
+                None,
+                None,
+                13,
+                1_700_000_000,
+            )
             .expect("normalize unknown policy");
         assert_eq!(
             inconsistent.status,

--- a/crates/bridge/src/withdrawal/sequencer/rpc.rs
+++ b/crates/bridge/src/withdrawal/sequencer/rpc.rs
@@ -208,6 +208,13 @@ impl WithdrawalSequencerRpcService {
             })
     }
 
+    async fn require_reorg_ready(&self) -> Result<(), Status> {
+        self.withdrawal_state_store
+            .ensure_reorg_ready()
+            .await
+            .map_err(|err| Status::failed_precondition(err.to_string()))
+    }
+
     fn deferred_submit_response(reason: impl Into<String>) -> SequencerUpdateResponse {
         SequencerUpdateResponse {
             request_accepted: false,
@@ -795,6 +802,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerRegisterWithdrawalRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         metrics::init_metrics()
             .sequencer_withdrawal_registration_requests
             .increment();
@@ -955,6 +963,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerRecordCanonicalRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         metrics::init_metrics()
             .sequencer_withdrawal_canonicalize_requests
             .increment();
@@ -1071,6 +1080,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerAdvancePrecanonicalHandoffRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         let inner = request.into_inner();
         let id = inner
             .withdrawal_id
@@ -1091,6 +1101,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerRecordSignedProposalRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         let inner = request.into_inner();
         let envelope = inner
             .proposal
@@ -1158,6 +1169,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerAuthorizeProposalRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         metrics::init_metrics()
             .sequencer_withdrawal_authorize_requests
             .increment();
@@ -1260,6 +1272,7 @@ impl WithdrawalSequencer for WithdrawalSequencerRpcService {
         &self,
         request: Request<SequencerSubmitProposalRequest>,
     ) -> Result<Response<SequencerUpdateResponse>, Status> {
+        self.require_reorg_ready().await?;
         metrics::init_metrics()
             .sequencer_withdrawal_submit_attempts
             .increment();
@@ -2035,6 +2048,72 @@ mod tests {
         let err = elapsed_handoff_turns(200, 150, 10)
             .expect_err("regressing base height should be rejected");
         assert!(err.contains("behind stored turn_started_base_height"));
+    }
+
+    #[tokio::test]
+    async fn base_reorg_guard_blocks_every_mutating_rpc_and_preserves_read_access() {
+        let (rpc, withdrawal_state_store, _base_height_tracker, _submitter, _dir) =
+            open_rpc_service().await;
+        withdrawal_state_store
+            .activate_base_reorg_guard(
+                8_453,
+                Address::ZERO,
+                "proof fixture: Hoon recovery has not converged".to_string(),
+            )
+            .await
+            .expect("activate Base reorg guard");
+
+        let assert_blocked = |status: Status| {
+            assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+            assert!(
+                status.message().contains("reorg hold generation"),
+                "unexpected guard error: {status}"
+            );
+        };
+
+        assert_blocked(
+            rpc.register_withdrawal(Request::new(SequencerRegisterWithdrawalRequest::default()))
+                .await
+                .expect_err("registration must fail during Base reorg hold"),
+        );
+        assert_blocked(
+            rpc.record_canonical_proposal(Request::new(SequencerRecordCanonicalRequest::default()))
+                .await
+                .expect_err("canonicalization must fail during Base reorg hold"),
+        );
+        assert_blocked(
+            rpc.advance_precanonical_handoff(Request::new(
+                SequencerAdvancePrecanonicalHandoffRequest::default(),
+            ))
+            .await
+            .expect_err("handoff advance must fail during Base reorg hold"),
+        );
+        assert_blocked(
+            rpc.record_signed_proposal(Request::new(
+                SequencerRecordSignedProposalRequest::default(),
+            ))
+            .await
+            .expect_err("signature progress must fail during Base reorg hold"),
+        );
+        assert_blocked(
+            rpc.authorize_proposal(Request::new(SequencerAuthorizeProposalRequest::default()))
+                .await
+                .expect_err("authorization must fail during Base reorg hold"),
+        );
+        assert_blocked(
+            rpc.submit_proposal(Request::new(SequencerSubmitProposalRequest::default()))
+                .await
+                .expect_err("submission must fail during Base reorg hold"),
+        );
+
+        let reserved = rpc
+            .get_reserved_withdrawal_inputs(Request::new(
+                SequencerReservedWithdrawalInputsRequest {},
+            ))
+            .await
+            .expect("read-only reservation query remains available")
+            .into_inner();
+        assert!(reserved.reserved_inputs.is_empty());
     }
 
     #[tokio::test]

--- a/crates/bridge/src/withdrawal/sequencer/schema.rs
+++ b/crates/bridge/src/withdrawal/sequencer/schema.rs
@@ -119,9 +119,37 @@ diesel::table! {
         recorded_at -> BigInt,
     }
 }
+diesel::table! {
+    sequencer_base_burn_invalidations (event_id) {
+        event_id -> BigInt,
+        chain_id -> BigInt,
+        nock_contract_address -> Binary,
+        generation -> BigInt,
+        base_event_id -> Binary,
+        old_block_number -> BigInt,
+        old_block_hash -> Binary,
+        lifecycle_state -> Nullable<Text>,
+        invalidated_at -> BigInt,
+        reason -> Text,
+    }
+}
+
+diesel::table! {
+    sequencer_nock_reorg_events (event_id) {
+        event_id -> BigInt,
+        withdrawal_id_base_event_id -> Binary,
+        generation -> BigInt,
+        invalidated_height -> BigInt,
+        invalidated_block_id -> Binary,
+        next_state -> Text,
+        reason -> Text,
+        created_at -> BigInt,
+    }
+}
 
 diesel::allow_tables_to_appear_in_same_query!(
     sequencer_journal_cursor, sequencer_withdrawals, withdrawal_reserved_inputs,
     withdrawal_submission_events, sequencer_base_burn_rejections,
-    sequencer_compensated_withdrawals,
+    sequencer_compensated_withdrawals, sequencer_base_burn_invalidations,
+    sequencer_nock_reorg_events,
 );

--- a/crates/bridge/src/withdrawal/sequencer/store.rs
+++ b/crates/bridge/src/withdrawal/sequencer/store.rs
@@ -7,7 +7,7 @@ use deadpool_diesel::sqlite::{Manager, Pool};
 use deadpool_diesel::Runtime;
 use diesel::connection::SimpleConnection;
 use diesel::prelude::*;
-use diesel::sql_types::{BigInt, Binary, Text};
+use diesel::sql_types::{BigInt, Binary, Nullable, Text};
 use diesel::sqlite::SqliteConnection;
 use nockapp::noun::slab::{NockJammer, NounSlab};
 use nockapp::{Bytes, NounAllocator};
@@ -23,7 +23,8 @@ use crate::withdrawal::proposals::TrackedWithdrawalRequest;
 use crate::withdrawal::raw_tx as withdrawal_raw_tx;
 use crate::withdrawal::sequencer::base_activity::{
     assign_withdrawal_nonce, ensure_base_activity_schema, load_activity_cursor_for_reconciliation,
-    load_verified_burn_for_reconciliation, BaseActivityStore, VerifiedBaseWithdrawalBurn,
+    load_verified_burn_for_reconciliation, BaseActivityReorgPlan, BaseActivityStore,
+    VerifiedBaseWithdrawalBurn,
 };
 use crate::withdrawal::sequencer::base_incidents::compensated_withdrawal_exists;
 use crate::withdrawal::sequencer::journal::{
@@ -46,7 +47,47 @@ use crate::withdrawal::types::{
 };
 
 const SQLITE_BUSY_TIMEOUT_MS: u64 = 2_000;
+fn checked_i64(value: u64, field: &str) -> Result<i64, BridgeError> {
+    i64::try_from(value).map_err(|err| {
+        BridgeError::ValueConversion(format!("{field} does not fit SQLite INTEGER: {err}"))
+    })
+}
 
+#[derive(QueryableByName)]
+struct BaseReorgBurnRow {
+    #[diesel(sql_type = Binary)]
+    base_event_id: Vec<u8>,
+    #[diesel(sql_type = BigInt)]
+    block_number: i64,
+    #[diesel(sql_type = Binary)]
+    block_hash: Vec<u8>,
+}
+
+#[derive(QueryableByName)]
+struct OptionalMaxGeneration {
+    #[diesel(sql_type = Nullable<BigInt>)]
+    value: Option<i64>,
+}
+
+#[derive(QueryableByName)]
+struct BaseReorgGuardRow {
+    #[diesel(sql_type = BigInt)]
+    generation: i64,
+    #[diesel(sql_type = Text)]
+    reason: String,
+}
+
+#[derive(QueryableByName)]
+struct NockReorgObservationRow {
+    #[diesel(sql_type = BigInt)]
+    expected_height: i64,
+    #[diesel(sql_type = Binary)]
+    expected_block_id: Vec<u8>,
+    #[diesel(sql_type = BigInt)]
+    first_observed_at: i64,
+    #[diesel(sql_type = BigInt)]
+    missing_count: i64,
+}
 /// Sequencer-owned withdrawal coordination state store.
 ///
 /// This store is used by the API-node sequencer process. It owns the durable
@@ -65,12 +106,15 @@ pub enum WithdrawalSubmissionEventType {
     ProposerTurnExpired,
     ProposalAuthorized,
     ProposalRejected,
+    NockInclusionInvalidated,
     ProposalExpired,
     ProposalSuperseded,
     TxSubmitted,
     TxSeenMempoolAccepted,
     MempoolRetryAttempted,
     TxConfirmed,
+    BaseBurnInvalidated,
+    BaseReorgHold,
 }
 
 impl WithdrawalSubmissionEventType {
@@ -85,12 +129,15 @@ impl WithdrawalSubmissionEventType {
             Self::ProposerTurnExpired => "proposer_turn_expired",
             Self::ProposalAuthorized => "proposal_authorized",
             Self::ProposalRejected => "proposal_rejected",
+            Self::NockInclusionInvalidated => "nock_inclusion_invalidated",
             Self::ProposalExpired => "proposal_expired",
             Self::ProposalSuperseded => "proposal_superseded",
             Self::TxSubmitted => "tx_submitted",
             Self::TxSeenMempoolAccepted => "tx_seen_mempool_accepted",
             Self::MempoolRetryAttempted => "mempool_retry_attempted",
             Self::TxConfirmed => "tx_confirmed",
+            Self::BaseBurnInvalidated => "base_burn_invalidated",
+            Self::BaseReorgHold => "base_reorg_hold",
         }
     }
 
@@ -105,12 +152,15 @@ impl WithdrawalSubmissionEventType {
             "proposer_turn_expired" => Ok(Self::ProposerTurnExpired),
             "proposal_authorized" => Ok(Self::ProposalAuthorized),
             "proposal_rejected" => Ok(Self::ProposalRejected),
+            "nock_inclusion_invalidated" => Ok(Self::NockInclusionInvalidated),
             "proposal_expired" => Ok(Self::ProposalExpired),
             "proposal_superseded" => Ok(Self::ProposalSuperseded),
             "tx_submitted" => Ok(Self::TxSubmitted),
             "tx_seen_mempool_accepted" => Ok(Self::TxSeenMempoolAccepted),
             "mempool_retry_attempted" => Ok(Self::MempoolRetryAttempted),
             "tx_confirmed" => Ok(Self::TxConfirmed),
+            "base_burn_invalidated" => Ok(Self::BaseBurnInvalidated),
+            "base_reorg_hold" => Ok(Self::BaseReorgHold),
             other => Err(BridgeError::Runtime(format!(
                 "unknown withdrawal submission event type: {other}"
             ))),
@@ -134,10 +184,21 @@ pub struct WithdrawalSubmissionEventRecord {
     pub confirmed_block_id: Option<Tip5Hash>,
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicWithdrawalRecoveryProjection {
+    pub generation: u64,
+    pub invalidated_block_height: u64,
+    pub invalidated_block_id: Vec<u8>,
+    pub prior_status: String,
+    pub reason: String,
+    pub observed_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicWithdrawalLifecycleProjection {
     pub lifecycle: LiveWithdrawalView,
     pub net_amount: Option<u64>,
     pub confirmation: Option<WithdrawalSubmissionEventRecord>,
+    pub recovery: Option<PublicWithdrawalRecoveryProjection>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -199,6 +260,37 @@ pub struct BaseBurnRecoveryReport {
     pub recovered_pending: u64,
     pub already_registered: u64,
     pub ineligible: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfirmedNockchainWithdrawal {
+    pub id: WithdrawalId,
+    pub epoch: u64,
+    pub submitted_raw_tx_id: String,
+    pub raw_tx: nockchain_types::v1::RawTx,
+    pub confirmed_height: u64,
+    pub confirmed_block_id: Tip5Hash,
+    pub snapshot_height: u64,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct NockchainReorgRecoveryReport {
+    pub inspected: u64,
+    pub unchanged: u64,
+    pub re_included: u64,
+    pub regressed_to_mempool: u64,
+    pub regressed_to_authorized: u64,
+    pub held: u64,
+}
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseActivityReorgReport {
+    pub generation: u64,
+    pub old_cursor_block: u64,
+    pub common_ancestor_block: u64,
+    pub rewind_depth: u64,
+    pub burns_invalidated: u64,
+    pub lifecycle_rows_invalidated: u64,
+    pub lifecycle_rows_held: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1096,6 +1188,25 @@ impl WithdrawalSequencerStore {
         .await
     }
 
+    pub async fn record_nockchain_inclusion_invalidated(
+        &self,
+        id: &WithdrawalId,
+        confirmed_height: u64,
+        confirmed_block_id: Tip5Hash,
+        next_state: WithdrawalState,
+        reason: String,
+    ) -> Result<u64, BridgeError> {
+        let id = id.clone();
+        let created_at = now_unix_secs()?;
+        self.with_write_tx(move |conn, journal| {
+            record_nockchain_inclusion_invalidated_tx(
+                conn, journal, &id, confirmed_height, &confirmed_block_id, next_state, &reason,
+                created_at,
+            )
+        })
+        .await
+    }
+
     /// Records that the submitted transaction was observed as mempool-accepted
     /// by a Nockchain node without yet marking it confirmed.
     pub async fn record_tx_seen_mempool_accepted(
@@ -1389,7 +1500,7 @@ impl WithdrawalSequencerStore {
     }
 
     /// Loads and validates the exact persisted raw transaction for startup
-    /// reconciliation of an authorized or mempool-accepted withdrawal.
+    /// reconciliation or operator inspection of an authorized transaction.
     pub async fn load_authorized_transaction_for_reconciliation(
         &self,
         id: &WithdrawalId,
@@ -1446,6 +1557,113 @@ impl WithdrawalSequencerStore {
             .await
     }
 
+    pub async fn list_confirmed_nockchain_withdrawals(
+        &self,
+    ) -> Result<Vec<ConfirmedNockchainWithdrawal>, BridgeError> {
+        self.with_conn(load_confirmed_nockchain_withdrawals).await
+    }
+
+    pub async fn note_missing_nockchain_inclusion(
+        &self,
+        id: &WithdrawalId,
+        expected_height: u64,
+        expected_block_id: &Tip5Hash,
+    ) -> Result<u64, BridgeError> {
+        let id = id.clone();
+        let expected_block_id = tip5_to_bytes(expected_block_id);
+        let observed_at = now_unix_secs()?;
+        self.with_conn(move |conn| {
+            conn.immediate_transaction::<_, anyhow::Error, _>(|conn| {
+                let expected_height_i64 = checked_i64(expected_height, "expected_height")?;
+                let existing = diesel::sql_query(
+                    r#"
+                    SELECT expected_height, expected_block_id,
+                           first_observed_at, missing_count
+                    FROM sequencer_nock_reorg_observations
+                    WHERE withdrawal_id_base_event_id = ?
+                    "#,
+                )
+                .bind::<Binary, _>(id.base_event_id.0.clone())
+                .get_result::<NockReorgObservationRow>(conn)
+                .optional()?;
+                let matches_expected = existing.as_ref().is_some_and(|row| {
+                    row.expected_height == expected_height_i64
+                        && row.expected_block_id == expected_block_id
+                });
+                let missing_count = if matches_expected {
+                    existing
+                        .as_ref()
+                        .and_then(|row| row.missing_count.checked_add(1))
+                        .ok_or_else(|| {
+                            BridgeError::ValueConversion(
+                                "Nock missing-inclusion count overflow".into(),
+                            )
+                        })?
+                } else {
+                    1
+                };
+                let first_observed_at = if matches_expected {
+                    existing
+                        .as_ref()
+                        .map(|row| row.first_observed_at)
+                        .unwrap_or(observed_at)
+                } else {
+                    observed_at
+                };
+                diesel::sql_query(
+                    r#"
+                    INSERT INTO sequencer_nock_reorg_observations (
+                        withdrawal_id_base_event_id, expected_height,
+                        expected_block_id, missing_count,
+                        first_observed_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(withdrawal_id_base_event_id) DO UPDATE SET
+                        expected_height = excluded.expected_height,
+                        expected_block_id = excluded.expected_block_id,
+                        missing_count = excluded.missing_count,
+                        first_observed_at = excluded.first_observed_at,
+                        updated_at = excluded.updated_at
+                    "#,
+                )
+                .bind::<Binary, _>(id.base_event_id.0)
+                .bind::<BigInt, _>(expected_height_i64)
+                .bind::<Binary, _>(expected_block_id)
+                .bind::<BigInt, _>(missing_count)
+                .bind::<BigInt, _>(first_observed_at)
+                .bind::<BigInt, _>(observed_at)
+                .execute(conn)?;
+                Ok(u64::try_from(missing_count)?)
+            })
+            .map_err(|err| {
+                BridgeError::Runtime(format!(
+                    "Nock missing-inclusion observation transaction failed: {err}"
+                ))
+            })
+        })
+        .await
+    }
+
+    pub async fn clear_missing_nockchain_inclusion(
+        &self,
+        id: &WithdrawalId,
+    ) -> Result<(), BridgeError> {
+        let id = id.clone();
+        self.with_conn(move |conn| {
+            diesel::sql_query(
+                "DELETE FROM sequencer_nock_reorg_observations WHERE withdrawal_id_base_event_id = ?",
+            )
+            .bind::<Binary, _>(id.base_event_id.0)
+            .execute(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!(
+                    "Nock missing-inclusion observation clear failed: {err}"
+                ))
+            })?;
+            Ok(())
+        })
+        .await
+    }
+
     /// Verifies the complete lifecycle/reservation projection after replay and
     /// chain reconciliation. This check is read-only and fails closed rather
     /// than repairing corruption without a journal event.
@@ -1455,6 +1673,160 @@ impl WithdrawalSequencerStore {
         let journal_enabled = self.journal.is_enabled();
         self.with_conn(move |conn| verify_startup_lifecycle_integrity(conn, journal_enabled))
             .await
+    }
+
+    pub async fn activate_base_reorg_guard(
+        &self,
+        chain_id: u64,
+        nock_contract_address: Address,
+        reason: String,
+    ) -> Result<u64, BridgeError> {
+        let created_at = now_unix_secs()?;
+        self.with_conn(move |conn| {
+            conn.immediate_transaction::<_, anyhow::Error, _>(|conn| {
+                let existing = diesel::sql_query(
+                    r#"
+                    SELECT generation, reason
+                    FROM sequencer_base_reorg_guard
+                    WHERE chain_id = ? AND nock_contract_address = ?
+                    "#,
+                )
+                .bind::<BigInt, _>(checked_i64(chain_id, "chain_id")?)
+                .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+                .get_result::<BaseReorgGuardRow>(conn)
+                .optional()?;
+                if let Some(existing) = existing {
+                    if existing.reason == reason {
+                        return Ok(u64::try_from(existing.generation)?);
+                    }
+                }
+                let generation = diesel::sql_query(
+                    r#"
+                    SELECT MAX(value) AS value
+                    FROM (
+                        SELECT generation AS value
+                        FROM sequencer_base_reorg_events
+                        WHERE chain_id = ? AND nock_contract_address = ?
+                        UNION ALL
+                        SELECT generation AS value
+                        FROM sequencer_base_burn_invalidations
+                        WHERE chain_id = ? AND nock_contract_address = ?
+                        UNION ALL
+                        SELECT generation AS value
+                        FROM sequencer_base_reorg_guard
+                        WHERE chain_id = ? AND nock_contract_address = ?
+                    )
+                    "#,
+                )
+                .bind::<BigInt, _>(checked_i64(chain_id, "chain_id")?)
+                .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+                .bind::<BigInt, _>(checked_i64(chain_id, "chain_id")?)
+                .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+                .bind::<BigInt, _>(checked_i64(chain_id, "chain_id")?)
+                .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+                .get_result::<OptionalMaxGeneration>(conn)?
+                .value
+                .map(u64::try_from)
+                .transpose()?
+                .unwrap_or_default()
+                .saturating_add(1);
+                diesel::sql_query(
+                    r#"
+                    INSERT INTO sequencer_base_reorg_guard (
+                        chain_id, nock_contract_address, generation, reason, created_at
+                    ) VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(chain_id, nock_contract_address) DO UPDATE SET
+                        generation = excluded.generation,
+                        reason = excluded.reason,
+                        created_at = excluded.created_at
+                    "#,
+                )
+                .bind::<BigInt, _>(checked_i64(chain_id, "chain_id")?)
+                .bind::<Binary, _>(nock_contract_address.as_slice().to_vec())
+                .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+                .bind::<Text, _>(reason)
+                .bind::<BigInt, _>(created_at)
+                .execute(conn)?;
+                Ok(generation)
+            })
+            .map_err(|err| {
+                BridgeError::Runtime(format!("Base reorg guard transaction failed: {err}"))
+            })
+        })
+        .await
+    }
+
+    pub async fn ensure_reorg_ready(&self) -> Result<(), BridgeError> {
+        self.with_conn(|conn| {
+            let guard = diesel::sql_query(
+                r#"
+                SELECT generation, reason
+                FROM (
+                    SELECT generation, reason, created_at
+                    FROM sequencer_base_reorg_guard
+                    UNION ALL
+                    SELECT invalidation.generation, invalidation.reason,
+                           invalidation.invalidated_at AS created_at
+                    FROM sequencer_base_burn_invalidations AS invalidation
+                    JOIN sequencer_withdrawals AS withdrawal
+                      ON withdrawal.withdrawal_id_base_event_id =
+                         invalidation.base_event_id
+                    WHERE withdrawal.state = 'reorg_hold'
+                    UNION ALL
+                    SELECT invalidation.generation, invalidation.reason,
+                           invalidation.created_at
+                    FROM sequencer_nock_reorg_events AS invalidation
+                    JOIN sequencer_withdrawals AS withdrawal
+                      ON withdrawal.withdrawal_id_base_event_id =
+                         invalidation.withdrawal_id_base_event_id
+                    WHERE withdrawal.state = 'reorg_hold'
+                    UNION ALL
+                    SELECT -1 AS generation,
+                           'withdrawal lifecycle remains reorg_hold' AS reason,
+                           updated_at - 1 AS created_at
+                    FROM sequencer_withdrawals
+                    WHERE state = 'reorg_hold'
+                )
+                ORDER BY created_at DESC
+                LIMIT 1
+                "#,
+            )
+            .get_result::<BaseReorgGuardRow>(conn)
+            .optional()
+            .map_err(|err| BridgeError::Runtime(format!("Base reorg guard load failed: {err}")))?;
+            if let Some(guard) = guard {
+                return Err(BridgeError::BaseBridgeMonitoring(format!(
+                    "reorg hold generation {} blocks sequencer mutations: {}",
+                    guard.generation, guard.reason
+                )));
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    /// Applies one bounded Base rewind or durably escalates unsafe lifecycle rows.
+    pub async fn apply_base_activity_reorg(
+        &self,
+        plan: BaseActivityReorgPlan,
+    ) -> Result<BaseActivityReorgReport, BridgeError> {
+        let evidence = plan.clone();
+        let report = self
+            .with_write_tx(move |conn, journal| apply_base_activity_reorg_tx(conn, journal, &plan))
+            .await?;
+        if report.lifecycle_rows_held > 0 {
+            return Err(BridgeError::BaseBridgeMonitoring(format!(
+                "Base reorg requires operator intervention: generation={} cursor={} {:?} ancestor={} {:?} depth={} held_rows={}",
+                report.generation,
+                evidence.old_cursor.last_verified_block,
+                evidence.old_cursor.last_verified_block_hash,
+                evidence.common_ancestor.block_number,
+                evidence.common_ancestor.block_hash,
+                evidence.rewind_depth,
+                report.lifecycle_rows_held
+            )));
+        }
+        Ok(report)
     }
 
     /// Recovers eligible canonical Base burns that have no sequencer ordering
@@ -1557,6 +1929,36 @@ impl WithdrawalSequencerStore {
                         "sequencer withdrawal {:?} Base batch end conflicts with verified Base burn",
                         id
                     )));
+                }
+                if existing.state == WithdrawalState::Invalidated {
+                    let next_epoch = existing.current_epoch.checked_add(1).ok_or_else(|| {
+                        BridgeError::Runtime(format!(
+                            "invalidated withdrawal {:?} epoch overflow",
+                            existing.id
+                        ))
+                    })?;
+                    let record = sequencer_journal_record_with_request_facts(
+                        created_at,
+                        SequencerJournalEventType::WithdrawalOrdered,
+                        &id,
+                        next_epoch,
+                        existing.withdrawal_nonce,
+                        Some(&request_facts),
+                        journal_base_context(None, Some(turn_started_base_height), None),
+                        None,
+                        None,
+                        None,
+                        None,
+                    )?;
+                    append_and_project_journal_records(conn, journal, &[record])?;
+                    let nonce = existing.withdrawal_nonce.ok_or_else(|| {
+                        BridgeError::Runtime(format!(
+                            "invalidated sequencer withdrawal {:?} is missing nonce",
+                            id
+                        ))
+                    })?;
+                    assign_withdrawal_nonce(conn, &burn, nonce)?;
+                    return Ok(BaseBurnRecoveryOutcome::Recovered);
                 }
                 let nonce = existing.withdrawal_nonce.ok_or_else(|| {
                     BridgeError::Runtime(format!(
@@ -1730,6 +2132,30 @@ impl WithdrawalSequencerStore {
             CREATE UNIQUE INDEX IF NOT EXISTS withdrawal_reserved_inputs_by_name
               ON withdrawal_reserved_inputs(input_first, input_last);
 
+
+            CREATE TABLE IF NOT EXISTS sequencer_nock_reorg_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                withdrawal_id_base_event_id BLOB NOT NULL
+                  CHECK(length(withdrawal_id_base_event_id) = 32),
+                generation INTEGER NOT NULL,
+                invalidated_height INTEGER NOT NULL,
+                invalidated_block_id BLOB NOT NULL
+                  CHECK(length(invalidated_block_id) = 40),
+                next_state TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                UNIQUE (withdrawal_id_base_event_id, generation)
+            );
+
+            CREATE TABLE IF NOT EXISTS sequencer_nock_reorg_observations (
+                withdrawal_id_base_event_id BLOB PRIMARY KEY NOT NULL
+                  CHECK(length(withdrawal_id_base_event_id) = 32),
+                expected_height INTEGER NOT NULL,
+                expected_block_id BLOB NOT NULL CHECK(length(expected_block_id) = 40),
+                missing_count INTEGER NOT NULL,
+                first_observed_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
             DROP TABLE IF EXISTS current_reserved_inputs;
             DROP TABLE IF EXISTS withdrawal_submission_event_inputs;
             "#,
@@ -2018,6 +2444,13 @@ fn journal_base_context(
         base_batch_end,
         turn_started_base_height,
         last_submit_attempt_base_height,
+        reorg_generation: None,
+        invalidated_block_height: None,
+        invalidated_block_hash: None,
+        common_ancestor_height: None,
+        common_ancestor_hash: None,
+        prior_state: None,
+        reorg_reason: None,
     })
 }
 
@@ -2146,6 +2579,9 @@ fn journal_confirmation_context(
         included_block_id: None,
         confirmed_height: Some(confirmed_height),
         confirmed_block_id: Some(hex::encode(tip5_to_bytes(confirmed_block_id))),
+        reorg_generation: None,
+        next_state: None,
+        reorg_reason: None,
     }
 }
 
@@ -2437,6 +2873,8 @@ fn withdrawal_state_rank(state: WithdrawalState) -> u8 {
         WithdrawalState::Authorized => 3,
         WithdrawalState::MempoolAccepted => 4,
         WithdrawalState::Confirmed => 5,
+        WithdrawalState::Invalidated => 0,
+        WithdrawalState::ReorgHold => 6,
     }
 }
 
@@ -2516,6 +2954,15 @@ fn verify_journal_cursor_event_applied(
             verify_cursor_mempool_retry_attempted(conn, event, &decoded)
         }
         SequencerJournalEventType::TxConfirmed => verify_cursor_tx_confirmed(conn, event, &decoded),
+        SequencerJournalEventType::BaseBurnInvalidated => {
+            verify_cursor_base_reorg_state(conn, event, &decoded, WithdrawalState::Invalidated)
+        }
+        SequencerJournalEventType::BaseReorgHold => {
+            verify_cursor_base_reorg_state(conn, event, &decoded, WithdrawalState::ReorgHold)
+        }
+        SequencerJournalEventType::NockInclusionInvalidated => {
+            verify_cursor_nock_inclusion_invalidated(conn, event, &decoded)
+        }
     }
 }
 
@@ -2650,6 +3097,82 @@ fn verify_cursor_tx_confirmed(
             .submit_metadata()
             .reservations(CursorReservationCheck::Cleared),
     )
+}
+
+fn verify_cursor_base_reorg_state(
+    conn: &mut SqliteConnection,
+    event: &SequencerJournalRecord,
+    decoded: &DecodedJournalEvent,
+    target_state: WithdrawalState,
+) -> Result<(), BridgeError> {
+    let existing =
+        fetch_sequenced_withdrawal(conn, &decoded.id.base_event_id)?.ok_or_else(|| {
+            cursor_projection_mismatch(event, "Base reorg event has no sequencer row")
+        })?;
+    if existing.state != target_state {
+        return Err(cursor_projection_mismatch(
+            event, "Base reorg lifecycle state was not projected",
+        ));
+    }
+    let reserved = load_reserved_input_rows_for_withdrawal(conn, &decoded.id)?;
+    if target_state == WithdrawalState::Invalidated {
+        if !reserved.is_empty() {
+            return Err(cursor_projection_mismatch(
+                event, "invalidated Base burn still owns reservations",
+            ));
+        }
+        let active_burns = diesel::sql_query(
+            r#"
+            SELECT COUNT(*) AS value
+            FROM sequencer_base_burns
+            WHERE base_event_id = ? AND canonical = 1
+            "#,
+        )
+        .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+        .get_result::<LastInsertRowId>(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("Base reorg cursor burn verification failed: {err}"))
+        })?
+        .value;
+        if active_burns != 0 {
+            return Err(cursor_projection_mismatch(
+                event, "invalidated Base burn remains canonical in activity projection",
+            ));
+        }
+    } else {
+        let expected = canonical_inputs_for_startup_integrity(&existing)?;
+        verify_exact_startup_reservations(&existing, &reserved, &expected)
+            .map_err(|err| cursor_projection_mismatch(event, &err.to_string()))?;
+    }
+    Ok(())
+}
+
+fn verify_cursor_nock_inclusion_invalidated(
+    conn: &mut SqliteConnection,
+    event: &SequencerJournalRecord,
+    decoded: &DecodedJournalEvent,
+) -> Result<(), BridgeError> {
+    let confirmation = event.confirmation.as_ref().ok_or_else(|| {
+        cursor_projection_mismatch(event, "Nock invalidation has no confirmation context")
+    })?;
+    let next_state = confirmation
+        .next_state
+        .as_deref()
+        .ok_or_else(|| cursor_projection_mismatch(event, "Nock invalidation has no next state"))?;
+    let expected_state = WithdrawalState::parse(next_state)?;
+    let existing =
+        fetch_sequenced_withdrawal(conn, &decoded.id.base_event_id)?.ok_or_else(|| {
+            cursor_projection_mismatch(event, "Nock invalidation has no sequencer row")
+        })?;
+    if existing.state != expected_state {
+        return Err(cursor_projection_mismatch(
+            event, "Nock invalidation lifecycle state was not projected",
+        ));
+    }
+    let expected = canonical_inputs_for_startup_integrity(&existing)?;
+    let reserved = load_reserved_input_rows_for_withdrawal(conn, &decoded.id)?;
+    verify_exact_startup_reservations(&existing, &reserved, &expected)
+        .map_err(|err| cursor_projection_mismatch(event, &err.to_string()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4026,7 +4549,357 @@ fn apply_journal_event(
         SequencerJournalEventType::TxConfirmed => {
             apply_journal_tx_confirmed(conn, event, &decoded, mode)
         }
+        SequencerJournalEventType::BaseBurnInvalidated => apply_journal_base_reorg_state(
+            conn,
+            event,
+            &decoded,
+            mode,
+            WithdrawalState::Invalidated,
+        ),
+        SequencerJournalEventType::BaseReorgHold => {
+            apply_journal_base_reorg_state(conn, event, &decoded, mode, WithdrawalState::ReorgHold)
+        }
+        SequencerJournalEventType::NockInclusionInvalidated => {
+            apply_journal_nock_inclusion_invalidated(conn, event, &decoded, mode)
+        }
     }
+}
+fn apply_journal_base_reorg_state(
+    conn: &mut SqliteConnection,
+    event: &SequencerJournalRecord,
+    decoded: &DecodedJournalEvent,
+    mode: SequencerJournalApplyMode,
+    target_state: WithdrawalState,
+) -> Result<(), BridgeError> {
+    let base = event.base.as_ref().ok_or_else(|| {
+        BridgeError::Runtime(format!(
+            "{:?} is missing Base reorg context",
+            event.event_type
+        ))
+    })?;
+    let generation = base.reorg_generation.ok_or_else(|| {
+        BridgeError::Runtime(format!(
+            "{:?} is missing reorg generation",
+            event.event_type
+        ))
+    })?;
+    let invalidated_block_height = base.invalidated_block_height.ok_or_else(|| {
+        BridgeError::Runtime(format!(
+            "{:?} is missing invalidated block height",
+            event.event_type
+        ))
+    })?;
+    let invalidated_block_hash = decode_journal_hex(
+        "base.invalidated_block_hash",
+        base.invalidated_block_hash.as_deref().ok_or_else(|| {
+            BridgeError::Runtime(format!(
+                "{:?} is missing invalidated block hash",
+                event.event_type
+            ))
+        })?,
+    )?;
+    let common_ancestor_height = base.common_ancestor_height.ok_or_else(|| {
+        BridgeError::Runtime(format!(
+            "{:?} is missing common ancestor height",
+            event.event_type
+        ))
+    })?;
+    let common_ancestor_hash = decode_journal_hex(
+        "base.common_ancestor_hash",
+        base.common_ancestor_hash.as_deref().ok_or_else(|| {
+            BridgeError::Runtime(format!(
+                "{:?} is missing common ancestor hash",
+                event.event_type
+            ))
+        })?,
+    )?;
+    let reason = base.reorg_reason.as_deref().ok_or_else(|| {
+        BridgeError::Runtime(format!("{:?} is missing reorg reason", event.event_type))
+    })?;
+    let existing =
+        fetch_sequenced_withdrawal(conn, &decoded.id.base_event_id)?.ok_or_else(|| {
+            BridgeError::Runtime(format!(
+                "{:?} references missing withdrawal {:?}",
+                event.event_type, decoded.id
+            ))
+        })?;
+    if target_state == WithdrawalState::Invalidated
+        && matches!(
+            existing.state,
+            WithdrawalState::Authorized
+                | WithdrawalState::MempoolAccepted
+                | WithdrawalState::Confirmed
+                | WithdrawalState::ReorgHold
+        )
+    {
+        return Err(BridgeError::Runtime(format!(
+            "refusing automatic Base invalidation of {:?} in state {}",
+            decoded.id,
+            existing.state.as_str()
+        )));
+    }
+    if target_state == WithdrawalState::ReorgHold
+        && !matches!(
+            existing.state,
+            WithdrawalState::Authorized
+                | WithdrawalState::MempoolAccepted
+                | WithdrawalState::Confirmed
+                | WithdrawalState::ReorgHold
+        )
+    {
+        return Err(BridgeError::Runtime(format!(
+            "refusing Base reorg hold for pre-authorization withdrawal {:?} in state {}",
+            decoded.id,
+            existing.state.as_str()
+        )));
+    }
+    diesel::sql_query(
+        r#"
+        UPDATE sequencer_withdrawals
+        SET state = ?, updated_at = ?
+        WHERE withdrawal_id_base_event_id = ?
+        "#,
+    )
+    .bind::<Text, _>(target_state.as_str())
+    .bind::<BigInt, _>(decoded.created_at)
+    .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base reorg state update failed: {err}")))?;
+    if mode == SequencerJournalApplyMode::Runtime {
+        let debug_event_type = if target_state == WithdrawalState::Invalidated {
+            WithdrawalSubmissionEventType::BaseBurnInvalidated
+        } else {
+            WithdrawalSubmissionEventType::BaseReorgHold
+        };
+        let debug_row = NewWithdrawalSubmissionEventRow::from_withdrawal_id(
+            &decoded.id, decoded.epoch, debug_event_type, decoded.created_at,
+        )?;
+        insert_debug_event(conn, &debug_row)?;
+    }
+    if target_state == WithdrawalState::ReorgHold {
+        let inputs = canonical_inputs_for_startup_integrity(&existing)?;
+        insert_reserved_inputs_for_names(
+            conn, &existing.id, existing.current_epoch, &inputs, decoded.created_at, mode,
+        )?;
+    }
+
+    diesel::sql_query(
+        r#"
+            INSERT OR IGNORE INTO sequencer_base_burn_invalidations (
+                chain_id, nock_contract_address, generation, base_event_id,
+                old_block_number, old_block_hash, lifecycle_state,
+                invalidated_at, reason
+            )
+            SELECT chain_id, nock_contract_address, ?, base_event_id,
+                   block_number, block_hash, ?, ?, ?
+            FROM sequencer_base_burns
+            WHERE base_event_id = ? AND canonical = 1
+            "#,
+    )
+    .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+    .bind::<Text, _>(
+        base.prior_state
+            .clone()
+            .unwrap_or_else(|| existing.state.as_str().to_string()),
+    )
+    .bind::<BigInt, _>(decoded.created_at)
+    .bind::<Text, _>(reason.to_string())
+    .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+    .execute(conn)
+    .map_err(|err| {
+        BridgeError::Runtime(format!(
+            "Base burn invalidation history insert failed: {err}"
+        ))
+    })?;
+    if target_state == WithdrawalState::Invalidated {
+        clear_reserved_inputs_for_withdrawal(conn, &existing.id)?;
+        diesel::sql_query(
+            r#"
+            UPDATE sequencer_base_burns
+            SET canonical = 0, invalidated_at = ?,
+                invalidation_generation = ?, invalidation_reason = ?
+            WHERE base_event_id = ? AND canonical = 1
+            "#,
+        )
+        .bind::<BigInt, _>(decoded.created_at)
+        .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+        .bind::<Text, _>(reason.to_string())
+        .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+        .execute(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("Base burn invalidation update failed: {err}"))
+        })?;
+        diesel::sql_query(
+            r#"
+            UPDATE sequencer_base_activity_cursor
+            SET last_verified_block = ?, last_verified_block_hash = ?, updated_at = ?
+            WHERE EXISTS (
+                SELECT 1 FROM sequencer_base_burns AS burn
+                WHERE burn.chain_id = sequencer_base_activity_cursor.chain_id
+                  AND burn.nock_contract_address =
+                      sequencer_base_activity_cursor.nock_contract_address
+                  AND burn.base_event_id = ?
+            )
+              AND last_verified_block >= ?
+            "#,
+        )
+        .bind::<BigInt, _>(checked_i64(
+            common_ancestor_height, "common_ancestor_height",
+        )?)
+        .bind::<Binary, _>(common_ancestor_hash.clone())
+        .bind::<BigInt, _>(decoded.created_at)
+        .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+        .bind::<BigInt, _>(checked_i64(
+            common_ancestor_height, "common_ancestor_height",
+        )?)
+        .execute(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("Base activity cursor rewind failed: {err}"))
+        })?;
+        diesel::sql_query(
+            r#"
+            DELETE FROM sequencer_base_header_checkpoints
+            WHERE block_number > ?
+              AND EXISTS (
+                SELECT 1 FROM sequencer_base_burns AS burn
+                WHERE burn.chain_id = sequencer_base_header_checkpoints.chain_id
+                  AND burn.nock_contract_address =
+                      sequencer_base_header_checkpoints.nock_contract_address
+                  AND burn.base_event_id = ?
+              )
+            "#,
+        )
+        .bind::<BigInt, _>(checked_i64(
+            common_ancestor_height, "common_ancestor_height",
+        )?)
+        .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+        .execute(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("Base header checkpoint rewind failed: {err}"))
+        })?;
+    }
+    if invalidated_block_hash.len() != 32 || common_ancestor_hash.len() != 32 {
+        return Err(BridgeError::Runtime(
+            "Base reorg journal hashes must be 32 bytes".into(),
+        ));
+    }
+    if invalidated_block_height <= common_ancestor_height {
+        return Err(BridgeError::Runtime(format!(
+            "Base reorg invalidated height {invalidated_block_height} must exceed ancestor {common_ancestor_height}"
+        )));
+    }
+    Ok(())
+}
+
+fn apply_journal_nock_inclusion_invalidated(
+    conn: &mut SqliteConnection,
+    event: &SequencerJournalRecord,
+    decoded: &DecodedJournalEvent,
+    mode: SequencerJournalApplyMode,
+) -> Result<(), BridgeError> {
+    let confirmation = event.confirmation.as_ref().ok_or_else(|| {
+        BridgeError::Runtime("Nock inclusion invalidation is missing confirmation context".into())
+    })?;
+    let generation = confirmation.reorg_generation.ok_or_else(|| {
+        BridgeError::Runtime("Nock inclusion invalidation is missing generation".into())
+    })?;
+    let invalidated_height = confirmation.confirmed_height.ok_or_else(|| {
+        BridgeError::Runtime("Nock inclusion invalidation is missing old height".into())
+    })?;
+    let invalidated_block_id = decode_journal_hex(
+        "confirmation.confirmed_block_id",
+        confirmation.confirmed_block_id.as_deref().ok_or_else(|| {
+            BridgeError::Runtime("Nock inclusion invalidation is missing old block id".into())
+        })?,
+    )?;
+    if invalidated_block_id.len() != 40 {
+        return Err(BridgeError::Runtime(format!(
+            "Nock inclusion invalidation block id has {} bytes, expected 40",
+            invalidated_block_id.len()
+        )));
+    }
+    let next_state =
+        WithdrawalState::parse(confirmation.next_state.as_deref().ok_or_else(|| {
+            BridgeError::Runtime("Nock inclusion invalidation is missing next state".into())
+        })?)?;
+    if !matches!(
+        next_state,
+        WithdrawalState::Authorized | WithdrawalState::MempoolAccepted | WithdrawalState::ReorgHold
+    ) {
+        return Err(BridgeError::Runtime(format!(
+            "invalid Nock inclusion recovery state {}",
+            next_state.as_str()
+        )));
+    }
+    let reason = confirmation.reorg_reason.as_deref().ok_or_else(|| {
+        BridgeError::Runtime("Nock inclusion invalidation is missing reason".into())
+    })?;
+    if reason.is_empty() {
+        return Err(BridgeError::Runtime(
+            "Nock inclusion invalidation reason must not be empty".into(),
+        ));
+    }
+    let existing =
+        fetch_sequenced_withdrawal(conn, &decoded.id.base_event_id)?.ok_or_else(|| {
+            BridgeError::Runtime(format!(
+                "Nock inclusion invalidation references missing withdrawal {:?}",
+                decoded.id
+            ))
+        })?;
+    if existing.state != WithdrawalState::Confirmed && existing.state != next_state {
+        return Err(BridgeError::Runtime(format!(
+            "cannot invalidate Nock inclusion for {:?} from state {}",
+            decoded.id,
+            existing.state.as_str()
+        )));
+    }
+    diesel::sql_query(
+        r#"
+        INSERT OR IGNORE INTO sequencer_nock_reorg_events (
+            withdrawal_id_base_event_id, generation, invalidated_height,
+            invalidated_block_id, next_state, reason, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+    .bind::<BigInt, _>(checked_i64(generation, "nock_reorg_generation")?)
+    .bind::<BigInt, _>(checked_i64(invalidated_height, "invalidated_height")?)
+    .bind::<Binary, _>(invalidated_block_id)
+    .bind::<Text, _>(next_state.as_str())
+    .bind::<Text, _>(reason.to_string())
+    .bind::<BigInt, _>(decoded.created_at)
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Nock reorg event projection failed: {err}")))?;
+    diesel::sql_query(
+        r#"
+        UPDATE sequencer_withdrawals
+        SET state = ?, updated_at = ?
+        WHERE withdrawal_id_base_event_id = ?
+        "#,
+    )
+    .bind::<Text, _>(next_state.as_str())
+    .bind::<BigInt, _>(decoded.created_at)
+    .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+    .execute(conn)
+    .map_err(|err| {
+        BridgeError::Runtime(format!(
+            "Nock inclusion invalidation state update failed: {err}"
+        ))
+    })?;
+    let inputs = canonical_inputs_for_startup_integrity(&existing)?;
+    insert_reserved_inputs_for_names(
+        conn, &existing.id, existing.current_epoch, &inputs, decoded.created_at, mode,
+    )?;
+    if mode == SequencerJournalApplyMode::Runtime {
+        let debug = NewWithdrawalSubmissionEventRow::from_withdrawal_id(
+            &decoded.id,
+            decoded.epoch,
+            WithdrawalSubmissionEventType::NockInclusionInvalidated,
+            decoded.created_at,
+        )?;
+        insert_debug_event(conn, &debug)?;
+    }
+    Ok(())
 }
 
 /// Projects `withdrawal_ordered` by materializing the sequencer row and nonce.
@@ -4050,6 +4923,46 @@ fn apply_journal_withdrawal_ordered(
                 "withdrawal_ordered journal event {} request facts do not match existing projection for {:?}",
                 event.event_id, decoded.id
             )));
+        }
+        if existing.state == WithdrawalState::Invalidated {
+            diesel::sql_query(
+                r#"
+                UPDATE sequencer_withdrawals
+                SET withdrawal_id_as_of = ?, current_epoch = ?,
+                    proposal_hash = NULL, canonical_amount = NULL,
+                    canonical_base_batch_end = NULL,
+                    canonical_transaction_jam = NULL,
+                    canonical_selected_inputs_jam = NULL,
+                    canonical_snapshot_height = NULL,
+                    canonical_snapshot_block_id = NULL,
+                    peer_commit_certificate = NULL,
+                    authorized_transaction_name = NULL,
+                    authorized_transaction_jam = NULL,
+                    authorized_raw_tx = NULL,
+                    handoff_index = 0, turn_started_base_height = ?,
+                    submit_attempt_count = 0,
+                    last_submit_attempt_base_height = NULL,
+                    last_submit_error = NULL,
+                    state = 'pending', updated_at = ?
+                WHERE withdrawal_id_base_event_id = ?
+                "#,
+            )
+            .bind::<Binary, _>(tip5_to_bytes(&decoded.id.as_of))
+            .bind::<BigInt, _>(checked_i64(decoded.epoch, "epoch")?)
+            .bind::<Nullable<BigInt>, _>(
+                turn_started_base_height
+                    .map(|height| checked_i64(height, "turn_started_base_height"))
+                    .transpose()?,
+            )
+            .bind::<BigInt, _>(decoded.created_at)
+            .bind::<Binary, _>(decoded.id.base_event_id.0.clone())
+            .execute(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!(
+                    "withdrawal_ordered re-admission update failed: {err}"
+                ))
+            })?;
+            return Ok(());
         }
         if turn_started_base_height.is_some()
             && existing.turn_started_base_height != turn_started_base_height
@@ -4371,10 +5284,10 @@ fn apply_journal_tx_confirmed(
     )?;
     // `sequencer_withdrawals` does not currently persist confirmation block
     // metadata; validate it here so malformed replay records still fail closed.
-    let _confirmed_height = confirmation.confirmed_height.ok_or_else(|| {
+    let confirmed_height = confirmation.confirmed_height.ok_or_else(|| {
         BridgeError::Runtime("tx_confirmed journal event is missing confirmed_height".to_string())
     })?;
-    let _confirmed_block_id = confirmation
+    let confirmed_block_id = confirmation
         .confirmed_block_id
         .as_deref()
         .ok_or_else(|| {
@@ -4445,7 +5358,30 @@ fn apply_journal_tx_confirmed(
             updated_at: decoded.created_at,
         },
     )?;
-    clear_reserved_inputs_for_withdrawal(conn, &decoded.id)
+    clear_reserved_inputs_for_withdrawal(conn, &decoded.id)?;
+    if mode == SequencerJournalApplyMode::Replay {
+        let debug = NewWithdrawalSubmissionEventRow {
+            created_at: decoded.created_at,
+            withdrawal_id_as_of: tip5_to_bytes(&decoded.id.as_of),
+            withdrawal_id_base_event_id: decoded.id.base_event_id.0.clone(),
+            epoch: i64::try_from(decoded.epoch)
+                .map_err(|err| BridgeError::ValueConversion(format!("epoch too large: {err}")))?,
+            proposal_hash: proposal.proposal_hash.clone(),
+            transaction_name: journal_submitted_raw_tx_id(event).unwrap_or_default(),
+            event_type: WithdrawalSubmissionEventType::TxConfirmed
+                .as_str()
+                .to_string(),
+            signer_node_id: None,
+            commit_certificate: None,
+            transaction_jam: None,
+            snapshot_height: None,
+            snapshot_block_id: None,
+            confirmed_height: Some(checked_i64(confirmed_height, "confirmed_height")?),
+            confirmed_block_id: Some(tip5_to_bytes(&confirmed_block_id)),
+        };
+        insert_debug_event(conn, &debug)?;
+    }
+    Ok(())
 }
 
 impl NewWithdrawalSubmissionEventRow {
@@ -4787,6 +5723,8 @@ fn set_journal_recovery_bounds(
         observe_height(max_base_height, base.base_batch_end);
         observe_height(max_base_height, base.turn_started_base_height);
         observe_height(max_base_height, base.last_submit_attempt_base_height);
+        observe_height(max_base_height, base.invalidated_block_height);
+        observe_height(max_base_height, base.common_ancestor_height);
     }
     if let Some(nockchain) = &record.nockchain {
         observe_height(max_nockchain_height, nockchain.snapshot_height);
@@ -5650,6 +6588,121 @@ fn record_tx_confirmed_tx(
     Ok(())
 }
 
+fn record_nockchain_inclusion_invalidated_tx(
+    conn: &mut SqliteConnection,
+    journal: &SequencerJournalHandle,
+    id: &WithdrawalId,
+    confirmed_height: u64,
+    confirmed_block_id: &Tip5Hash,
+    next_state: WithdrawalState,
+    reason: &str,
+    created_at: i64,
+) -> Result<u64, BridgeError> {
+    if !matches!(
+        next_state,
+        WithdrawalState::Authorized | WithdrawalState::MempoolAccepted | WithdrawalState::ReorgHold
+    ) {
+        return Err(BridgeError::Runtime(format!(
+            "unsupported Nock inclusion recovery state {}",
+            next_state.as_str()
+        )));
+    }
+    let existing = fetch_sequenced_withdrawal(conn, &id.base_event_id)?.ok_or_else(|| {
+        BridgeError::Runtime(format!(
+            "cannot invalidate Nock inclusion for missing withdrawal {:?}",
+            id
+        ))
+    })?;
+    if existing.state != WithdrawalState::Confirmed {
+        return Err(BridgeError::Runtime(format!(
+            "cannot invalidate Nock inclusion for withdrawal {:?} in state {}",
+            id,
+            existing.state.as_str()
+        )));
+    }
+    let confirmation = load_events(conn)?
+        .into_iter()
+        .rev()
+        .find(|event| {
+            event.event_type == WithdrawalSubmissionEventType::TxConfirmed
+                && same_base_event_id(&event.id, id)
+        })
+        .ok_or_else(|| {
+            BridgeError::Runtime(format!(
+                "confirmed withdrawal {:?} has no durable confirmation event",
+                id
+            ))
+        })?;
+    if confirmation.confirmed_height != Some(confirmed_height)
+        || confirmation.confirmed_block_id.as_ref() != Some(confirmed_block_id)
+    {
+        return Err(BridgeError::Runtime(format!(
+            "Nock inclusion invalidation evidence for {:?} does not match latest confirmation",
+            id
+        )));
+    }
+    let generation = diesel::sql_query(
+        r#"
+        SELECT MAX(generation) AS value
+        FROM sequencer_nock_reorg_events
+        WHERE withdrawal_id_base_event_id = ?
+        "#,
+    )
+    .bind::<Binary, _>(id.base_event_id.0.clone())
+    .get_result::<OptionalMaxGeneration>(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Nock reorg generation load failed: {err}")))?
+    .value
+    .map(u64::try_from)
+    .transpose()
+    .map_err(|err| {
+        BridgeError::ValueConversion(format!("Nock reorg generation is invalid: {err}"))
+    })?
+    .unwrap_or_default()
+    .saturating_add(1);
+    let nockchain =
+        existing
+            .canonical_snapshot
+            .as_ref()
+            .map(|snapshot| SequencerJournalNockchainContext {
+                snapshot_height: Some(snapshot.height),
+                snapshot_block_id: Some(hex::encode(tip5_to_bytes(&snapshot.block_id))),
+                safe_tip_height_observed_by_writer: None,
+            });
+    let record = sequencer_journal_record(
+        created_at,
+        SequencerJournalEventType::NockInclusionInvalidated,
+        &existing.id,
+        existing.current_epoch,
+        existing.withdrawal_nonce,
+        journal_base_context(
+            existing
+                .request_facts
+                .as_ref()
+                .map(|facts| facts.base_batch_end),
+            existing.turn_started_base_height,
+            existing.last_submit_attempt_base_height,
+        ),
+        nockchain,
+        Some(journal_proposal_context_from_existing(&existing)?),
+        Some(journal_submission_context_from_existing(
+            &existing,
+            Some(existing.submit_attempt_count),
+            existing.last_submit_error.as_deref(),
+        )),
+        Some(SequencerJournalConfirmationContext {
+            included_height: None,
+            included_block_id: None,
+            confirmed_height: Some(confirmed_height),
+            confirmed_block_id: Some(hex::encode(tip5_to_bytes(confirmed_block_id))),
+            reorg_generation: Some(generation),
+            next_state: Some(next_state.as_str().to_string()),
+            reorg_reason: Some(reason.to_string()),
+        }),
+    )?;
+    append_and_project_journal_records(conn, journal, &[record])?;
+    Ok(generation)
+}
+
 fn record_tx_seen_mempool_accepted_tx(
     conn: &mut SqliteConnection,
     journal: &SequencerJournalHandle,
@@ -6164,6 +7217,8 @@ fn current_live_withdrawal_frontier(
         WithdrawalState::Pending.as_str(),
         WithdrawalState::PeerCanonical.as_str(),
         WithdrawalState::Authorized.as_str(),
+        WithdrawalState::MempoolAccepted.as_str(),
+        WithdrawalState::ReorgHold.as_str(),
     ];
     let row = sequencer_withdrawals::table
         .filter(sequenced::state.eq_any(unreleased_states))
@@ -6371,6 +7426,76 @@ fn load_all_sequenced_withdrawal_views(
         .collect()
 }
 
+fn load_confirmed_nockchain_withdrawals(
+    conn: &mut SqliteConnection,
+) -> Result<Vec<ConfirmedNockchainWithdrawal>, BridgeError> {
+    let rows = load_all_sequenced_withdrawal_views(conn)?;
+    let events = load_events(conn)?;
+    rows.into_iter()
+        .filter(|row| row.state == WithdrawalState::Confirmed)
+        .map(|row| {
+            let confirmation = events
+                .iter()
+                .rev()
+                .find(|event| {
+                    event.event_type == WithdrawalSubmissionEventType::TxConfirmed
+                        && same_base_event_id(&event.id, &row.id)
+                })
+                .ok_or_else(|| {
+                    BridgeError::Runtime(format!(
+                        "confirmed withdrawal {:?} has no confirmation event",
+                        row.id
+                    ))
+                })?;
+            let confirmed_height = confirmation.confirmed_height.ok_or_else(|| {
+                BridgeError::Runtime(format!(
+                    "confirmed withdrawal {:?} event has no height",
+                    row.id
+                ))
+            })?;
+            let confirmed_block_id = confirmation.confirmed_block_id.clone().ok_or_else(|| {
+                BridgeError::Runtime(format!(
+                    "confirmed withdrawal {:?} event has no block id",
+                    row.id
+                ))
+            })?;
+            let submitted_raw_tx_id = row.authorized_transaction_name.clone().ok_or_else(|| {
+                BridgeError::Runtime(format!(
+                    "confirmed withdrawal {:?} has no raw tx id",
+                    row.id
+                ))
+            })?;
+            let raw_tx = withdrawal_raw_tx::decode_raw_tx(
+                row.authorized_raw_tx.clone().ok_or_else(|| {
+                    BridgeError::Runtime(format!(
+                        "confirmed withdrawal {:?} has no authorized raw tx",
+                        row.id
+                    ))
+                })?,
+            )?;
+            let snapshot_height = row
+                .canonical_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.height)
+                .ok_or_else(|| {
+                    BridgeError::Runtime(format!(
+                        "confirmed withdrawal {:?} has no canonical snapshot",
+                        row.id
+                    ))
+                })?;
+            Ok(ConfirmedNockchainWithdrawal {
+                id: row.id,
+                epoch: row.current_epoch,
+                submitted_raw_tx_id,
+                raw_tx,
+                confirmed_height,
+                confirmed_block_id,
+                snapshot_height,
+            })
+        })
+        .collect()
+}
+
 fn fetch_all_sequenced_withdrawals(
     conn: &mut SqliteConnection,
 ) -> Result<Vec<LiveWithdrawalView>, BridgeError> {
@@ -6378,6 +7503,136 @@ fn fetch_all_sequenced_withdrawals(
         .into_iter()
         .map(SequencedWithdrawalView::into_live_withdrawal_view)
         .collect())
+}
+
+fn public_recovery_bytes<const N: usize>(
+    value: &[u8],
+    field: &str,
+) -> Result<[u8; N], BridgeError> {
+    value.try_into().map_err(|_| {
+        BridgeError::ValueConversion(format!("public recovery {field} must be exactly {N} bytes"))
+    })
+}
+
+fn load_public_recovery_projections(
+    conn: &mut SqliteConnection,
+    base_event_ids: &[Vec<u8>],
+) -> Result<HashMap<BaseEventId, PublicWithdrawalRecoveryProjection>, BridgeError> {
+    use diesel::dsl::max;
+
+    use crate::withdrawal::sequencer::schema::sequencer_base_burn_invalidations::dsl as base;
+    use crate::withdrawal::sequencer::schema::sequencer_nock_reorg_events::dsl as nock;
+
+    let latest_base_event_ids = base::sequencer_base_burn_invalidations
+        .filter(base::base_event_id.eq_any(base_event_ids))
+        .group_by(base::base_event_id)
+        .select(max(base::event_id))
+        .load::<Option<i64>>(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("public Base recovery index query failed: {err}"))
+        })?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let latest_nock_event_ids = nock::sequencer_nock_reorg_events
+        .filter(nock::withdrawal_id_base_event_id.eq_any(base_event_ids))
+        .group_by(nock::withdrawal_id_base_event_id)
+        .select(max(nock::event_id))
+        .load::<Option<i64>>(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("public Nock recovery index query failed: {err}"))
+        })?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+    let mut recoveries = HashMap::new();
+    if !latest_base_event_ids.is_empty() {
+        let rows = base::sequencer_base_burn_invalidations
+            .filter(base::event_id.eq_any(latest_base_event_ids))
+            .select((
+                base::base_event_id,
+                base::generation,
+                base::old_block_number,
+                base::old_block_hash,
+                base::lifecycle_state,
+                base::invalidated_at,
+                base::reason,
+            ))
+            .load::<(Vec<u8>, i64, i64, Vec<u8>, Option<String>, i64, String)>(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!("public Base recovery query failed: {err}"))
+            })?;
+        for (base_event_id, generation, height, block_id, prior_status, observed_at, reason) in rows
+        {
+            let base_event_id =
+                BaseEventId(public_recovery_bytes::<32>(&base_event_id, "base_event_id")?.to_vec());
+            recoveries.insert(
+                base_event_id,
+                PublicWithdrawalRecoveryProjection {
+                    generation: u64::try_from(generation).map_err(|err| {
+                        BridgeError::ValueConversion(format!(
+                            "public Base recovery generation is invalid: {err}"
+                        ))
+                    })?,
+                    invalidated_block_height: u64::try_from(height).map_err(|err| {
+                        BridgeError::ValueConversion(format!(
+                            "public Base recovery height is invalid: {err}"
+                        ))
+                    })?,
+                    invalidated_block_id: public_recovery_bytes::<32>(&block_id, "Base block id")?
+                        .to_vec(),
+                    prior_status: prior_status.unwrap_or_else(|| "unknown".to_string()),
+                    reason,
+                    observed_at,
+                },
+            );
+        }
+    }
+    if !latest_nock_event_ids.is_empty() {
+        let rows = nock::sequencer_nock_reorg_events
+            .filter(nock::event_id.eq_any(latest_nock_event_ids))
+            .select((
+                nock::withdrawal_id_base_event_id,
+                nock::generation,
+                nock::invalidated_height,
+                nock::invalidated_block_id,
+                nock::reason,
+                nock::created_at,
+            ))
+            .load::<(Vec<u8>, i64, i64, Vec<u8>, String, i64)>(conn)
+            .map_err(|err| {
+                BridgeError::Runtime(format!("public Nock recovery query failed: {err}"))
+            })?;
+        for (base_event_id, generation, height, block_id, reason, observed_at) in rows {
+            let base_event_id =
+                BaseEventId(public_recovery_bytes::<32>(&base_event_id, "base_event_id")?.to_vec());
+            let recovery = PublicWithdrawalRecoveryProjection {
+                generation: u64::try_from(generation).map_err(|err| {
+                    BridgeError::ValueConversion(format!(
+                        "public Nock recovery generation is invalid: {err}"
+                    ))
+                })?,
+                invalidated_block_height: u64::try_from(height).map_err(|err| {
+                    BridgeError::ValueConversion(format!(
+                        "public Nock recovery height is invalid: {err}"
+                    ))
+                })?,
+                invalidated_block_id: public_recovery_bytes::<40>(&block_id, "Nock block id")?
+                    .to_vec(),
+                prior_status: WithdrawalState::Confirmed.as_str().to_string(),
+                reason,
+                observed_at,
+            };
+            if recoveries
+                .get(&base_event_id)
+                .is_none_or(|existing| existing.observed_at <= recovery.observed_at)
+            {
+                recoveries.insert(base_event_id, recovery);
+            }
+        }
+    }
+    Ok(recoveries)
 }
 
 fn load_public_lifecycle_projections(
@@ -6394,6 +7649,7 @@ fn load_public_lifecycle_projections(
         .iter()
         .map(|id| id.0.clone())
         .collect::<Vec<_>>();
+    let mut recoveries = load_public_recovery_projections(conn, &ids)?;
     let rows = sequencer_withdrawals::table
         .filter(sequenced::withdrawal_id_base_event_id.eq_any(ids.clone()))
         .load::<SequencerWithdrawalStoredRow>(conn)
@@ -6401,7 +7657,7 @@ fn load_public_lifecycle_projections(
             BridgeError::Runtime(format!("public lifecycle batch query failed: {err}"))
         })?;
     let confirmation_rows = withdrawal_submission_events::table
-        .filter(events::withdrawal_id_base_event_id.eq_any(ids))
+        .filter(events::withdrawal_id_base_event_id.eq_any(ids.clone()))
         .filter(events::event_type.eq(WithdrawalSubmissionEventType::TxConfirmed.as_str()))
         .filter(events::confirmed_height.is_not_null())
         .filter(events::confirmed_block_id.is_not_null())
@@ -6436,6 +7692,7 @@ fn load_public_lifecycle_projections(
                 lifecycle: view.into_live_withdrawal_view(),
                 net_amount,
                 confirmation: confirmations.remove(&base_event_id),
+                recovery: recoveries.remove(&base_event_id),
             },
         );
     }
@@ -6512,6 +7769,25 @@ fn verify_startup_lifecycle_integrity(
                     ));
                 }
             }
+            WithdrawalState::Invalidated => {
+                if !reserved.is_empty() {
+                    return Err(startup_integrity_error(
+                        row, "invalidated withdrawal still owns input reservations",
+                    ));
+                }
+            }
+            WithdrawalState::ReorgHold => {
+                let expected_inputs = canonical_inputs_for_startup_integrity(row)?;
+                verify_authorized_startup_artifacts(row)?;
+                verify_exact_startup_reservations(row, &reserved, &expected_inputs)?;
+                report.reservations_verified = report.reservations_verified.saturating_add(
+                    u64::try_from(reserved.len()).map_err(|err| {
+                        BridgeError::ValueConversion(format!(
+                            "startup reservation count overflow: {err}"
+                        ))
+                    })?,
+                );
+            }
         }
     }
 
@@ -6521,6 +7797,350 @@ fn verify_startup_lifecycle_integrity(
         )));
     }
     Ok(report)
+}
+
+fn apply_base_activity_reorg_tx(
+    conn: &mut SqliteConnection,
+    journal: &SequencerJournalHandle,
+    plan: &BaseActivityReorgPlan,
+) -> Result<BaseActivityReorgReport, BridgeError> {
+    let cursor =
+        load_activity_cursor_for_reconciliation(conn, plan.chain_id, plan.nock_contract_address)?
+            .ok_or_else(|| BridgeError::Runtime("Base reorg has no activity cursor".into()))?;
+    if cursor != plan.old_cursor {
+        return Err(BridgeError::Runtime(format!(
+            "Base reorg plan cursor changed before apply: planned {} {:?}, current {} {:?}",
+            plan.old_cursor.last_verified_block,
+            plan.old_cursor.last_verified_block_hash,
+            cursor.last_verified_block,
+            cursor.last_verified_block_hash
+        )));
+    }
+    let generation = diesel::sql_query(
+        r#"
+        SELECT MAX(value) AS value
+        FROM (
+            SELECT generation AS value
+            FROM sequencer_base_reorg_events
+            WHERE chain_id = ? AND nock_contract_address = ?
+            UNION ALL
+            SELECT generation AS value
+            FROM sequencer_base_burn_invalidations
+            WHERE chain_id = ? AND nock_contract_address = ?
+        )
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .get_result::<OptionalMaxGeneration>(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base reorg generation load failed: {err}")))?
+    .value
+    .map(u64::try_from)
+    .transpose()
+    .map_err(|err| {
+        BridgeError::ValueConversion(format!("Base reorg generation is invalid: {err}"))
+    })?
+    .unwrap_or_default()
+    .saturating_add(1);
+    let affected = diesel::sql_query(
+        r#"
+        SELECT base_event_id, block_number, block_hash
+        FROM sequencer_base_burns
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND canonical = 1 AND block_number > ?
+        ORDER BY block_number ASC, base_event_id ASC
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?)
+    .load::<BaseReorgBurnRow>(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base reorg burn load failed: {err}")))?;
+    let reason = format!(
+        "Base fork generation {generation}: cursor {} {:?} rewinds to common ancestor {} {:?}",
+        plan.old_cursor.last_verified_block,
+        plan.old_cursor.last_verified_block_hash,
+        plan.common_ancestor.block_number,
+        plan.common_ancestor.block_hash
+    );
+    let mut lifecycle = Vec::new();
+    let mut held = Vec::new();
+    for burn in &affected {
+        let event_id = BaseEventId(burn.base_event_id.clone());
+        let Some(existing) = fetch_sequenced_withdrawal(conn, &event_id)? else {
+            continue;
+        };
+        if matches!(
+            existing.state,
+            WithdrawalState::Authorized
+                | WithdrawalState::MempoolAccepted
+                | WithdrawalState::Confirmed
+                | WithdrawalState::ReorgHold
+        ) {
+            held.push((burn, existing));
+        } else {
+            lifecycle.push((burn, existing));
+        }
+    }
+    if !held.is_empty() {
+        let records = held
+            .iter()
+            .map(|(burn, existing)| {
+                base_reorg_journal_record(
+                    SequencerJournalEventType::BaseReorgHold,
+                    plan,
+                    generation,
+                    burn,
+                    existing,
+                    &reason,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        append_and_project_journal_records(conn, journal, &records)?;
+        diesel::sql_query(
+            r#"
+            INSERT INTO sequencer_base_reorg_guard (
+                chain_id, nock_contract_address, generation, reason, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(chain_id, nock_contract_address) DO UPDATE SET
+                generation = excluded.generation,
+                reason = excluded.reason,
+                created_at = excluded.created_at
+            "#,
+        )
+        .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+        .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+        .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+        .bind::<Text, _>(reason.clone())
+        .bind::<BigInt, _>(plan.detected_at)
+        .execute(conn)
+        .map_err(|err| BridgeError::Runtime(format!("Base reorg guard update failed: {err}")))?;
+        insert_base_reorg_event(conn, plan, generation, "escalated", &reason)?;
+        return Ok(BaseActivityReorgReport {
+            generation,
+            old_cursor_block: plan.old_cursor.last_verified_block,
+            common_ancestor_block: plan.common_ancestor.block_number,
+            rewind_depth: plan.rewind_depth,
+            burns_invalidated: 0,
+            lifecycle_rows_invalidated: 0,
+            lifecycle_rows_held: u64::try_from(held.len()).map_err(|err| {
+                BridgeError::ValueConversion(format!("Base reorg held row count overflow: {err}"))
+            })?,
+        });
+    }
+    let records = lifecycle
+        .iter()
+        .map(|(burn, existing)| {
+            base_reorg_journal_record(
+                SequencerJournalEventType::BaseBurnInvalidated,
+                plan,
+                generation,
+                burn,
+                existing,
+                &reason,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    append_and_project_journal_records(conn, journal, &records)?;
+    for burn in &affected {
+        let event_id = BaseEventId(burn.base_event_id.clone());
+        let lifecycle_state =
+            fetch_sequenced_withdrawal(conn, &event_id)?.map(|row| row.state.as_str().to_string());
+        diesel::sql_query(
+            r#"
+            INSERT OR IGNORE INTO sequencer_base_burn_invalidations (
+                chain_id, nock_contract_address, generation, base_event_id,
+                old_block_number, old_block_hash, lifecycle_state,
+                invalidated_at, reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+        .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+        .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+        .bind::<Binary, _>(burn.base_event_id.clone())
+        .bind::<BigInt, _>(burn.block_number)
+        .bind::<Binary, _>(burn.block_hash.clone())
+        .bind::<Nullable<Text>, _>(lifecycle_state)
+        .bind::<BigInt, _>(plan.detected_at)
+        .bind::<Text, _>(reason.clone())
+        .execute(conn)
+        .map_err(|err| {
+            BridgeError::Runtime(format!("Base burn invalidation insert failed: {err}"))
+        })?;
+    }
+    diesel::sql_query(
+        r#"
+        UPDATE sequencer_base_burns
+        SET canonical = 0, invalidated_at = ?,
+            invalidation_generation = ?, invalidation_reason = ?
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND canonical = 1 AND block_number > ?
+        "#,
+    )
+    .bind::<BigInt, _>(plan.detected_at)
+    .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+    .bind::<Text, _>(reason.clone())
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?)
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base burn rewind update failed: {err}")))?;
+    diesel::sql_query(
+        r#"
+        UPDATE sequencer_base_burn_rejections
+        SET canonical = 0
+        WHERE chain_id = ? AND nock_contract_address = ?
+          AND canonical = 1 AND block_number > ?
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?)
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base rejection rewind update failed: {err}")))?;
+    diesel::sql_query(
+        r#"
+        UPDATE sequencer_base_activity_cursor
+        SET last_verified_block = ?, last_verified_block_hash = ?, updated_at = ?
+        WHERE chain_id = ? AND nock_contract_address = ?
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?)
+    .bind::<Binary, _>(plan.common_ancestor.block_hash.as_slice().to_vec())
+    .bind::<BigInt, _>(plan.detected_at)
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base activity rewind failed: {err}")))?;
+    diesel::sql_query(
+        r#"
+        DELETE FROM sequencer_base_header_checkpoints
+        WHERE chain_id = ? AND nock_contract_address = ? AND block_number > ?
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?)
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base checkpoint rewind failed: {err}")))?;
+    diesel::sql_query(
+        r#"
+        DELETE FROM sequencer_base_reorg_guard
+        WHERE chain_id = ? AND nock_contract_address = ?
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base reorg guard clear failed: {err}")))?;
+    insert_base_reorg_event(conn, plan, generation, "rewound", &reason)?;
+    Ok(BaseActivityReorgReport {
+        generation,
+        old_cursor_block: plan.old_cursor.last_verified_block,
+        common_ancestor_block: plan.common_ancestor.block_number,
+        rewind_depth: plan.rewind_depth,
+        burns_invalidated: u64::try_from(affected.len()).map_err(|err| {
+            BridgeError::ValueConversion(format!("Base reorg burn count overflow: {err}"))
+        })?,
+        lifecycle_rows_invalidated: u64::try_from(lifecycle.len()).map_err(|err| {
+            BridgeError::ValueConversion(format!("Base reorg lifecycle count overflow: {err}"))
+        })?,
+        lifecycle_rows_held: 0,
+    })
+}
+
+fn base_reorg_journal_record(
+    event_type: SequencerJournalEventType,
+    plan: &BaseActivityReorgPlan,
+    generation: u64,
+    burn: &BaseReorgBurnRow,
+    existing: &SequencedWithdrawalView,
+    reason: &str,
+) -> Result<SequencerJournalRecord, BridgeError> {
+    sequencer_journal_record(
+        plan.detected_at,
+        event_type,
+        &existing.id,
+        existing.current_epoch,
+        existing.withdrawal_nonce,
+        Some(SequencerJournalBaseContext {
+            base_batch_end: existing
+                .request_facts
+                .as_ref()
+                .map(|facts| facts.base_batch_end),
+            turn_started_base_height: existing.turn_started_base_height,
+            last_submit_attempt_base_height: existing.last_submit_attempt_base_height,
+            reorg_generation: Some(generation),
+            invalidated_block_height: Some(u64::try_from(burn.block_number).map_err(|err| {
+                BridgeError::ValueConversion(format!(
+                    "Base reorg burn block number is invalid: {err}"
+                ))
+            })?),
+            invalidated_block_hash: Some(hex::encode(&burn.block_hash)),
+            common_ancestor_height: Some(plan.common_ancestor.block_number),
+            common_ancestor_hash: Some(hex::encode(plan.common_ancestor.block_hash.as_slice())),
+            prior_state: Some(existing.state.as_str().to_string()),
+            reorg_reason: Some(reason.to_string()),
+        }),
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+fn insert_base_reorg_event(
+    conn: &mut SqliteConnection,
+    plan: &BaseActivityReorgPlan,
+    generation: u64,
+    outcome: &str,
+    reason: &str,
+) -> Result<(), BridgeError> {
+    diesel::sql_query(
+        r#"
+        INSERT INTO sequencer_base_reorg_events (
+            chain_id, nock_contract_address, generation, detected_at,
+            old_cursor_block, old_cursor_hash, common_ancestor_block,
+            common_ancestor_hash, canonical_tip_block, canonical_tip_hash,
+            rewind_depth, outcome, reason
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind::<BigInt, _>(checked_i64(plan.chain_id, "chain_id")?)
+    .bind::<Binary, _>(plan.nock_contract_address.as_slice().to_vec())
+    .bind::<BigInt, _>(checked_i64(generation, "reorg_generation")?)
+    .bind::<BigInt, _>(plan.detected_at)
+    .bind::<BigInt, _>(checked_i64(
+        plan.old_cursor.last_verified_block, "old_cursor_block",
+    )?)
+    .bind::<Binary, _>(plan.old_cursor.last_verified_block_hash.as_slice().to_vec())
+    .bind::<Nullable<BigInt>, _>(Some(checked_i64(
+        plan.common_ancestor.block_number, "common_ancestor_block",
+    )?))
+    .bind::<Nullable<Binary>, _>(Some(plan.common_ancestor.block_hash.as_slice().to_vec()))
+    .bind::<BigInt, _>(checked_i64(
+        plan.canonical_cursor_header.block_number, "canonical_tip_block",
+    )?)
+    .bind::<Binary, _>(plan.canonical_cursor_header.block_hash.as_slice().to_vec())
+    .bind::<Nullable<BigInt>, _>(Some(checked_i64(plan.rewind_depth, "rewind_depth")?))
+    .bind::<Text, _>(outcome.to_string())
+    .bind::<Text, _>(reason.to_string())
+    .execute(conn)
+    .map_err(|err| BridgeError::Runtime(format!("Base reorg event insert failed: {err}")))?;
+    Ok(())
 }
 
 fn reconcile_journal_with_base_tx(
@@ -6564,6 +8184,15 @@ fn reconcile_journal_with_base_tx(
     };
     let mut ordering = Vec::new();
     for row in &rows {
+        if row.state == WithdrawalState::Invalidated {
+            report.historical_rows_skipped = report.historical_rows_skipped.saturating_add(1);
+            continue;
+        }
+        if row.state == WithdrawalState::ReorgHold {
+            return Err(base_reconciliation_error(
+                row, "lifecycle state", "actionable canonical state", "reorg_hold",
+            ));
+        }
         let facts = row
             .request_facts
             .as_ref()
@@ -7350,8 +8979,12 @@ fn load_authorized_transaction_for_reconciliation(
     load_authorized_transaction(
         conn,
         id,
-        &[WithdrawalState::Authorized, WithdrawalState::MempoolAccepted],
-        "startup reconciliation",
+        &[
+            WithdrawalState::Authorized,
+            WithdrawalState::MempoolAccepted,
+            WithdrawalState::ReorgHold,
+        ],
+        "startup reconciliation or operator inspection",
     )
 }
 
@@ -7910,6 +9543,72 @@ mod tests {
             )
             .await
             .expect("advance Base activity cursor");
+    }
+
+    async fn seed_base_reorg_activity(
+        service: &WithdrawalSequencerStore,
+        proposal: &WithdrawalProposalData,
+    ) -> BaseActivityReorgPlan {
+        let mut burn =
+            sample_verified_base_burn(200, 105, proposal.base_batch_end, proposal.burned_amount);
+        burn.base_event_id = proposal.id.base_event_id.clone();
+        burn.lock_root = proposal.recipient.clone();
+        burn.block_hash = B256::from([0x55; 32]);
+        burn.parent_hash = B256::from([0x44; 32]);
+        let ancestor = crate::withdrawal::sequencer::base_activity::BaseActivityHeaderCheckpoint {
+            chain_id: 8_453,
+            nock_contract_address: Address::ZERO,
+            block_number: 104,
+            block_hash: B256::from([0x44; 32]),
+            parent_hash: B256::from([0x43; 32]),
+            block_timestamp: 1_700_000_104,
+            verified_at: 1_700_000_200,
+        };
+        let old_cursor_header =
+            crate::withdrawal::sequencer::base_activity::BaseActivityHeaderCheckpoint {
+                chain_id: 8_453,
+                nock_contract_address: Address::ZERO,
+                block_number: 109,
+                block_hash: B256::from([0xa5; 32]),
+                parent_hash: B256::from([0xa4; 32]),
+                block_timestamp: 1_700_000_109,
+                verified_at: 1_700_000_200,
+            };
+        let old_cursor = crate::withdrawal::sequencer::base_activity::BaseActivityCursor {
+            chain_id: 8_453,
+            nock_contract_address: Address::ZERO,
+            last_verified_block: 109,
+            last_verified_block_hash: old_cursor_header.block_hash,
+            updated_at: 1_700_000_200,
+        };
+        service
+            .base_activity_store()
+            .apply_verified_chunk_with_headers(
+                vec![burn],
+                vec![ancestor.clone(), old_cursor_header],
+                old_cursor.clone(),
+                100,
+            )
+            .await
+            .expect("seed Base reorg activity");
+        BaseActivityReorgPlan {
+            chain_id: 8_453,
+            nock_contract_address: Address::ZERO,
+            old_cursor,
+            common_ancestor: ancestor,
+            canonical_cursor_header:
+                crate::withdrawal::sequencer::base_activity::BaseActivityHeaderCheckpoint {
+                    chain_id: 8_453,
+                    nock_contract_address: Address::ZERO,
+                    block_number: 109,
+                    block_hash: B256::from([0xb5; 32]),
+                    parent_hash: B256::from([0xb4; 32]),
+                    block_timestamp: 1_700_000_109,
+                    verified_at: 1_700_000_201,
+                },
+            rewind_depth: 5,
+            detected_at: 1_700_000_201,
+        }
     }
 
     async fn base_reconciliation_cursor_count(service: &WithdrawalSequencerStore) -> i64 {
@@ -10881,7 +12580,7 @@ mod tests {
             .expect_err("authorized-but-not-mempool-accepted retry load should fail");
         assert!(err
             .to_string()
-            .contains("instead of mempool_accepted for orphan retry"));
+            .contains("instead of an allowed state for orphan retry"));
     }
 
     #[tokio::test]
@@ -11509,10 +13208,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authorization_blocks_later_nonce_until_prior_released() {
-        // A later nonce cannot even become peer-canonical while an earlier
-        // nonce remains the unreleased sequencer frontier. Once the earlier
-        // nonce reaches mempool acceptance, the frontier can advance.
+    async fn authorization_blocks_later_nonce_until_prior_confirmed() {
+        // A later nonce cannot become peer-canonical while an earlier nonce is
+        // pending, authorized, or merely mempool-accepted. Durable confirmation
+        // is the only normal frontier release.
         let (_dir, service) = open_service().await;
         let proposal_a = sample_proposal(10, 0);
         let proposal_b = sample_proposal(20, 0);
@@ -11548,11 +13247,24 @@ mod tests {
         service
             .record_submit_outcome(&proposal_a, WithdrawalState::MempoolAccepted, 1, 111, None)
             .await
-            .expect("release first nonce from ordering");
-        service
+            .expect("record first nonce mempool acceptance");
+        let still_blocked = service
             .record_proposal_canonicalized(&proposal_b, 102)
             .await
-            .expect("record second canonicalized after release");
+            .expect_err("mempool acceptance must not release the frontier");
+        assert!(still_blocked.to_string().contains("sequencer frontier"));
+        service
+            .record_tx_confirmed(
+                &proposal_a,
+                777,
+                Tip5Hash([Belt(870), Belt(871), Belt(872), Belt(873), Belt(874)]),
+            )
+            .await
+            .expect("confirm first nonce");
+        service
+            .record_proposal_canonicalized(&proposal_b, 103)
+            .await
+            .expect("record second canonicalized after confirmation");
         service
             .record_proposal_authorized(&proposal_b)
             .await
@@ -11710,7 +13422,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mempool_accepted_releases_next_pending_ordering() {
+    async fn mempool_accepted_holds_next_pending_ordering_until_confirmation() {
         let (_dir, service) = open_service().await;
         let proposal_a = sample_proposal(10, 0);
         let proposal_b = sample_proposal(20, 0);
@@ -11741,8 +13453,8 @@ mod tests {
             .await
             .expect("next pending ordering")
             .expect("pending ordering exists");
-        assert_eq!(next.0, proposal_b.id);
-        assert_eq!(next.1, 2);
+        assert_eq!(next.0, proposal_a.id);
+        assert_eq!(next.1, 1);
         assert_eq!(
             service
                 .list_reserved_input_names()
@@ -11750,6 +13462,21 @@ mod tests {
                 .expect("list reserved inputs after mempool acceptance"),
             proposal_a.selected_inputs
         );
+        service
+            .record_tx_confirmed(
+                &proposal_a,
+                777,
+                Tip5Hash([Belt(860), Belt(861), Belt(862), Belt(863), Belt(864)]),
+            )
+            .await
+            .expect("confirm first ordering");
+        let next = service
+            .next_pending_withdrawal_ordering()
+            .await
+            .expect("next ordering after confirmation")
+            .expect("second ordering exists");
+        assert_eq!(next.0, proposal_b.id);
+        assert_eq!(next.1, 2);
     }
 
     #[tokio::test]
@@ -11841,9 +13568,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn current_live_withdrawal_nonce_skips_mempool_accepted_nonce() {
-        // MempoolAccepted releases its nonce under the default ordering rule,
-        // so the frontier advances to the next unreleased row.
+    async fn current_live_withdrawal_nonce_holds_mempool_accepted_until_confirmed() {
+        // Mempool acceptance is not durable settlement. Nonce 1 remains the
+        // single frontier until confirmation, then nonce 2 advances.
         let (_dir, service) = open_service().await;
         let proposal_a = sample_proposal(24, 0);
         let proposal_b = sample_proposal(25, 0);
@@ -11874,6 +13601,21 @@ mod tests {
                 .current_live_withdrawal_nonce()
                 .await
                 .expect("current live withdrawal nonce"),
+            Some(1)
+        );
+        service
+            .record_tx_confirmed(
+                &proposal_a,
+                777,
+                Tip5Hash([Belt(911), Belt(912), Belt(913), Belt(914), Belt(915)]),
+            )
+            .await
+            .expect("record durable confirmation");
+        assert_eq!(
+            service
+                .current_live_withdrawal_nonce()
+                .await
+                .expect("frontier after confirmation"),
             Some(2)
         );
     }
@@ -11954,6 +13696,14 @@ mod tests {
             .record_submit_outcome(&proposal_a, WithdrawalState::MempoolAccepted, 1, 111, None)
             .await
             .expect("record first mempool accepted");
+        service
+            .record_tx_confirmed(
+                &proposal_a,
+                777,
+                Tip5Hash([Belt(850), Belt(851), Belt(852), Belt(853), Belt(854)]),
+            )
+            .await
+            .expect("confirm first withdrawal");
         service
             .record_proposal_canonicalized(&proposal_b, 101)
             .await
@@ -12103,7 +13853,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonicalization_rejects_inputs_reserved_by_other_withdrawal() {
+    async fn frontier_preserves_cross_withdrawal_reservation_ownership() {
         let (_dir, service) = open_service().await;
         let proposal_a = sample_proposal(60, 0);
         let mut proposal_b = sample_proposal(61, 0);
@@ -12134,12 +13884,8 @@ mod tests {
         let err = service
             .record_proposal_canonicalized(&proposal_b, 200)
             .await
-            .expect_err("canonicalization should reject conflicting reserved inputs");
-        assert!(matches!(
-            err,
-            WithdrawalSequencerStoreError::Store(ref message)
-                if message.contains("already reserved by withdrawal")
-        ));
+            .expect_err("later withdrawal must not claim an active reservation");
+        assert!(err.to_string().contains("sequencer frontier"));
 
         let blocked = service
             .fetch_sequenced_withdrawal(&proposal_b.id)
@@ -12156,10 +13902,34 @@ mod tests {
                 .expect("list reserved inputs after canonical conflict"),
             proposal_a.selected_inputs
         );
+        service
+            .record_tx_confirmed(
+                &proposal_a,
+                777,
+                Tip5Hash([Belt(880), Belt(881), Belt(882), Belt(883), Belt(884)]),
+            )
+            .await
+            .expect("confirm reservation owner");
+        assert!(service
+            .list_reserved_input_names()
+            .await
+            .expect("reservations after owner confirmation")
+            .is_empty());
+        service
+            .record_proposal_canonicalized(&proposal_b, 201)
+            .await
+            .expect("later withdrawal claims released inputs");
+        assert_eq!(
+            service
+                .list_reserved_input_names()
+                .await
+                .expect("later reservation owner"),
+            proposal_b.selected_inputs
+        );
     }
 
     #[tokio::test]
-    async fn later_nonce_may_confirm_before_earlier_nonce_after_mempool_acceptance() {
+    async fn later_nonce_waits_for_earlier_durable_confirmation() {
         let (_dir, service) = open_service().await;
         let proposal_a = sample_proposal(10, 0);
         let proposal_b = sample_proposal(20, 0);
@@ -12171,49 +13941,69 @@ mod tests {
                 .ensure_tracked_withdrawal_ordering(&tracked_from_proposal(proposal, nonce))
                 .await
                 .expect("record ordering");
-            service
-                .record_proposal_canonicalized(proposal, 100)
-                .await
-                .expect("record canonicalized");
-            service
-                .record_proposal_authorized(proposal)
-                .await
-                .expect("record authorized");
-            service
-                .record_submit_outcome(proposal, WithdrawalState::MempoolAccepted, 1, 111, None)
-                .await
-                .expect("record mempool accepted");
         }
+        service
+            .record_proposal_canonicalized(&proposal_a, 100)
+            .await
+            .expect("record first canonicalized");
+        service
+            .record_proposal_authorized(&proposal_a)
+            .await
+            .expect("record first authorized");
+        service
+            .record_submit_outcome(&proposal_a, WithdrawalState::MempoolAccepted, 1, 111, None)
+            .await
+            .expect("record first mempool accepted");
+
+        let blocked = service
+            .record_proposal_canonicalized(&proposal_b, 112)
+            .await
+            .expect_err("later nonce must wait for durable confirmation");
+        assert!(blocked.to_string().contains("sequencer frontier"));
+        assert_eq!(
+            service
+                .current_live_withdrawal_nonce()
+                .await
+                .expect("frontier before confirmation"),
+            Some(1)
+        );
 
         service
-            .record_tx_confirmed(&proposal_b, 777, block_b.clone())
+            .record_tx_confirmed(&proposal_a, 777, block_a)
             .await
-            .expect("confirm later nonce first");
-
-        let earlier = service
-            .fetch_sequenced_withdrawal(&proposal_a.id)
-            .await
-            .expect("fetch earlier withdrawal")
-            .expect("earlier withdrawal exists");
-        let later = service
-            .fetch_sequenced_withdrawal(&proposal_b.id)
-            .await
-            .expect("fetch later withdrawal")
-            .expect("later withdrawal exists");
-        assert_eq!(earlier.state, WithdrawalState::MempoolAccepted);
-        assert_eq!(later.state, WithdrawalState::Confirmed);
-
+            .expect("confirm first nonce");
+        assert_eq!(
+            service
+                .current_live_withdrawal_nonce()
+                .await
+                .expect("frontier after first confirmation"),
+            Some(2)
+        );
         service
-            .record_tx_confirmed(&proposal_a, 778, block_a.clone())
+            .record_proposal_canonicalized(&proposal_b, 113)
             .await
-            .expect("confirm earlier nonce second");
-
-        let earlier = service
-            .fetch_sequenced_withdrawal(&proposal_a.id)
+            .expect("record second canonicalized");
+        service
+            .record_proposal_authorized(&proposal_b)
             .await
-            .expect("fetch earlier withdrawal after confirm")
-            .expect("earlier withdrawal exists");
-        assert_eq!(earlier.state, WithdrawalState::Confirmed);
+            .expect("record second authorized");
+        service
+            .record_submit_outcome(&proposal_b, WithdrawalState::MempoolAccepted, 1, 114, None)
+            .await
+            .expect("record second mempool accepted");
+        service
+            .record_tx_confirmed(&proposal_b, 778, block_b)
+            .await
+            .expect("confirm second nonce");
+        assert_eq!(
+            service
+                .fetch_sequenced_withdrawal(&proposal_b.id)
+                .await
+                .expect("fetch second withdrawal")
+                .expect("second withdrawal")
+                .state,
+            WithdrawalState::Confirmed
+        );
     }
 
     #[tokio::test]
@@ -13165,6 +14955,265 @@ mod tests {
                 .expect("replay-mapped burn")
                 .withdrawal_nonce,
             Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn shallow_base_reorg_invalidates_peer_canonical_and_releases_reservations() {
+        let journal = RecordingSequencerJournal::default();
+        let (_dir, service) = open_service_with_journal(journal.handle()).await;
+        let proposal = sample_proposal(200, 0);
+        service
+            .ensure_tracked_withdrawal_ordering(&tracked_from_proposal(&proposal, 1))
+            .await
+            .expect("register withdrawal ordering");
+        service
+            .record_proposal_canonicalized(&proposal, 100)
+            .await
+            .expect("record canonical proposal");
+        let plan = seed_base_reorg_activity(&service, &proposal).await;
+
+        let report = service
+            .apply_base_activity_reorg(plan)
+            .await
+            .expect("apply shallow Base reorg");
+        assert_eq!(report.burns_invalidated, 1);
+        assert_eq!(report.lifecycle_rows_invalidated, 1);
+        assert_eq!(report.lifecycle_rows_held, 0);
+        let row = service
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch invalidated row")
+            .expect("invalidated row");
+        assert_eq!(row.state, WithdrawalState::Invalidated);
+        service
+            .ensure_reorg_ready()
+            .await
+            .expect("shallow rewind clears Base reorg guard");
+        assert!(service
+            .reserved_input_names_for(&proposal.id)
+            .await
+            .expect("load invalidated reservations")
+            .is_empty());
+        let activity = service.base_activity_store();
+        assert!(activity
+            .load_verified_burn(8_453, Address::ZERO, &proposal.id.base_event_id)
+            .await
+            .expect("load invalidated burn")
+            .is_none());
+        let public_burn = activity
+            .load_public_burn(8_453, Address::ZERO, &proposal.id.base_event_id)
+            .await
+            .expect("load invalidated public burn")
+            .expect("invalidated public burn remains queryable");
+        assert!(!public_burn.canonical);
+        assert_eq!(public_burn.invalidation_generation, Some(1));
+        assert!(public_burn
+            .invalidation_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("Base fork generation")));
+        assert_eq!(
+            activity
+                .load_cursor(8_453, Address::ZERO)
+                .await
+                .expect("load rewound cursor")
+                .expect("rewound cursor")
+                .last_verified_block,
+            104
+        );
+        assert_eq!(
+            journal
+                .records()
+                .last()
+                .expect("Base invalidation journal event")
+                .event_type,
+            SequencerJournalEventType::BaseBurnInvalidated
+        );
+        let (_replay_dir, replay) = open_service_with_journal(journal.handle()).await;
+        replay
+            .recover_from_journal_on_startup()
+            .await
+            .expect("replay Base invalidation journal")
+            .expect("Base invalidation recovery report");
+        let replayed = replay
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch replayed invalidation")
+            .expect("replayed invalidation row");
+        assert_eq!(replayed.state, WithdrawalState::Invalidated);
+        assert!(replay
+            .reserved_input_names_for(&proposal.id)
+            .await
+            .expect("replayed invalidation reservations")
+            .is_empty());
+        assert_eq!(
+            replay
+                .recover_from_journal_on_startup()
+                .await
+                .expect("verify replayed invalidation cursor")
+                .expect("second invalidation recovery report")
+                .replayed_count,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn base_reorg_after_authorization_commits_hold_without_rewinding() {
+        let journal = RecordingSequencerJournal::default();
+        let (_dir, service) = open_service_with_journal(journal.handle()).await;
+        let proposal = sample_proposal(201, 0);
+        authorize_with_handoffs(&service, &proposal).await;
+        let authorized_before = service
+            .load_authorized_transaction_for_reconciliation(&proposal.id)
+            .await
+            .expect("load authorized identity")
+            .expect("authorized identity");
+        let plan = seed_base_reorg_activity(&service, &proposal).await;
+
+        let error = service
+            .apply_base_activity_reorg(plan)
+            .await
+            .expect_err("authorized Base orphan must escalate");
+        assert!(error.to_string().contains("operator intervention"));
+        let row = service
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch held row")
+            .expect("held row");
+        assert_eq!(row.state, WithdrawalState::ReorgHold);
+        assert_eq!(
+            service
+                .load_authorized_transaction_for_reconciliation(&proposal.id)
+                .await
+                .expect("reload held authorized identity")
+                .expect("held authorized identity"),
+            authorized_before
+        );
+        let guard = service
+            .ensure_reorg_ready()
+            .await
+            .expect_err("authorized orphan must activate Base reorg guard");
+        assert!(guard.to_string().contains("generation 1"));
+        assert_eq!(
+            service
+                .reserved_input_names_for(&proposal.id)
+                .await
+                .expect("load held reservations"),
+            proposal.selected_inputs
+        );
+        let activity = service.base_activity_store();
+        assert!(activity
+            .load_verified_burn(8_453, Address::ZERO, &proposal.id.base_event_id)
+            .await
+            .expect("load held burn")
+            .is_some());
+        assert_eq!(
+            activity
+                .load_cursor(8_453, Address::ZERO)
+                .await
+                .expect("load unrewound cursor")
+                .expect("unrewound cursor")
+                .last_verified_block,
+            109
+        );
+        assert_eq!(
+            journal
+                .records()
+                .last()
+                .expect("Base hold journal event")
+                .event_type,
+            SequencerJournalEventType::BaseReorgHold
+        );
+        let (_replay_dir, replay) = open_service_with_journal(journal.handle()).await;
+        replay
+            .recover_from_journal_on_startup()
+            .await
+            .expect("replay Base reorg hold")
+            .expect("Base reorg hold recovery report");
+        let replayed = replay
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch replayed hold")
+            .expect("replayed hold row");
+        assert_eq!(replayed.state, WithdrawalState::ReorgHold);
+        assert_eq!(
+            replay
+                .load_authorized_transaction_for_reconciliation(&proposal.id)
+                .await
+                .expect("load replayed authorized identity")
+                .expect("replayed authorized identity"),
+            authorized_before
+        );
+        assert_eq!(
+            replay
+                .reserved_input_names_for(&proposal.id)
+                .await
+                .expect("replayed hold reservations"),
+            proposal.selected_inputs
+        );
+        assert!(replay.ensure_reorg_ready().await.is_err());
+    }
+    #[tokio::test]
+    async fn nock_inclusion_invalidation_replays_exact_artifacts_and_reservations() {
+        let journal = RecordingSequencerJournal::default();
+        let (_dir, service) = open_service_with_journal(journal.handle()).await;
+        let proposal = sample_proposal(202, 0);
+        mempool_accept_with_handoffs(&service, &proposal, 1, 200, None).await;
+        let confirmed_block_id = Tip5Hash([Belt(801), Belt(802), Belt(803), Belt(804), Belt(805)]);
+        service
+            .record_tx_confirmed(&proposal, 8_000, confirmed_block_id.clone())
+            .await
+            .expect("record confirmed withdrawal");
+        service
+            .record_nockchain_inclusion_invalidated(
+                &proposal.id,
+                8_000,
+                confirmed_block_id,
+                WithdrawalState::MempoolAccepted,
+                "test orphaned Nock inclusion".to_string(),
+            )
+            .await
+            .expect("record Nock inclusion invalidation");
+        let row = service
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch regressed row")
+            .expect("regressed row");
+        assert_eq!(row.state, WithdrawalState::MempoolAccepted);
+        assert_eq!(
+            service
+                .reserved_input_names_for(&proposal.id)
+                .await
+                .expect("restored source reservations"),
+            proposal.selected_inputs
+        );
+        assert_eq!(
+            journal
+                .records()
+                .last()
+                .expect("Nock invalidation journal event")
+                .event_type,
+            SequencerJournalEventType::NockInclusionInvalidated
+        );
+
+        let (_replay_dir, replay) = open_service_with_journal(journal.handle()).await;
+        replay
+            .recover_from_journal_on_startup()
+            .await
+            .expect("replay Nock invalidation")
+            .expect("Nock invalidation recovery report");
+        let replayed = replay
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch replayed Nock invalidation")
+            .expect("replayed Nock invalidation row");
+        assert_eq!(replayed.state, WithdrawalState::MempoolAccepted);
+        assert_eq!(
+            replay
+                .reserved_input_names_for(&proposal.id)
+                .await
+                .expect("replayed Nock reservations"),
+            proposal.selected_inputs
         );
     }
 }

--- a/crates/bridge/src/withdrawal/state.rs
+++ b/crates/bridge/src/withdrawal/state.rs
@@ -11,6 +11,8 @@ pub enum WithdrawalState {
     Authorized,
     MempoolAccepted,
     Confirmed,
+    Invalidated,
+    ReorgHold,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,6 +42,8 @@ impl WithdrawalState {
             Self::Authorized => "authorized",
             Self::MempoolAccepted => "mempool_accepted",
             Self::Confirmed => "confirmed",
+            Self::Invalidated => "invalidated",
+            Self::ReorgHold => "reorg_hold",
         }
     }
 
@@ -52,6 +56,8 @@ impl WithdrawalState {
             "authorized" => Ok(Self::Authorized),
             "mempool_accepted" => Ok(Self::MempoolAccepted),
             "confirmed" => Ok(Self::Confirmed),
+            "invalidated" => Ok(Self::Invalidated),
+            "reorg_hold" => Ok(Self::ReorgHold),
             other => Err(BridgeError::Runtime(format!(
                 "unknown withdrawal state: {other}"
             ))),

--- a/crates/bridge/src/withdrawal/submission.rs
+++ b/crates/bridge/src/withdrawal/submission.rs
@@ -27,6 +27,10 @@ use crate::shared::errors::BridgeError;
 use crate::shared::ingress::proto::{
     SequencedWithdrawalStatusResponse, WithdrawalCommitCertificate,
 };
+use crate::shared::nockchain::{
+    nockchain_reinclusion_within_rewind, nockchain_snapshot_is_stable_for_replay,
+    NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS,
+};
 use crate::shared::stop::StopHandle;
 use crate::shared::types::Tip5Hash;
 use crate::withdrawal::proposals::{
@@ -35,7 +39,7 @@ use crate::withdrawal::proposals::{
 use crate::withdrawal::raw_tx as withdrawal_raw_tx;
 use crate::withdrawal::sequencer::base_height::SequencerBaseHeightTracker;
 use crate::withdrawal::sequencer::store::{
-    cue_transaction, AuthorizedRetryPayload, WithdrawalSequencerStore,
+    cue_transaction, AuthorizedRetryPayload, NockchainReorgRecoveryReport, WithdrawalSequencerStore,
 };
 use crate::withdrawal::state::{LiveWithdrawalView, WithdrawalFallbackPolicy, WithdrawalState};
 use crate::withdrawal::types::{
@@ -48,7 +52,12 @@ pub(crate) fn is_withdrawal_submit_deferred_error(error: &str) -> bool {
     error.starts_with(WITHDRAWAL_SUBMIT_DEFERRED_PREFIX)
 }
 
-pub(crate) fn sequenced_withdrawal_released(status: &SequencedWithdrawalStatusResponse) -> bool {
+/// Stops duplicate bridge-node assembly/broadcast work. Mempool acceptance
+/// satisfies this predicate but remains the sequencer ordering frontier until
+/// durable confirmation.
+pub(crate) fn sequenced_withdrawal_needs_no_bridge_work(
+    status: &SequencedWithdrawalStatusResponse,
+) -> bool {
     status.found && matches!(status.state.as_str(), "mempool_accepted" | "confirmed")
 }
 
@@ -79,6 +88,13 @@ pub trait WithdrawalSubmitPort: Send + Sync {
     async fn transaction_mempool_accepted(
         &self,
         _proposal: &WithdrawalProposalData,
+    ) -> Result<Option<bool>, BridgeError> {
+        Ok(None)
+    }
+
+    async fn raw_tx_mempool_accepted(
+        &self,
+        _submitted_raw_tx_id: &str,
     ) -> Result<Option<bool>, BridgeError> {
         Ok(None)
     }
@@ -564,6 +580,14 @@ impl WithdrawalSubmitPort for PublicNockchainWithdrawalSubmitter {
             .await
     }
 
+    async fn raw_tx_mempool_accepted(
+        &self,
+        submitted_raw_tx_id: &str,
+    ) -> Result<Option<bool>, BridgeError> {
+        self.raw_tx_mempool_accepted_by_id(submitted_raw_tx_id)
+            .await
+    }
+
     async fn get_transaction_included_block(
         &self,
         submitted_raw_tx_id: &str,
@@ -631,7 +655,7 @@ async fn ensure_frontier_withdrawal_registered<S: WithdrawalSequencerPort>(
             .sequencer
             .get_sequenced_withdrawal_status(&tracked.id)
             .await?;
-        if sequenced_withdrawal_released(&status) {
+        if sequenced_withdrawal_needs_no_bridge_work(&status) {
             continue;
         }
         register_withdrawal_or_alert(context.sequencer.as_ref(), &context.bridge_status, &tracked)
@@ -643,7 +667,7 @@ async fn ensure_frontier_withdrawal_registered<S: WithdrawalSequencerPort>(
             .sequencer
             .get_sequenced_withdrawal_status(&tracked.id)
             .await?;
-        if sequenced_withdrawal_released(&status) {
+        if sequenced_withdrawal_needs_no_bridge_work(&status) {
             continue;
         }
         return Ok(None);
@@ -876,6 +900,14 @@ pub async fn withdrawal_sequencer_startup_reconcile<S>(
 where
     S: WithdrawalSubmitPort + ?Sized,
 {
+    let nock_reorg =
+        withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store, submitter).await?;
+    if nock_reorg.held > 0 {
+        return Err(BridgeError::Runtime(format!(
+            "{} confirmed Nock withdrawal(s) entered reorg hold during startup",
+            nock_reorg.held
+        )));
+    }
     let sequenced = withdrawal_state_store.list_sequenced_withdrawals().await?;
     let has_unconfirmed = sequenced.iter().any(|row| {
         matches!(
@@ -1060,6 +1092,153 @@ fn nockchain_inclusion_has_depth(
     tip_height.saturating_sub(included_height) >= confirmation_depth
 }
 
+/// Revalidates every terminal Nock inclusion and applies bounded recovery.
+pub async fn withdrawal_sequencer_nock_reorg_tick_once<S>(
+    withdrawal_state_store: &WithdrawalSequencerStore,
+    submitter: &S,
+) -> Result<NockchainReorgRecoveryReport, BridgeError>
+where
+    S: WithdrawalSubmitPort + ?Sized,
+{
+    withdrawal_state_store.ensure_reorg_ready().await?;
+    let candidates = withdrawal_state_store
+        .list_confirmed_nockchain_withdrawals()
+        .await?;
+    let mut report = NockchainReorgRecoveryReport::default();
+    for candidate in candidates {
+        report.inspected = report.inspected.saturating_add(1);
+        let inclusion = submitter
+            .get_transaction_included_block(&candidate.submitted_raw_tx_id)
+            .await?;
+        if inclusion.as_ref().is_some_and(|included| {
+            included.height == candidate.confirmed_height
+                && included.block_id == candidate.confirmed_block_id
+        }) {
+            withdrawal_state_store
+                .clear_missing_nockchain_inclusion(&candidate.id)
+                .await?;
+            report.unchanged = report.unchanged.saturating_add(1);
+            continue;
+        }
+        if let Some(included) = inclusion {
+            withdrawal_state_store
+                .clear_missing_nockchain_inclusion(&candidate.id)
+                .await?;
+            if !nockchain_reinclusion_within_rewind(candidate.confirmed_height, included.height) {
+                withdrawal_state_store
+                    .record_nockchain_inclusion_invalidated(
+                        &candidate.id,
+                        candidate.confirmed_height,
+                        candidate.confirmed_block_id,
+                        WithdrawalState::ReorgHold,
+                        format!(
+                            "Nock transaction {} moved from block {} to {} beyond automatic depth {}",
+                            candidate.submitted_raw_tx_id,
+                            candidate.confirmed_height,
+                            included.height,
+                            NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS
+                        ),
+                    )
+                    .await?;
+                report.held = report.held.saturating_add(1);
+                continue;
+            }
+            withdrawal_state_store
+                .record_nockchain_inclusion_invalidated(
+                    &candidate.id,
+                    candidate.confirmed_height,
+                    candidate.confirmed_block_id,
+                    WithdrawalState::MempoolAccepted,
+                    format!(
+                        "Nock transaction {} was re-included at block {} {:?}",
+                        candidate.submitted_raw_tx_id, included.height, included.block_id
+                    ),
+                )
+                .await?;
+            withdrawal_state_store
+                .record_tx_confirmed_by_id(&candidate.id, included.height, included.block_id)
+                .await?;
+            report.re_included = report.re_included.saturating_add(1);
+            continue;
+        }
+        let missing_count = withdrawal_state_store
+            .note_missing_nockchain_inclusion(
+                &candidate.id, candidate.confirmed_height, &candidate.confirmed_block_id,
+            )
+            .await?;
+        if missing_count < 2 {
+            report.unchanged = report.unchanged.saturating_add(1);
+            continue;
+        }
+        let snapshot_is_stable = nockchain_snapshot_is_stable_for_replay(
+            candidate.snapshot_height, candidate.confirmed_height,
+        );
+        if !snapshot_is_stable {
+            withdrawal_state_store
+                .record_nockchain_inclusion_invalidated(
+                    &candidate.id,
+                    candidate.confirmed_height,
+                    candidate.confirmed_block_id,
+                    WithdrawalState::ReorgHold,
+                    format!(
+                        "Nock transaction {} disappeared and snapshot height {} is not {} blocks behind old inclusion {}",
+                        candidate.submitted_raw_tx_id,
+                        candidate.snapshot_height,
+                        NOCKCHAIN_MAX_AUTOMATIC_REORG_REWIND_BLOCKS,
+                        candidate.confirmed_height
+                    ),
+                )
+                .await?;
+            withdrawal_state_store
+                .clear_missing_nockchain_inclusion(&candidate.id)
+                .await?;
+            report.held = report.held.saturating_add(1);
+            continue;
+        }
+        let mempool_accepted = submitter
+            .raw_tx_mempool_accepted(&candidate.submitted_raw_tx_id)
+            .await?
+            .unwrap_or(false);
+        let next_state = if mempool_accepted {
+            WithdrawalState::MempoolAccepted
+        } else {
+            WithdrawalState::Authorized
+        };
+        withdrawal_state_store
+            .record_nockchain_inclusion_invalidated(
+                &candidate.id,
+                candidate.confirmed_height,
+                candidate.confirmed_block_id,
+                next_state,
+                format!(
+                    "Nock transaction {} is no longer included; preserving exact authorized raw transaction",
+                    candidate.submitted_raw_tx_id
+                ),
+            )
+            .await?;
+        withdrawal_state_store
+            .clear_missing_nockchain_inclusion(&candidate.id)
+            .await?;
+        if mempool_accepted {
+            report.regressed_to_mempool = report.regressed_to_mempool.saturating_add(1);
+            continue;
+        }
+        match submitter.resubmit_raw_tx(&candidate.raw_tx).await? {
+            WithdrawalNetworkSubmitStatus::MempoolAccepted
+            | WithdrawalNetworkSubmitStatus::AlreadyMempoolAccepted => {
+                withdrawal_state_store
+                    .record_authorized_mempool_accepted_by_id(&candidate.id)
+                    .await?;
+                report.regressed_to_mempool = report.regressed_to_mempool.saturating_add(1);
+            }
+            WithdrawalNetworkSubmitStatus::RetryExhausted => {
+                report.regressed_to_authorized = report.regressed_to_authorized.saturating_add(1);
+            }
+        }
+    }
+    Ok(report)
+}
+
 /// Runs one sequencer-owned confirmation poll over accepted withdrawals using
 /// the colocated public Nockchain API.
 pub async fn withdrawal_sequencer_confirmation_tick_once<S>(
@@ -1070,6 +1249,14 @@ pub async fn withdrawal_sequencer_confirmation_tick_once<S>(
 where
     S: WithdrawalSubmitPort + ?Sized,
 {
+    let reorg =
+        withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store, submitter).await?;
+    if reorg.held > 0 {
+        return Err(BridgeError::Runtime(format!(
+            "{} confirmed Nock withdrawal(s) entered reorg hold",
+            reorg.held
+        )));
+    }
     metrics::init_metrics()
         .sequencer_withdrawal_confirmation_polls
         .increment();
@@ -1162,6 +1349,7 @@ pub async fn withdrawal_sequencer_orphan_retry_tick_once<S>(
 where
     S: WithdrawalSubmitPort + ?Sized,
 {
+    withdrawal_state_store.ensure_reorg_ready().await?;
     let Some(current_base_height) = base_height_tracker.latest_confirmed_base_height() else {
         return Ok(0);
     };
@@ -1785,6 +1973,7 @@ mod tests {
     struct RecordingSubmitter {
         included_blocks: Mutex<HashMap<String, WithdrawalIncludedBlock>>,
         nockchain_tip_height: Mutex<Option<u64>>,
+        raw_tx_mempool_acceptance: Mutex<HashMap<String, bool>>,
         resubmitted_raw_tx_ids: Mutex<Vec<String>>,
         resubmitted_raw_txs: Mutex<Vec<nockchain_types::v1::RawTx>>,
         scripted_resubmit_results: Mutex<VecDeque<Result<WithdrawalNetworkSubmitStatus, String>>>,
@@ -1813,6 +2002,13 @@ mod tests {
                 .lock()
                 .expect("included blocks lock")
                 .insert(submitted_raw_tx_id, block);
+        }
+
+        fn set_raw_tx_mempool_accepted(&self, submitted_raw_tx_id: String, accepted: bool) {
+            self.raw_tx_mempool_acceptance
+                .lock()
+                .expect("raw tx mempool acceptance lock")
+                .insert(submitted_raw_tx_id, accepted);
         }
     }
 
@@ -1847,6 +2043,18 @@ mod tests {
                 Ok(status) => Ok(status),
                 Err(message) => Err(BridgeError::Runtime(message)),
             }
+        }
+
+        async fn raw_tx_mempool_accepted(
+            &self,
+            submitted_raw_tx_id: &str,
+        ) -> Result<Option<bool>, BridgeError> {
+            Ok(self
+                .raw_tx_mempool_acceptance
+                .lock()
+                .expect("raw tx mempool acceptance lock")
+                .get(submitted_raw_tx_id)
+                .copied())
         }
 
         async fn get_transaction_included_block(
@@ -2045,7 +2253,7 @@ mod tests {
             for (id, withdrawal_nonce) in candidates {
                 let released = statuses
                     .get(&id)
-                    .map(|status| matches!(status.state.as_str(), "mempool_accepted" | "confirmed"))
+                    .map(|status| status.state == "confirmed")
                     .unwrap_or(false);
                 if !released {
                     return Ok(Some(NextPendingWithdrawalOrdering {
@@ -3003,7 +3211,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submission_tick_submits_later_nonce_after_prior_nonce_mempool_accepted() {
+    async fn submission_tick_waits_for_prior_nonce_confirmation() {
         let (registry, _withdrawal_state_store, _dir) = open_context().await;
         let earlier = sample_request_with_seed(0xaa);
         let later = sample_request_with_seed(0xbb);
@@ -3120,7 +3328,24 @@ mod tests {
 
         let outcome = withdrawal_submission_tick_once(&context)
             .await
-            .expect("submission tick");
+            .expect("submission tick before confirmation");
+        assert_eq!(outcome, WithdrawalSubmissionTickOutcome::Idle);
+        assert!(sequencer
+            .submitted
+            .lock()
+            .expect("submitted proposals lock")
+            .is_empty());
+
+        sequencer
+            .statuses
+            .lock()
+            .expect("sequencer statuses lock")
+            .get_mut(&earlier_proposal.id)
+            .expect("earlier status")
+            .state = "confirmed".to_string();
+        let outcome = withdrawal_submission_tick_once(&context)
+            .await
+            .expect("submission tick after confirmation");
         assert_eq!(
             outcome,
             WithdrawalSubmissionTickOutcome::MempoolAccepted {
@@ -3660,6 +3885,140 @@ mod tests {
         .await
         .expect("sequencer confirmation tick");
         assert_eq!(observed, 0);
+    }
+
+    #[tokio::test]
+    async fn nock_reorg_reincludes_exact_confirmed_transaction_in_new_block() {
+        let (_validator, withdrawal_state_store, _dir) = open_context().await;
+        let proposal = sample_proposal(0);
+        seed_confirmed_sequenced_withdrawal(withdrawal_state_store.as_ref(), &proposal, 111).await;
+        let submitter = RecordingSubmitter::default();
+        let tx_id = transaction_id_base58(&proposal.transaction).expect("tx id");
+        submitter.set_included_block(tx_id, sample_included_block(7_780));
+
+        let report =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("Nock re-inclusion recovery");
+        assert_eq!(report.re_included, 1);
+        let row = withdrawal_state_store
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch re-included row")
+            .expect("re-included row");
+        assert_eq!(row.state, WithdrawalState::Confirmed);
+        assert!(withdrawal_state_store
+            .list_reserved_input_names()
+            .await
+            .expect("re-included reservations")
+            .is_empty());
+        assert!(submitter
+            .resubmitted_raw_tx_ids
+            .lock()
+            .expect("resubmitted ids lock")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn nock_reorg_regresses_confirmed_to_mempool_and_restores_reservations() {
+        let (_validator, withdrawal_state_store, _dir) = open_context().await;
+        let proposal = sample_proposal(0);
+        seed_confirmed_sequenced_withdrawal(withdrawal_state_store.as_ref(), &proposal, 111).await;
+        let submitter = RecordingSubmitter::default();
+        let tx_id = transaction_id_base58(&proposal.transaction).expect("tx id");
+        submitter.set_raw_tx_mempool_accepted(tx_id, true);
+
+        let first =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("first missing inclusion observation");
+        assert_eq!(first.unchanged, 1);
+        let report =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("Nock mempool recovery");
+        assert_eq!(report.regressed_to_mempool, 1);
+        let row = withdrawal_state_store
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch regressed row")
+            .expect("regressed row");
+        assert_eq!(row.state, WithdrawalState::MempoolAccepted);
+        assert_eq!(
+            withdrawal_state_store
+                .list_reserved_input_names()
+                .await
+                .expect("restored reservations"),
+            proposal.selected_inputs
+        );
+    }
+
+    #[tokio::test]
+    async fn nock_reorg_resubmits_only_exact_authorized_raw_transaction() {
+        let (_validator, withdrawal_state_store, _dir) = open_context().await;
+        let proposal = sample_proposal(0);
+        seed_confirmed_sequenced_withdrawal(withdrawal_state_store.as_ref(), &proposal, 111).await;
+        let expected = withdrawal_state_store
+            .list_confirmed_nockchain_withdrawals()
+            .await
+            .expect("confirmed recovery candidates")
+            .remove(0);
+        let submitter = RecordingSubmitter::default();
+        submitter.set_raw_tx_mempool_accepted(expected.submitted_raw_tx_id.clone(), false);
+        submitter.script_resubmit_results([Ok(WithdrawalNetworkSubmitStatus::MempoolAccepted)]);
+
+        let first =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("first missing inclusion observation");
+        assert_eq!(first.unchanged, 1);
+        let report =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("Nock exact raw transaction recovery");
+        assert_eq!(report.regressed_to_mempool, 1);
+        assert_eq!(
+            submitter
+                .resubmitted_raw_txs
+                .lock()
+                .expect("resubmitted raw tx lock")
+                .as_slice(),
+            &[expected.raw_tx]
+        );
+    }
+
+    #[tokio::test]
+    async fn nock_reorg_holds_confirmed_transaction_with_unsafe_snapshot_origin() {
+        let (_validator, withdrawal_state_store, _dir) = open_context().await;
+        let mut proposal = sample_proposal(0);
+        proposal.snapshot.height = 7_750;
+        seed_confirmed_sequenced_withdrawal(withdrawal_state_store.as_ref(), &proposal, 111).await;
+        let submitter = RecordingSubmitter::default();
+
+        let first =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("first missing inclusion observation");
+        assert_eq!(first.unchanged, 1);
+        let report =
+            withdrawal_sequencer_nock_reorg_tick_once(withdrawal_state_store.as_ref(), &submitter)
+                .await
+                .expect("Nock unsafe-origin recovery classification");
+        assert_eq!(report.held, 1);
+        let row = withdrawal_state_store
+            .fetch_sequenced_withdrawal(&proposal.id)
+            .await
+            .expect("fetch held row")
+            .expect("held row");
+        assert_eq!(row.state, WithdrawalState::ReorgHold);
+        assert_eq!(
+            withdrawal_state_store
+                .list_reserved_input_names()
+                .await
+                .expect("held reservations"),
+            proposal.selected_inputs
+        );
+        assert!(withdrawal_state_store.ensure_reorg_ready().await.is_err());
     }
 
     #[tokio::test]

--- a/crates/bridge/src/withdrawal/transport.rs
+++ b/crates/bridge/src/withdrawal/transport.rs
@@ -35,7 +35,7 @@ use crate::withdrawal::proposals::{
 use crate::withdrawal::snapshot::BridgeNoteSnapshotService;
 use crate::withdrawal::state::{LiveWithdrawalView, WithdrawalFallbackPolicy, WithdrawalState};
 use crate::withdrawal::submission::{
-    register_withdrawal_or_alert, sequenced_withdrawal_released,
+    register_withdrawal_or_alert, sequenced_withdrawal_needs_no_bridge_work,
     WithdrawalSequencerCanonicalizationError, WithdrawalSequencerPort,
 };
 use crate::withdrawal::types::{
@@ -364,7 +364,7 @@ impl WithdrawalProposalTransport {
                 let status = sequencer
                     .get_sequenced_withdrawal_status(&tracked.id)
                     .await?;
-                if sequenced_withdrawal_released(&status) {
+                if sequenced_withdrawal_needs_no_bridge_work(&status) {
                     continue;
                 }
                 if let Some(bridge_status) = self.bridge_status.as_ref() {
@@ -379,7 +379,7 @@ impl WithdrawalProposalTransport {
                 let status = sequencer
                     .get_sequenced_withdrawal_status(&tracked.id)
                     .await?;
-                if sequenced_withdrawal_released(&status) {
+                if sequenced_withdrawal_needs_no_bridge_work(&status) {
                     continue;
                 }
                 break;
@@ -1097,6 +1097,10 @@ impl WithdrawalProposalTransport {
                 .await?;
             self.registry
                 .reconcile_pending_epoch(id, status.current_epoch)
+                .await?;
+        } else if status.found && matches!(status.state.as_str(), "invalidated" | "reorg_hold") {
+            self.registry
+                .reconcile_base_reorg_state(id, status.current_epoch, status.state == "reorg_hold")
                 .await?;
         }
         Ok(())
@@ -3638,7 +3642,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn broadcaster_expires_prepared_attempt_when_local_reserved_input_precheck_fails() {
+    async fn broadcaster_keeps_later_reserved_input_conflict_passive_behind_frontier() {
         let request = sample_request();
         let proposal = sample_proposal(0);
         let mut blocking_request = sample_request();
@@ -3702,17 +3706,19 @@ mod tests {
             .await
             .expect("record blocking mempool acceptance");
 
-        let err = transport
+        let outcome = transport
             .broadcast_proposal_to_peers(&proposal, &[])
             .await
-            .expect_err("local reserved-input precheck should fail");
-        assert!(err.to_string().contains("before sequencer submission"));
+            .expect("later proposal should remain passive behind frontier");
+        assert!(outcome.accepted_node_ids.is_empty());
+        assert!(!outcome.canonicalized);
         let live = transport
             .registry()
             .fetch_live_withdrawal(&proposal.id)
             .await
-            .expect("fetch local live row");
-        assert_eq!(live, None);
+            .expect("fetch local live row")
+            .expect("prepared local row remains live");
+        assert_eq!(live.state, WithdrawalState::Prepared);
         let sequenced = withdrawal_state_store
             .fetch_sequenced_withdrawal(&proposal.id)
             .await
@@ -3839,6 +3845,14 @@ mod tests {
             )
             .await
             .expect("record stale mempool acceptance");
+        withdrawal_state_store
+            .record_tx_confirmed(
+                &stale_proposal,
+                777,
+                Tip5Hash([Belt(840), Belt(841), Belt(842), Belt(843), Belt(844)]),
+            )
+            .await
+            .expect("confirm stale nonce before frontier advances");
 
         let outcome = transport
             .broadcast_proposal_to_peers(&stale_proposal, &[])

--- a/crates/bridge/tests/reorg_recovery_tests.rs
+++ b/crates/bridge/tests/reorg_recovery_tests.rs
@@ -1,0 +1,16 @@
+#![allow(clippy::unwrap_used)]
+//! Real-kernel proof of the post-confirmation history-divergence boundary.
+
+#[cfg(feature = "bazel_build")]
+use bridge_roswell_harness::run_roswell_test;
+#[cfg(not(feature = "bazel_build"))]
+mod roswell_harness;
+#[cfg(not(feature = "bazel_build"))]
+use self::roswell_harness::run_roswell_test;
+
+#[tokio::test]
+async fn hoon_post_confirmation_reorg_fail_stop_suite() {
+    run_roswell_test("test-reorg-recovery")
+        .await
+        .expect("Roswell reorg recovery boundary tests failed");
+}

--- a/crates/nockchain-bridge-sequencer/src/main.rs
+++ b/crates/nockchain-bridge-sequencer/src/main.rs
@@ -799,6 +799,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             base_height_tracker.clone(),
             bridge_constants.base_start_height,
             bridge_constants.base_blocks_chunk,
+            base_confirmation_depth,
         )
         .await?,
     );

--- a/hoon/apps/bridge/base.hoon
+++ b/hoon/apps/bridge/base.hoon
@@ -186,7 +186,7 @@
           (from-atom:blist base-event-id.i.txs)
         :*  (from-atom:blist base-event-id.i.txs)
             lock-root.content.i.txs
-            amount-burned=amount.content.i.txs  ::  TODO: what about withdrawal fees on the nock side?
+            amount-burned=amount.content.i.txs  ::  gross burn; Rust validates fees and payout before proposal
         ==
       ==
     $(txs t.txs)

--- a/hoon/tests/bridge/main.hoon
+++ b/hoon/tests/bridge/main.hoon
@@ -2,10 +2,12 @@
 /=  bridge  /tests/bridge/mod/bridge
 /=  hold-tests  /tests/bridge/mod/hold-tests
 /=  withdrawal-tests  /tests/bridge/mod/withdrawal-tests
+/=  reorg-recovery-tests  /tests/bridge/mod/reorg-recovery-tests
 |=  name=term
 ^-  (list test-arm:tt)
 ;:  weld
   (get-prefix-arms:tt name !>(bridge))
   (get-prefix-arms:tt name !>(hold-tests))
   (get-prefix-arms:tt name !>(withdrawal-tests))
+  (get-prefix-arms:tt name !>(reorg-recovery-tests))
 ==

--- a/hoon/tests/bridge/mod/reorg-recovery-tests.hoon
+++ b/hoon/tests/bridge/mod/reorg-recovery-tests.hoon
@@ -1,0 +1,115 @@
+::  Proof tests for post-confirmation bridge history divergence.
+::
+::  These fixtures bypass the Rust confirmation buffers and assert the kernel's
+::  fail-stop boundary after accepted history changes. They do not model an
+::  ordinary shallow fork or require automatic rewind as a launch condition.
+::
+/=  *  /common/test
+/=  base-lib  /apps/bridge/base
+/=  nock-lib  /apps/bridge/nock
+/=  hel  /tests/bridge/helpers
+/=  *  /apps/bridge/types
+|%
+++  has-stop-effect
+  |=  effects=(list effect)
+  ^-  ?
+  ?~  effects  %.n
+  ?:  ?=([%0 %stop * *] i.effects)
+    %.y
+  $(effects t.effects)
+::
+::  This fixture directly injects a replacement Base branch after the original
+::  burn was accepted, bypassing the driver-side confirmation depth. With no
+::  stop flag present, the kernel keeps the old hashchain cursor and orphaned
+::  withdrawal, so the replacement reaches the same stop on every retry.
+++  test-reorg-recovery-post-confirmation-base-retry-preserves-orphaned-withdrawal
+  ^-  tang
+  =/  state=bridge-state  *bridge-state
+  =.  constants.state  (small-constants:hel 1 10 0)
+  =.  base-hashchain-next-height.hash-state.state  10
+  =/  event-id=beid  (from-atom:blist 0x44)
+  =/  recipient=nock-lock-root  [0x1 0x2 0x3 0x4 0x5]
+  =/  burn-event=base-event
+    :*  (to-atom:blist event-id)
+        [%burn-for-withdrawal 0x1111 10.000.000.000 recipient]
+    ==
+  =/  canonical-raw=raw-base-blocks:cause
+    :~  [10 0xa10 0x0 ~[burn-event]]
+    ==
+  =/  base  ~(. base-lib state)
+  =/  [stage-effects=(list effect) staged=bridge-state]
+    (incoming-base-blocks:base [canonical-raw [~ 0 0x0 *@da]])
+  ?~  stage-effects
+    ~|('expected canonical Base batch to stage' !!)
+  ?>  ?=([%0 %base-block-withdrawals-pending *] i.stage-effects)
+  =/  pending=pending-base-block-withdrawals  pending.i.stage-effects
+  =/  ack=base-block-commit-ack
+    [blocks-hash.pending first-height.pending last-height.pending]
+  =/  base-staged  ~(. base-lib staged)
+  =/  [ack-effects=(list effect) canonical=bridge-state]
+    (commit-base-block-withdrawals:base-staged ack)
+  =/  canonical-hash-state=hash-state  hash-state.canonical
+  =/  orphan-present-before=?
+    (~(has z-bi unsettled-withdrawals.canonical-hash-state) blocks-hash.pending event-id)
+  =/  replacement-raw=raw-base-blocks:cause
+    :~  [11 0xb11 0xb10 ~]
+    ==
+  =/  canonical-base  ~(. base-lib canonical)
+  =/  [fork-effects=(list effect) after-fork=bridge-state]
+    (incoming-base-blocks:canonical-base [replacement-raw [~ 0 0x0 *@da]])
+  =/  after-fork-base  ~(. base-lib after-fork)
+  =/  [retry-effects=(list effect) after-retry=bridge-state]
+    (incoming-base-blocks:after-fork-base [replacement-raw [~ 0 0x0 *@da]])
+  =/  orphan-present-after=?
+    (~(has z-bi unsettled-withdrawals.hash-state.after-retry) blocks-hash.pending event-id)
+  ;:  weld
+    (expect-eq !>(~) !>(ack-effects))
+    (expect !>(orphan-present-before))
+    (expect !>((has-stop-effect fork-effects)))
+    (expect-eq !>(canonical-hash-state) !>(hash-state.after-fork))
+    (expect !>(?=(~ stop.after-fork)))
+    (expect !>((has-stop-effect retry-effects)))
+    (expect-eq !>(canonical-hash-state) !>(hash-state.after-retry))
+    (expect !>(orphan-present-after))
+  ==
+::
+::  This fixture likewise bypasses Nockchain's confirmation depth. With no stop
+::  flag present, the old page hashchain and next height still reject a
+::  post-confirmation replacement parent on every retry.
+++  test-reorg-recovery-post-confirmation-nock-retry-preserves-hashchain
+  ^-  tang
+  =/  state=bridge-state  *bridge-state
+  =.  constants.state  (small-constants:hel 1 0 20)
+  =.  nock-hashchain-next-height.hash-state.state  20
+  =/  canonical-id=block-id:t  [0xa20 0x0 0x0 0x0 0x0]
+  =/  canonical-page=page:v1:t  *page:v1:t
+  =.  height.canonical-page  20
+  =.  parent.canonical-page  *block-id:t
+  =.  digest.canonical-page  canonical-id
+  =.  tx-ids.canonical-page  *(z-set tx-id:t)
+  =/  empty-txs=(z-map tx-id:t tx:t)  *(z-map tx-id:t tx:t)
+  =/  nock  ~(. nock-lib state)
+  =/  [canonical-effects=(list effect) canonical=bridge-state]
+    (incoming-nockchain-block:nock [[canonical-page empty-txs] [~ 0 0x0 *@da]])
+  =/  canonical-hash-state=hash-state  hash-state.canonical
+  =/  replacement-page=page:v1:t  *page:v1:t
+  =.  height.replacement-page  21
+  =.  parent.replacement-page  [0xb20 0x0 0x0 0x0 0x0]
+  =.  digest.replacement-page  [0xb21 0x0 0x0 0x0 0x0]
+  =.  tx-ids.replacement-page  *(z-set tx-id:t)
+  =/  canonical-nock  ~(. nock-lib canonical)
+  =/  [fork-effects=(list effect) after-fork=bridge-state]
+    (incoming-nockchain-block:canonical-nock [[replacement-page empty-txs] [~ 0 0x0 *@da]])
+  =/  after-fork-nock  ~(. nock-lib after-fork)
+  =/  [retry-effects=(list effect) after-retry=bridge-state]
+    (incoming-nockchain-block:after-fork-nock [[replacement-page empty-txs] [~ 0 0x0 *@da]])
+  ;:  weld
+    (expect-eq !>(~) !>(canonical-effects))
+    (expect-eq !>(21) !>(nock-hashchain-next-height.canonical-hash-state))
+    (expect !>((has-stop-effect fork-effects)))
+    (expect-eq !>(canonical-hash-state) !>(hash-state.after-fork))
+    (expect !>(?=(~ stop.after-fork)))
+    (expect !>((has-stop-effect retry-effects)))
+    (expect-eq !>(canonical-hash-state) !>(hash-state.after-retry))
+  ==
+--


### PR DESCRIPTION
> [!NOTE]
> This PR is 3 of 7 in the withdrawal stack.
> Merge [PR #170](https://github.com/nockchain/nockchain/pull/170) before this PR. Then review [PR #172](https://github.com/nockchain/nockchain/pull/172).

## Summary

This PR prevents a second settlement after a reorg, restart, or recovery action.

## Changes

- The store records a bounded set of Base and Nockchain recovery facts.
- The bridge keeps the withdrawal identity during a recoverable fork.
- The bridge also keeps the note reservation during the fork.
- The bridge advances settlement only after it stores the required confirmation.
- The bridge keeps one owner while settlement or recovery is active.
- Readiness stays closed when a recovery bound is incomplete.
- Readiness also stays closed when a contract gate or reconciliation fact is incomplete.
- The Roswell and Rust tests cover recovery, refused mutations, and closed readiness.
- This PR adds a CI job for contract conformance.

## Safety

- A process restart does not release a reservation.
- The bridge rejects an ambiguous recovery change.
- The bridge does not advance settlement without durable confirmation.

## Tests

- [x] The complete stack test passed.
- [x] The test recorded one burn and one payout.
- [x] The burn-to-payout check passed.
- [x] The transaction-conservation check passed.

## Nockchain PR stack

Merge these PRs in order:

1. [PR #169: Define the canonical withdrawal protocol](https://github.com/nockchain/nockchain/pull/169)
2. [PR #170: Make withdrawal state recoverable and queryable](https://github.com/nockchain/nockchain/pull/170)
3. [PR #171: Enforce reorg-safe single-flight settlement](https://github.com/nockchain/nockchain/pull/171)
4. [PR #172: Add the deterministic withdrawal harness](https://github.com/nockchain/nockchain/pull/172)
5. [PR #173: Prove terminal withdrawal settlement](https://github.com/nockchain/nockchain/pull/173)
6. [PR #174: Model and replay withdrawal failures](https://github.com/nockchain/nockchain/pull/174)
7. [PR #175: Add the production browser path](https://github.com/nockchain/nockchain/pull/175)

GitHub uses `ryjm/bridge-withdrawal-02-state-public-api` as the base for this PR.

The head commit is `a982da0d5b37c78c477f54aaa5cb0527d5fc8acd`.