### PR TITLE
feat(honk): add kick, a build-trap evaluator CLI

### DIFF
--- a/.github/workflows/honk-kick.yml
+++ b/.github/workflows/honk-kick.yml
@@ -1,0 +1,47 @@
+name: honk kick
+
+# Smoke test for `kick`, the build-trap evaluator. The traps are assembled in
+# the test itself rather than compiled, so the whole suite runs in seconds and
+# needs none of the heavy Bazel machinery the parity workflow does; the wall
+# clock here is a cold cargo build of the honk crate and its dependencies.
+
+on:
+  push:
+    branches: ["master", "nightly"]
+    paths:
+      - "crates/honk/**"
+      - "crates/nockapp/**"
+      - "crates/nockvm/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/honk-kick.yml"
+  pull_request:
+    branches: ["master", "nightly"]
+    paths:
+      - "crates/honk/**"
+      - "crates/nockapp/**"
+      - "crates/nockvm/**"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - ".github/workflows/honk-kick.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: honk-kick-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kick-smoke:
+    name: kick smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Test kick (fire, axis, timeout, bad input)
+        run: cargo test -p honk --test kick_cli

--- a/crates/honk/BUILD.bazel
+++ b/crates/honk/BUILD.bazel
@@ -100,3 +100,24 @@ rust_binary(
         "//crates/zkvm-jetpack",
     ] + all_crate_deps(),
 )
+
+# kick binary: fires the build traps honk --arbitrary emits. It shares honk's
+# evaluation environment through honk_lib (see crates/honk/src/eval.rs) and
+# embeds none of the prelude assets, so it needs neither compile_data nor the
+# cache-namespace fingerprint.
+rust_binary(
+    name = "kick",
+    srcs = ["src/bin/kick.rs"],
+    aliases = aliases(),
+    crate_name = "kick",
+    crate_root = "src/bin/kick.rs",
+    edition = "2021",
+    proc_macro_deps = [
+        "//crates/nockvm/rust/nockvm_macros",
+    ] + all_crate_deps(proc_macro = True),
+    deps = [
+        ":honk_lib",
+        "//crates/nockapp",
+        "//crates/nockvm/rust/nockvm",
+    ] + all_crate_deps(),
+)

--- a/crates/honk/Cargo.toml
+++ b/crates/honk/Cargo.toml
@@ -9,6 +9,12 @@ build = "build.rs"
 name = "honk"
 path = "src/bin/honk.rs"
 
+# The build-trap evaluator: fires what `honk --arbitrary` emits. Installs
+# alongside honk; downstream harnesses conventionally rename it honk-kick.
+[[bin]]
+name = "kick"
+path = "src/bin/kick.rs"
+
 [dependencies]
 blake3 = { workspace = true }
 chumsky = "0.10"

--- a/crates/honk/src/bin/honk.rs
+++ b/crates/honk/src/bin/honk.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::panic::{self, AssertUnwindSafe};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -18,16 +17,16 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use hatch::ast::hoon::{Hoon, Limb};
 use hatch::utils::hoon_to_noun;
 use honk::build_cache::{BuildCache, CacheObjectKind, CacheRead, CacheWrite};
+use honk::eval::{catch_nock_panic, create_eval_context};
 use honk::nasm_bridge::SlabToNockasm;
 use honk::native::formula::comb;
-use honk::native::hot::native_hot_state;
 use honk::native::noun::term_to_noun;
 use honk::native::ut::{ty_noun, Ut};
 use honk::pipeline;
 use honk::pipeline::{NativeImportKind, ScopeMode};
 use nockapp::noun::slab::{NockJammer, NounSlab};
 use nockapp::noun::{BrandedEvalExt, BrandedNounSpaceExt, NounAllocatorExt};
-use nockapp::utils::{create_context, NOCK_STACK_SIZE_MEDIUM};
+use nockapp::utils::NOCK_STACK_SIZE_MEDIUM;
 use nockapp::AtomExt;
 use nockvm::ext::NounExt;
 use nockvm::hamt::Hamt;
@@ -36,8 +35,7 @@ use nockvm::jets::cold::{Cold, Nounable};
 use nockvm::jets::math::util::lth_b;
 use nockvm::jets::nock::util::mook;
 use nockvm::jets::warm::Warm;
-use nockvm::jets::JetDispatchMode;
-use nockvm::mem::{AllocationError, NockStack};
+use nockvm::mem::NockStack;
 use nockvm::mug::{calc_atom_mug_u32, calc_cell_mug_u32, get_mug, set_mug};
 use nockvm::noun::{Atom, Cell, Noun, NounAllocator, NounSpace, D, DIRECT_MAX, T};
 use nockvm::serialization::jam as nock_jam;
@@ -4087,26 +4085,6 @@ fn jam_standard_kernel_trap_native(
     })
 }
 
-// Constant-fold evaluation interns shared mack-core copies on the eval
-// stack for the lifetime of each entry compile; 16GB fills up on
-// fold-heavy kernels (tx-engine digests), and exhaustion silently degrades
-// folds to step evaluation. The reservation is virtual, so size it well
-// above observed peaks.
-const HONK_EVAL_STACK_SIZE: usize = NOCK_STACK_SIZE_MEDIUM; // 16GB
-
-fn create_eval_context() -> Context {
-    let mut stack = NockStack::new(HONK_EVAL_STACK_SIZE, 0);
-    let cold = Cold::new(&mut stack);
-    create_context(
-        stack,
-        native_hot_state(),
-        cold,
-        None,
-        vec![],
-        JetDispatchMode::HintBlind,
-    )
-}
-
 fn eval_formula_noun_in_context(
     eval_context: &mut Context,
     formula: Noun,
@@ -4380,30 +4358,6 @@ fn slam_gate_formula<A: NounAllocator>(allocator: &mut A) -> Noun {
     let slot2 = T(allocator, &[D(0), D(2)]);
     let edit_gate = T(allocator, &[D(10), edit_axis6, slot2]);
     T(allocator, &[D(9), D(2), edit_gate])
-}
-
-fn catch_nock_panic<T>(label: impl Into<String>, f: impl FnOnce() -> Result<T>) -> Result<T> {
-    let label = label.into();
-    match panic::catch_unwind(AssertUnwindSafe(f)) {
-        Ok(result) => result,
-        Err(payload) => {
-            let detail = payload
-                .downcast_ref::<AllocationError>()
-                .map(|err| format!(": {err}"))
-                .or_else(|| {
-                    payload
-                        .downcast_ref::<String>()
-                        .map(|err| format!(": {err}"))
-                })
-                .or_else(|| {
-                    payload
-                        .downcast_ref::<&'static str>()
-                        .map(|err| format!(": {err}"))
-                })
-                .unwrap_or_default();
-            Err(format!("{label}: nock stack panic{detail}").into())
-        }
-    }
 }
 
 fn trace_native(message: impl AsRef<str>) {

--- a/crates/honk/src/bin/kick.rs
+++ b/crates/honk/src/bin/kick.rs
@@ -1,0 +1,211 @@
+//! kick: fire a honk/hoonc build trap and jam the product.
+//!
+//! `honk --arbitrary` emits a deferred vase trap; nothing downstream of the
+//! compiler could previously fire it, because the Python and vere
+//! interpreters lack the formula-keyed jets the deferred build relies on
+//! (unjetted `+ut` work is the cold-hoonc regime). kick closes that loop by
+//! reusing honk's own evaluation environment — see `honk::eval` — to cue the
+//! jam, interpret `[9 2 0 1]`, and jam the result (optionally the subnoun at
+//! an axis, e.g. 3 for a vase tail).
+//!
+//! First consumer: the Jock corpus harness (sigilante/jock tools/vex.sh),
+//! where a 648KB build trap kicks in 0.14s.
+//!
+//! Build & install:
+//!
+//!     cargo build --release -p honk --bin kick
+//!     cp target/release/kick ~/.cargo/bin/honk-kick
+//!
+//! Example (value of an --arbitrary build; axis 3 for the vase tail):
+//!
+//!     honk --new --arbitrary --output out.jam --prelude hoon-138.hoon entry.hoon deps/
+//!     honk-kick out.jam value.jam
+
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{env, fs, process, thread};
+
+use honk::eval::{catch_nock_panic, create_eval_context};
+use nockapp::noun::slab::{NockJammer, NounSlab};
+use nockvm::ext::{AtomExt, NounExt};
+use nockvm::interpreter::{interpret, Context};
+use nockvm::noun::{Atom, Noun, D, T};
+use num_bigint::BigUint;
+
+/// Bad arguments. Matches honk's own usage-error code.
+const EXIT_USAGE: i32 = 2;
+/// The trap could not be read, cued, fired, or written.
+const EXIT_FAILURE: i32 = 1;
+/// `--timeout` elapsed. Matches timeout(1), which build systems already read.
+const EXIT_TIMEOUT: i32 = 124;
+
+const USAGE: &str = "\
+usage: kick <trap.jam> <out.jam> [axis] [--timeout <seconds>]
+
+Fires the trap in <trap.jam> ([9 2 0 1]) under honk's evaluation
+environment and writes the jam of the product to <out.jam>.
+
+  <trap.jam>            a jammed trap: a core whose arm at axis 2 is fired
+  <out.jam>             where to write the jammed product
+  [axis]                write the subnoun at this axis of the product
+                        instead of the whole product. Arbitrary precision;
+                        the product itself is axis 1, and 0 is not an axis.
+  --timeout <seconds>   give up after <seconds> and exit 124
+  -h, --help            print this message
+
+exit: 0 success, 1 failure, 2 bad arguments, 124 timed out
+";
+
+struct Args {
+    input: PathBuf,
+    output: PathBuf,
+    /// An axis is a path through a noun and has no width bound, so it is
+    /// carried as a bignum rather than parsed into a `u64`: a deep artifact
+    /// can legitimately name an axis past 2^64. It becomes an atom only once
+    /// there is a stack to intern it on.
+    axis: Option<BigUint>,
+    timeout: Option<Duration>,
+}
+
+fn parse_args(raw: impl IntoIterator<Item = String>) -> Result<Option<Args>, String> {
+    let mut positional: Vec<String> = Vec::new();
+    let mut timeout: Option<Duration> = None;
+    let mut args = raw.into_iter();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return Ok(None),
+            "-t" | "--timeout" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| format!("{arg} wants a number of seconds"))?;
+                let seconds: f64 = value
+                    .parse()
+                    .map_err(|_| format!("{arg}: {value:?} is not a number of seconds"))?;
+                if !(seconds.is_finite() && seconds > 0.0) {
+                    return Err(format!("{arg}: {value:?} is not a positive duration"));
+                }
+                timeout = Some(Duration::from_secs_f64(seconds));
+            }
+            flag if flag.starts_with('-') && flag != "-" => {
+                return Err(format!("unknown flag {flag:?}"));
+            }
+            _ => positional.push(arg),
+        }
+    }
+    let mut positional = positional.into_iter();
+    let input = positional.next().ok_or("missing <trap.jam>")?;
+    let output = positional.next().ok_or("missing <out.jam>")?;
+    let axis = positional.next().map(parse_axis).transpose()?;
+    if let Some(extra) = positional.next() {
+        return Err(format!("unexpected argument {extra:?}"));
+    }
+    Ok(Some(Args {
+        input: PathBuf::from(input),
+        output: PathBuf::from(output),
+        axis,
+        timeout,
+    }))
+}
+
+/// Read an axis argument.
+///
+/// Zero is rejected here rather than left to `slot_atom`, both for the
+/// diagnostic and because it is the one axis a bit-walking descent silently
+/// mistakes for the root.
+fn parse_axis(raw: String) -> Result<BigUint, String> {
+    let axis = BigUint::parse_bytes(raw.as_bytes(), 10)
+        .ok_or_else(|| format!("axis: {raw:?} is not a decimal number"))?;
+    if axis == BigUint::ZERO {
+        return Err("axis: 0 is not an axis; the whole product is axis 1".to_string());
+    }
+    Ok(axis)
+}
+
+/// Cue the trap, fire it, and jam the requested part of the product.
+fn fire(
+    context: &mut Context,
+    jam: &[u8],
+    label: &str,
+    axis: Option<&BigUint>,
+) -> Result<Vec<u8>, String> {
+    // Cued outside the eval frame so the trap outlives the interpretation.
+    let trap = <Noun as NounExt>::cue_bytes_slice(&mut context.stack, jam)
+        .map_err(|err| format!("{label} is not a valid jam: {err:?}"))?;
+    let product = unsafe {
+        context.with_stack_frame(0, |context: &mut Context| {
+            let kick = T(&mut context.stack, &[D(9), D(2), D(0), D(1)]);
+            interpret(context, trap, kick)
+        })
+    }
+    .map_err(|err| format!("{label} crashed: {err:?}"))?;
+
+    let value = match axis {
+        None => product,
+        Some(axis) => {
+            let atom = <Atom as AtomExt>::from_bytes(&mut context.stack, &axis.to_bytes_le());
+            let space = context.stack.noun_space();
+            product
+                .in_space(&space)
+                .slot_atom(atom)
+                .map_err(|err| format!("axis {axis} of the product: {err:?}"))?
+                .noun()
+        }
+    };
+
+    let space = context.stack.noun_space();
+    let mut slab: NounSlab<NockJammer> = NounSlab::new();
+    let root = slab.copy_into(value, &space);
+    slab.set_root(root);
+    Ok(slab.jam().to_vec())
+}
+
+fn run(args: &Args) -> Result<(), String> {
+    let label = args.input.display().to_string();
+    let jam = fs::read(&args.input).map_err(|err| format!("cannot read {label}: {err}"))?;
+    let mut context = create_eval_context();
+    let bytes = catch_nock_panic(format!("firing {label}"), || {
+        fire(&mut context, &jam, &label, args.axis.as_ref())
+    })?;
+    fs::write(&args.output, &bytes)
+        .map_err(|err| format!("cannot write {}: {err}", args.output.display()))
+}
+
+/// Abandon the process once `limit` has elapsed.
+///
+/// The interpreter has no interrupt, so a runaway trap cannot be unwound;
+/// for a one-shot CLI, exiting is the honest way to bound it. Nothing is
+/// lost by skipping destructors — the output file is written in one call at
+/// the very end, and the NockStack is an anonymous mapping the kernel
+/// reclaims.
+fn spawn_watchdog(limit: Duration, label: String) {
+    thread::spawn(move || {
+        thread::sleep(limit);
+        eprintln!(
+            "kick: timed out after {}s firing {label}",
+            limit.as_secs_f64()
+        );
+        process::exit(EXIT_TIMEOUT);
+    });
+}
+
+fn main() {
+    let args = match parse_args(env::args().skip(1)) {
+        Ok(Some(args)) => args,
+        Ok(None) => {
+            print!("{USAGE}");
+            return;
+        }
+        Err(err) => {
+            eprintln!("kick: {err}");
+            eprint!("{USAGE}");
+            process::exit(EXIT_USAGE);
+        }
+    };
+    if let Some(limit) = args.timeout {
+        spawn_watchdog(limit, args.input.display().to_string());
+    }
+    if let Err(err) = run(&args) {
+        eprintln!("kick: {err}");
+        process::exit(EXIT_FAILURE);
+    }
+}

--- a/crates/honk/src/eval.rs
+++ b/crates/honk/src/eval.rs
@@ -1,0 +1,92 @@
+//! The evaluation environment honk's binaries share.
+//!
+//! Everything honk fires — constant folds during a compile, and the build
+//! traps `kick` runs afterwards — must run under the same interpreter setup:
+//! the native hot state with formula-keyed jet dispatch (`HintBlind`). A
+//! second copy of that setup would be a silent correctness hazard, because a
+//! divergence shows up not as a build failure but as a *different noun*.
+//! Both binaries call in here instead.
+
+use std::env;
+use std::panic::{self, AssertUnwindSafe};
+
+use nockapp::utils::{create_context, NOCK_STACK_SIZE_MEDIUM};
+use nockvm::interpreter::Context;
+use nockvm::jets::cold::Cold;
+use nockvm::jets::JetDispatchMode;
+use nockvm::mem::{AllocationError, NockStack};
+
+/// Words of `NockStack` reserved for evaluation, absent an override.
+///
+/// Constant-fold evaluation interns shared mack-core copies on the eval
+/// stack for the lifetime of each entry compile; 16GB fills up on
+/// fold-heavy kernels (tx-engine digests), and exhaustion silently degrades
+/// folds to step evaluation. The reservation is virtual, so size it well
+/// above observed peaks.
+pub const HONK_EVAL_STACK_SIZE: usize = NOCK_STACK_SIZE_MEDIUM; // 16GB
+
+/// Words of `NockStack` to reserve, honouring `HONK_EVAL_STACK_WORDS`.
+///
+/// The default reservation is virtual and therefore free on a machine that
+/// overcommits, but a process that only fires a small trap does not need it,
+/// and several such processes at once (the `kick` test suite) can exceed what
+/// a heuristic-overcommit kernel will hand out. The override is in *words*,
+/// matching `NockStack::new`, so that it cannot be confused with the
+/// byte-denominated `HONK_WORKER_STACK_BYTES`.
+pub fn eval_stack_size() -> usize {
+    env::var("HONK_EVAL_STACK_WORDS")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(HONK_EVAL_STACK_SIZE)
+}
+
+/// A fresh interpreter context: native hot state, empty cold state, jets
+/// dispatched on formulas rather than hints.
+pub fn create_eval_context() -> Context {
+    let mut stack = NockStack::new(eval_stack_size(), 0);
+    let cold = Cold::new(&mut stack);
+    create_context(
+        stack,
+        crate::native::hot::native_hot_state(),
+        cold,
+        None,
+        vec![],
+        JetDispatchMode::HintBlind,
+    )
+}
+
+/// Run `f`, converting a nock-stack panic into an ordinary error.
+///
+/// The interpreter reports arena exhaustion and its own invariant violations
+/// by panicking, which for a CLI means an abort and a backtrace where the
+/// user wanted a diagnostic. `label` names the work in progress ("firing
+/// build.jam") and prefixes whatever the panic carried.
+pub fn catch_nock_panic<T, E>(
+    label: impl Into<String>,
+    f: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<String>,
+{
+    let label = label.into();
+    match panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let detail = payload
+                .downcast_ref::<AllocationError>()
+                .map(|err| format!(": {err}"))
+                .or_else(|| {
+                    payload
+                        .downcast_ref::<String>()
+                        .map(|err| format!(": {err}"))
+                })
+                .or_else(|| {
+                    payload
+                        .downcast_ref::<&'static str>()
+                        .map(|err| format!(": {err}"))
+                })
+                .unwrap_or_default();
+            Err(format!("{label}: nock stack panic{detail}").into())
+        }
+    }
+}

--- a/crates/honk/src/lib.rs
+++ b/crates/honk/src/lib.rs
@@ -11,6 +11,7 @@ pub mod arm_map;
 pub mod artifact;
 pub mod build_cache;
 pub mod errors;
+pub mod eval;
 pub mod nasm_bridge;
 pub mod native;
 pub mod pipeline;

--- a/crates/honk/tests/kick_cli.rs
+++ b/crates/honk/tests/kick_cli.rs
@@ -1,0 +1,180 @@
+//! Smoke tests for the `kick` build-trap evaluator.
+//!
+//! Every fixture is a trap assembled here rather than a compiler artifact, so
+//! the suite costs milliseconds and cannot rot against a checked-in jam: a
+//! trap is just a core whose arm at axis 2 gets fired, and a constant formula
+//! `[1 x]` is the smallest arm that produces a known product.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use nockapp::noun::slab::{NockJammer, NounSlab};
+use nockvm::noun::{Noun, D, T};
+use tempfile::TempDir;
+
+/// Words of NockStack for a test process: the default reservation is 16GB of
+/// virtual address space, and a suite running in parallel asks a
+/// heuristic-overcommit kernel for more than it will grant.
+const TEST_STACK_WORDS: &str = "33554432"; // 256MB
+
+fn jam_of(build: impl FnOnce(&mut NounSlab<NockJammer>) -> Noun) -> Vec<u8> {
+    let mut slab: NounSlab<NockJammer> = NounSlab::new();
+    let root = build(&mut slab);
+    slab.set_root(root);
+    slab.jam().to_vec()
+}
+
+/// A core `[battery 0]`, the minimal thing `[9 2 0 1]` can fire.
+fn trap_jam(battery: impl FnOnce(&mut NounSlab<NockJammer>) -> Noun) -> Vec<u8> {
+    jam_of(|slab| {
+        let battery = battery(slab);
+        T(slab, &[battery, D(0)])
+    })
+}
+
+/// A trap whose arm is the constant formula `[1 nouns]`.
+fn constant_trap(nouns: &[u64]) -> Vec<u8> {
+    trap_jam(|slab| {
+        let mut formula = vec![D(1)];
+        formula.extend(nouns.iter().map(|value| D(*value)));
+        T(slab, &formula)
+    })
+}
+
+fn run_kick(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_kick"))
+        .current_dir(dir)
+        .env("HONK_EVAL_STACK_WORDS", TEST_STACK_WORDS)
+        .args(args)
+        .output()
+        .expect("run kick")
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// The happy path: fire a trap, get the jam of its product.
+#[test]
+fn fires_a_trap_and_jams_the_product() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("trap.jam"), constant_trap(&[42])).unwrap();
+
+    let output = run_kick(dir.path(), &["trap.jam", "out.jam"]);
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(
+        std::fs::read(dir.path().join("out.jam")).unwrap(),
+        jam_of(|_| D(42))
+    );
+}
+
+/// An axis argument selects a subnoun of the product.
+#[test]
+fn selects_a_subnoun_by_axis() {
+    let dir = TempDir::new().unwrap();
+    // Product `[42 43]`; axis 3 is its tail.
+    std::fs::write(dir.path().join("trap.jam"), constant_trap(&[42, 43])).unwrap();
+
+    let output = run_kick(dir.path(), &["trap.jam", "out.jam", "3"]);
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(
+        std::fs::read(dir.path().join("out.jam")).unwrap(),
+        jam_of(|_| D(43))
+    );
+}
+
+/// Axis 0 names nothing. A bit-walking descent mistakes it for the root, so
+/// it is the one axis worth a test of its own.
+#[test]
+fn rejects_axis_zero() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("trap.jam"), constant_trap(&[42])).unwrap();
+
+    let output = run_kick(dir.path(), &["trap.jam", "out.jam", "0"]);
+    assert_eq!(output.status.code(), Some(2), "{}", stderr_of(&output));
+    assert!(stderr_of(&output).contains("0 is not an axis"));
+    assert!(!dir.path().join("out.jam").exists());
+}
+
+/// An axis is a path, not a machine word: one past 2^64 must be reported as
+/// a miss, never truncated into a different axis and never a parse panic.
+#[test]
+fn accepts_an_axis_wider_than_a_machine_word() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("trap.jam"), constant_trap(&[42])).unwrap();
+
+    // 2^70, whose low 64 bits are 0 — a truncating parse would either panic
+    // or silently ask for axis 0.
+    let output = run_kick(
+        dir.path(),
+        &["trap.jam", "out.jam", "1180591620717411303424"],
+    );
+    assert_eq!(output.status.code(), Some(1), "{}", stderr_of(&output));
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("axis 1180591620717411303424"), "{stderr}");
+    assert!(!stderr.contains("panicked"), "{stderr}");
+}
+
+/// Garbage in the input is a diagnostic, not an abort.
+#[test]
+fn reports_an_invalid_jam() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("trap.jam"), b"not a jam at all").unwrap();
+
+    let output = run_kick(dir.path(), &["trap.jam", "out.jam"]);
+    assert_eq!(output.status.code(), Some(1), "{}", stderr_of(&output));
+    let stderr = stderr_of(&output);
+    assert!(!stderr.contains("panicked"), "{stderr}");
+    assert!(!dir.path().join("out.jam").exists());
+}
+
+/// So is a missing input.
+#[test]
+fn reports_a_missing_input() {
+    let dir = TempDir::new().unwrap();
+
+    let output = run_kick(dir.path(), &["absent.jam", "out.jam"]);
+    assert_eq!(output.status.code(), Some(1), "{}", stderr_of(&output));
+    assert!(stderr_of(&output).contains("cannot read absent.jam"));
+}
+
+/// A trap that never returns is bounded by `--timeout`, which is the whole
+/// point of the flag for a build system.
+#[test]
+fn times_out_on_a_trap_that_never_returns() {
+    let dir = TempDir::new().unwrap();
+    // Arm `[9 2 0 1]`: firing it fires it again, forever, in tail position.
+    let spin = trap_jam(|slab| T(slab, &[D(9), D(2), D(0), D(1)]));
+    std::fs::write(dir.path().join("spin.jam"), spin).unwrap();
+
+    let output = run_kick(dir.path(), &["spin.jam", "out.jam", "--timeout", "1"]);
+    assert_eq!(output.status.code(), Some(124), "{}", stderr_of(&output));
+    assert!(stderr_of(&output).contains("timed out"));
+}
+
+/// Bad arguments are usage errors, distinct from failures.
+#[test]
+fn reports_bad_arguments() {
+    let dir = TempDir::new().unwrap();
+
+    for args in [
+        vec!["trap.jam"],
+        vec!["trap.jam", "out.jam", "--timeout"],
+        vec!["trap.jam", "out.jam", "--timeout", "soon"],
+        vec!["trap.jam", "out.jam", "--timeout", "0"],
+        vec!["trap.jam", "out.jam", "--nonesuch"],
+        vec!["trap.jam", "out.jam", "1", "2"],
+    ] {
+        let output = run_kick(dir.path(), &args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+    }
+}
+
+#[test]
+fn prints_its_usage() {
+    let dir = TempDir::new().unwrap();
+
+    let output = run_kick(dir.path(), &["--help"]);
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains("usage: kick"));
+}


### PR DESCRIPTION
Migrates nockcloud/nockchain#4 here, rebased onto `master`, with your review notes addressed.

That PR was cut against `codex/honk-arena-seminoun-dag-rebased-onto-bug-fixes`, which is why it could not simply be retargeted. That work has since landed as #153, so this is a fresh branch off current `master` (b9dd5af3) — two commits, one file of new tool code.

## What it is

`honk --arbitrary` emits a deferred vase trap, and nothing downstream of the compiler can fire it: the Python and vere interpreters lack the formula-keyed jets the deferred build relies on (unjetted `+ut` work is the cold-hoonc regime). So build artifacts are writable but not runnable outside honk itself. `kick` closes that loop.

```
kick <trap.jam> <out.jam> [axis] [--timeout <seconds>]
```

Cue the jam → interpret `[9 2 0 1]` → jam the product, optionally the subnoun at an axis (`3` for a vase tail).

First consumer: the Jock corpus harness ([sigilante/jock](https://github.com/sigilante/jock) `tools/vex.sh`), where a 648KB build trap kicks in 0.14s.

## Your notes

**"duplicates Honk's evaluator setup, which could drift from Honk later."** — First commit, and the reason there are two: `create_eval_context` and `catch_nock_panic` were private fns in `bin/honk.rs`, but they describe the environment *anything* firing honk-minted Nock has to use. They are now `honk::eval`, and both binaries call in there. kick cannot drift from honk because it no longer has its own copy. A divergence here would surface not as a build failure but as a *different noun*, which is why this is the enabling commit rather than a follow-up.

`catch_nock_panic` became generic over the error type; it already built its error with `.into()`, so the honk call sites are byte-identical. The eval reservation gained a `HONK_EVAL_STACK_WORDS` override in the spirit of the existing `HONK_WORKER_STACK_BYTES` — the 16GB default is virtual and free where the kernel overcommits, but a process firing one small trap does not need it, and several at once (the test suite below) can exceed what a heuristic-overcommit kernel will grant. Unit is words, matching `NockStack::new`, so it cannot be confused with the byte-denominated worker override. Same size, same hot state, same dispatch mode otherwise.

**"invalid JAMs and axes panic."** — Every failure is now a diagnostic on stderr and a nonzero exit: unreadable file, jam that will not cue, trap that crashes, axis that misses. The whole fire is wrapped in `catch_nock_panic`, so interpreter panics (arena exhaustion) report instead of aborting with a backtrace.

**"axis 0 is mistakenly accepted as the root (?)."** — Correct, and the mechanism is worth naming: the old code walked the axis bit by bit with `while ax > 1`, which for `ax == 0` simply never entered the loop and returned the root. Axis 0 is now rejected as a usage error.

**"axes are limited to u64."** — An axis is a path through a noun and has no width bound. It is now carried as a `BigUint`, interned as an atom, and descended with nockvm's own `slot_atom`, so an axis that misses is nockvm's error rather than a truncation or a `parse::<u64>()` panic. This also means axis 0 would have been refused by `slot_direct` anyway; kick catches it earlier for the better message.

**"Arguably there should be an optional timeout flag if it's getting used for a build system."** — `--timeout <seconds>`. The interpreter has no interrupt, so a runaway trap cannot be unwound; for a one-shot CLI the honest bound is a watchdog thread that exits the process with 124, `timeout(1)`'s code. Nothing is lost by skipping destructors: the output file is written in a single call at the very end, and the NockStack is an anonymous mapping the kernel reclaims.

**"No tests, no CI checks, etc."** — `crates/honk/tests/kick_cli.rs`, nine tests, **1.31s**, plus `.github/workflows/honk-kick.yml` to run them and a bazel `rust_binary` target so the two build systems stay in step.

Every fixture is a trap assembled in the test rather than a compiler artifact, so the suite costs nothing and cannot rot against a checked-in jam — a trap is just a core whose arm at axis 2 gets fired, `[1 42]` is the smallest arm with a known product, and `[9 2 0 1]` is an arm that fires itself forever, which is how the timeout gets tested:

| test | covers |
|---|---|
| `fires_a_trap_and_jams_the_product` | the happy path |
| `selects_a_subnoun_by_axis` | axis 3 of `[42 43]` |
| `rejects_axis_zero` | exit 2, no output written |
| `accepts_an_axis_wider_than_a_machine_word` | 2^70, whose low 64 bits are 0 — a truncating parse would panic or silently ask for axis 0 |
| `reports_an_invalid_jam` | exit 1, stderr contains no `panicked` |
| `reports_a_missing_input` | exit 1 |
| `times_out_on_a_trap_that_never_returns` | `--timeout 1` → exit 124 |
| `reports_bad_arguments` | six malformed argv shapes, all exit 2 |
| `prints_its_usage` | `--help` exits 0 |

Exit codes: 0 success, 1 failure, 2 bad arguments (matching honk), 124 timed out.

## Verification

`cargo check -p honk --all-targets` and `cargo fmt --check` clean. Beyond the unit suite, a release build was run against the actual downstream consumer — Jock's full harness, whose every lane bottoms out in a `kick`:

- corpus (`tools/vex.sh`) — one kick on a 648KB trap whose product is the report noun for **788/788** vectors
- hoonc differential (`tools/accept.sh`) — the same corpus from a hoonc-built harness, **788/788**, so the two compilers' traps kick to the same answer
- python debug lane (`vexrun.py --slam`) over that kicked value — **198/198**
- examples (`tools/examples.sh`) — one kick per example, **23/23**
- sealed-kernel round trip (`tools/kern.sh --sealed`) — four kicks including the re-kick that checks the sealed jam yields the same core; green, `5 source cord(s) verified absent`
- compile gate and syntax lane — green

Worth noting for the dedup: that harness pairs this `kick`, built from current `master`, with a honk binary built from `ea6a8f34`. All 788 vectors agree byte-for-byte across the two, which is some evidence the shared evaluator setup is the whole of what the two binaries need to agree on.

I will close nockcloud/nockchain#4 pointing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeLBmSfHNWQj6KePRqd9ot
